### PR TITLE
Fix stripe credential importer

### DIFF
--- a/plugins/stripe/secret_key.go
+++ b/plugins/stripe/secret_key.go
@@ -11,6 +11,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+	"github.com/BurntSushi/toml"
 )
 
 func SecretKey() schema.CredentialType {
@@ -70,13 +71,22 @@ type ProjectConfig struct {
 
 func TryStripeConfigFile() sdk.Importer {
 	return importer.TryFile("~/.config/stripe/config.toml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
-		var config Config
-		if err := contents.ToTOML(&config); err != nil {
+		parsedFile := make(map[string]toml.Primitive)
+		metaData, err := toml.Decode(string(contents), &parsedFile)
+		if err != nil {
 			out.AddError(err)
 			return
 		}
 
-		for project, config := range config.Projects {
+		for project, rawConfig := range parsedFile {
+			var config ProjectConfig
+			err = metaData.PrimitiveDecode(rawConfig, &config)
+			if err != nil {
+				continue // skip sections that don't define credentials
+			}
+
+			// We only support secret keys for now.
+			// Support for publishable and restricted keys will be added later.
 			if strings.HasPrefix(config.LiveModeAPIKey, "sk_") {
 				out.AddCandidate(sdk.ImportCandidate{
 					Fields: []sdk.ImportCandidateField{


### PR DESCRIPTION
The stripe credential importer did not account for the fact that there might be other toml keys set in the root of the config file, not just a list of projects. By addressing this, credentials can be importer from stripe config files even if there are other config options in the root of the config file.