### PR TITLE
Fix stripe file importer signature

### DIFF
--- a/plugins/stripe/secret_key.go
+++ b/plugins/stripe/secret_key.go
@@ -69,7 +69,7 @@ type ProjectConfig struct {
 }
 
 func TryStripeConfigFile() sdk.Importer {
-	return importer.TryFile("~/.config/stripe/config.toml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportOutput) {
+	return importer.TryFile("~/.config/stripe/config.toml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
 		var config Config
 		if err := contents.ToTOML(&config); err != nil {
 			out.AddError(err)


### PR DESCRIPTION
The stripe secret key file importer was using the old, outdated signature for file importers and was not compiling. This MR updates it to use the latest signature thus fixing all compilation errors.