### PR TITLE
Expand import output with concept of attempts

### DIFF
--- a/plugins/aws/access_key.go
+++ b/plugins/aws/access_key.go
@@ -81,7 +81,7 @@ const FieldNameDefaultRegion = "Default Region"
 
 // TryCredentialsFile looks for the access key in the ~/.aws/credentials file.
 func TryCredentialsFile() sdk.Importer {
-	return importer.TryFile("~/.aws/credentials", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportOutput) {
+	return importer.TryFile("~/.aws/credentials", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
 		credentialsFile, err := contents.ToINI()
 		if err != nil {
 			out.AddError(err)

--- a/plugins/circleci/personal_api_token.go
+++ b/plugins/circleci/personal_api_token.go
@@ -47,7 +47,7 @@ type Config struct {
 }
 
 func TryCircleCIConfigFile() sdk.Importer {
-	return importer.TryFile("~/.circleci/cli.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportOutput) {
+	return importer.TryFile("~/.circleci/cli.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
 		var config Config
 		if err := contents.ToYAML(&config); err != nil {
 			out.AddError(err)

--- a/plugins/heroku/api_key.go
+++ b/plugins/heroku/api_key.go
@@ -42,7 +42,7 @@ func APIKey() schema.CredentialType {
 
 // TryNetrcFile tries to find Heroku API keys in the ~/.netrc file
 func TryNetrcFile() sdk.Importer {
-	return importer.TryFile("~/.netrc", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportOutput) {
+	return importer.TryFile("~/.netrc", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
 		// TODO: Iterate over 'machine' entries to look for 'api.heroku.com' or 'git.heroku.com'
 		// Example contents:
 		//

--- a/sdk/importer.go
+++ b/sdk/importer.go
@@ -64,15 +64,42 @@ type ImportInput struct {
 }
 
 type ImportOutput struct {
+	Attempts []*ImportAttempt
+}
+
+type ImportAttempt struct {
 	Candidates  []ImportCandidate
+	Source      ImportSource
 	Diagnostics Diagnostics
 }
 
-func (out *ImportOutput) AddCandidate(candidate ImportCandidate) {
+func (out *ImportOutput) Errors() (errors []Error) {
+	for _, attempt := range out.Attempts {
+		errors = append(errors, attempt.Diagnostics.Errors...)
+	}
+	return
+}
+
+func (out *ImportOutput) AllCandidates() (candidates []ImportCandidate) {
+	for _, attempt := range out.Attempts {
+		candidates = append(candidates, attempt.Candidates...)
+	}
+	return
+}
+
+func (out *ImportOutput) NewAttempt(src ImportSource) *ImportAttempt {
+	attempt := &ImportAttempt{
+		Source: src,
+	}
+	out.Attempts = append(out.Attempts, attempt)
+	return attempt
+}
+
+func (out *ImportAttempt) AddCandidate(candidate ImportCandidate) {
 	out.Candidates = append(out.Candidates, candidate)
 }
 
-func (out *ImportOutput) AddError(err error) {
+func (out *ImportAttempt) AddError(err error) {
 	out.Diagnostics.Errors = append(out.Diagnostics.Errors, Error{err.Error()})
 }
 

--- a/sdk/importer/env_var_importer.go
+++ b/sdk/importer/env_var_importer.go
@@ -9,10 +9,11 @@ import (
 
 func TryAllEnvVars(fieldName string, possibleEnvVarNames ...string) sdk.Importer {
 	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
-		matches := ScanEnvironment(fieldName, possibleEnvVarNames...)
+		attempt := out.NewAttempt(SourceEnvVars(possibleEnvVarNames...))
 
+		matches := ScanEnvironment(fieldName, possibleEnvVarNames...)
 		for _, match := range matches {
-			out.AddCandidate(sdk.ImportCandidate{
+			attempt.AddCandidate(sdk.ImportCandidate{
 				Fields: []sdk.ImportCandidateField{match},
 			})
 		}
@@ -21,15 +22,21 @@ func TryAllEnvVars(fieldName string, possibleEnvVarNames ...string) sdk.Importer
 
 func TryEnvVarPairVariations(pairPossibilities map[string][]string) sdk.Importer {
 	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
+		var envVarNames []string
 		var detectedFields []sdk.ImportCandidateField
+
 		for fieldName, possibleEnvVarNames := range pairPossibilities {
+			envVarNames = append(envVarNames, possibleEnvVarNames...)
+
 			matches := ScanEnvironment(fieldName, possibleEnvVarNames...)
 			if len(matches) > 0 {
 				detectedFields = append(detectedFields, matches[0])
 			}
 		}
+
+		attempt := out.NewAttempt(SourceEnvVars(envVarNames...))
 		if len(detectedFields) != 0 {
-			out.AddCandidate(sdk.ImportCandidate{
+			attempt.AddCandidate(sdk.ImportCandidate{
 				Fields: detectedFields,
 			})
 		}
@@ -38,16 +45,21 @@ func TryEnvVarPairVariations(pairPossibilities map[string][]string) sdk.Importer
 
 func TryEnvVarPair(pairPossibilities map[string]string) sdk.Importer {
 	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
+		var envVarNames []string
 		var detectedFields []sdk.ImportCandidateField
+
 		for fieldName, possibleEnvVarName := range pairPossibilities {
+			envVarNames = append(envVarNames, possibleEnvVarName)
+
 			matches := ScanEnvironment(fieldName, possibleEnvVarName)
 			if len(matches) > 0 {
 				detectedFields = append(detectedFields, matches[0])
 			}
 		}
 
+		attempt := out.NewAttempt(SourceEnvVars(envVarNames...))
 		if len(detectedFields) != 0 {
-			out.AddCandidate(sdk.ImportCandidate{
+			attempt.AddCandidate(sdk.ImportCandidate{
 				Fields: detectedFields,
 			})
 		}

--- a/sdk/importer/file_importer.go
+++ b/sdk/importer/file_importer.go
@@ -14,21 +14,23 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TryFile(path string, result func(ctx context.Context, contents FileContents, in sdk.ImportInput, out *sdk.ImportOutput)) sdk.Importer {
+func TryFile(path string, result func(ctx context.Context, contents FileContents, in sdk.ImportInput, out *sdk.ImportAttempt)) sdk.Importer {
 	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
+		abspath := path
 		if strings.HasPrefix(path, "~/") {
-			path = filepath.Join(in.HomeDir, strings.TrimPrefix(path, "~/"))
+			abspath = filepath.Join(in.HomeDir, strings.TrimPrefix(path, "~/"))
 		}
 
-		contents, err := os.ReadFile(path)
+		attempt := out.NewAttempt(SourceFile(path))
+		contents, err := os.ReadFile(abspath)
 		if os.IsNotExist(err) {
 			return
 		} else if err != nil {
-			out.AddError(err)
+			attempt.AddError(err)
 			return
 		}
 
-		result(ctx, contents, in, out)
+		result(ctx, contents, in, attempt)
 	}
 }
 

--- a/sdk/importer/source.go
+++ b/sdk/importer/source.go
@@ -4,6 +4,10 @@ import (
 	"github.com/1Password/shell-plugins/sdk"
 )
 
+func SourceEnvVars(envVars ...string) sdk.ImportSource {
+	return sdk.ImportSource{Env: envVars}
+}
+
 func SourceEnvName(envVarName string) sdk.ImportSource {
 	return sdk.ImportSource{Env: []string{envVarName}}
 }


### PR DESCRIPTION
We should also keep track of import attempts that did not yield any candidates. The import helpers already have a "Try..." kind of signature, so it makes sense to pair that with an actual concept of import attempts as well.