### PR TITLE
Change executable function name pattern

### DIFF
--- a/cmd/new/main.go
+++ b/cmd/new/main.go
@@ -239,7 +239,7 @@ func New() schema.Plugin {
 		{{- end }}
 		{{- if .Executable }}
 		Executables: []schema.Executable{
-			Executable_{{ .Executable }}(),
+			{{ .PlatformNameUpperCamelCase }}CLI(),
 		},
 		{{- end }}
 	}
@@ -325,7 +325,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_{{ .Executable }}() schema.Executable {
+func {{ .PlatformNameUpperCamelCase }}CLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"{{ .Executable }}"},
 		Name:      "{{ .PlatformName }} CLI", // TODO: Check if this is correct

--- a/plugins/aws/aws.go
+++ b/plugins/aws/aws.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_aws() schema.Executable {
+func AWSCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"aws"},
 		Name:      "AWS CLI",

--- a/plugins/aws/plugin.go
+++ b/plugins/aws/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			AccessKey(),
 		},
 		Executables: []schema.Executable{
-			Executable_aws(),
+			AWSCLI(),
 		},
 	}
 }

--- a/plugins/circleci/circleci.go
+++ b/plugins/circleci/circleci.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_circleci() schema.Executable {
+func CircleCICLI() schema.Executable {
 	return schema.Executable{
 		Runs:    []string{"circleci"},
 		Name:    "CircleCI CLI",

--- a/plugins/circleci/plugin.go
+++ b/plugins/circleci/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			PersonalAPIToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_circleci(),
+			CircleCICLI(),
 		},
 	}
 }

--- a/plugins/datadog/dogshell.go
+++ b/plugins/datadog/dogshell.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_dogshell() schema.Executable {
+func Dogshell() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"dog"},
 		Name:      "Dogshell",

--- a/plugins/datadog/plugin.go
+++ b/plugins/datadog/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			APIKey(),
 		},
 		Executables: []schema.Executable{
-			Executable_dogshell(),
+			Dogshell(),
 		},
 	}
 }

--- a/plugins/digitalocean/doctl.go
+++ b/plugins/digitalocean/doctl.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_doctl() schema.Executable {
+func DigitalOceanCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"doctl"},
 		Name:      "DigitalOcean CLI",

--- a/plugins/digitalocean/plugin.go
+++ b/plugins/digitalocean/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			PersonalAccessToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_doctl(),
+			DigitalOceanCLI(),
 		},
 	}
 }

--- a/plugins/github/gh.go
+++ b/plugins/github/gh.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_gh() schema.Executable {
+func GitHubCLI() schema.Executable {
 	return schema.Executable{
 		Runs:    []string{"gh"},
 		Name:    "GitHub CLI",

--- a/plugins/github/plugin.go
+++ b/plugins/github/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			PersonalAccessToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_gh(),
+			GitHubCLI(),
 		},
 	}
 }

--- a/plugins/gitlab/glab.go
+++ b/plugins/gitlab/glab.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_glab() schema.Executable {
+func GitLabCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"glab"},
 		Name:      "GitLab CLI",

--- a/plugins/gitlab/plugin.go
+++ b/plugins/gitlab/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			PersonalAccessToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_glab(),
+			GitLabCLI(),
 		},
 	}
 }

--- a/plugins/heroku/heroku.go
+++ b/plugins/heroku/heroku.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_heroku() schema.Executable {
+func HerokuCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"heroku"},
 		Name:      "Heroku CLI",

--- a/plugins/heroku/plugin.go
+++ b/plugins/heroku/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			APIKey(),
 		},
 		Executables: []schema.Executable{
-			Executable_heroku(),
+			HerokuCLI(),
 		},
 	}
 }

--- a/plugins/okta/okta.go
+++ b/plugins/okta/okta.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_Okta() schema.Executable {
+func OktaCLI() schema.Executable {
 	return schema.Executable{
 		Runs:    []string{"okta"},
 		Name:    "Okta CLI",

--- a/plugins/okta/plugin.go
+++ b/plugins/okta/plugin.go
@@ -17,7 +17,7 @@ func New() schema.Plugin {
 			APIToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_Okta(),
+			OktaCLI(),
 		},
 	}
 }

--- a/plugins/postgresql/plugin.go
+++ b/plugins/postgresql/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			DatabaseCredentials(),
 		},
 		Executables: []schema.Executable{
-			Executable_psql(),
+			Psql(),
 		},
 	}
 }

--- a/plugins/postgresql/psql.go
+++ b/plugins/postgresql/psql.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_psql() schema.Executable {
+func Psql() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"psql"},
 		Name:      "psql",

--- a/plugins/sentry/plugin.go
+++ b/plugins/sentry/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			AuthToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_sentry_cli(),
+			SentryCLI(),
 		},
 	}
 }

--- a/plugins/sentry/sentry_cli.go
+++ b/plugins/sentry/sentry_cli.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_sentry_cli() schema.Executable {
+func SentryCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"sentry-cli"},
 		Name:      "Sentry CLI",

--- a/plugins/snyk/plugin.go
+++ b/plugins/snyk/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			APIToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_snyk(),
+			SnykCLI(),
 		},
 	}
 }

--- a/plugins/snyk/snyk.go
+++ b/plugins/snyk/snyk.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_snyk() schema.Executable {
+func SnykCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"snyk"},
 		Name:      "Snyk CLI",

--- a/plugins/twilio/plugin.go
+++ b/plugins/twilio/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			APIKey(),
 		},
 		Executables: []schema.Executable{
-			Executable_twilio(),
+			TwilioCLI(),
 		},
 	}
 }

--- a/plugins/twilio/twilio.go
+++ b/plugins/twilio/twilio.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_twilio() schema.Executable {
+func TwilioCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"twilio"},
 		Name:      "Twilio CLI",

--- a/plugins/vault/plugin.go
+++ b/plugins/vault/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			AuthToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_vault(),
+			VaultCLI(),
 		},
 	}
 }

--- a/plugins/vault/vault.go
+++ b/plugins/vault/vault.go
@@ -6,10 +6,10 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_vault() schema.Executable {
+func VaultCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"vault"},
-		Name:      "HashiCorp Vault CLI",
+		Name:      "Vault CLI",
 		DocsURL:   sdk.URL("https://developer.hashicorp.com/vault/docs/commands"),
 		NeedsAuth: needsauth.NotForHelpOrVersion(),
 		Credentials: []schema.CredentialType{

--- a/sdk/example/example.go
+++ b/sdk/example/example.go
@@ -6,7 +6,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-func Executable_example() schema.Executable {
+func ExampleCLI() schema.Executable {
 	return schema.Executable{
 		Runs:      []string{"example"},
 		Name:      "Example CLI",

--- a/sdk/example/plugin.go
+++ b/sdk/example/plugin.go
@@ -17,7 +17,7 @@ func New() schema.Plugin {
 			APIToken(),
 		},
 		Executables: []schema.Executable{
-			Executable_example(),
+			ExampleCLI(),
 		},
 	}
 }


### PR DESCRIPTION
Makes more sense to use the executable display name, rather than the command with an underscore.