### PR TITLE
Fix AWS MFA provisioner

### DIFF
--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -19,7 +19,6 @@ type STSProvisioner struct {
 
 func (p STSProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
 	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(in.ItemFields[FieldNameDefaultRegion]),
 		Credentials: credentials.NewStaticCredentials(in.ItemFields[fieldname.AccessKeyID], in.ItemFields[fieldname.SecretAccessKey], ""),
 	})
 	if err != nil {
@@ -48,7 +47,10 @@ func (p STSProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, ou
 	out.AddEnvVar("AWS_ACCESS_KEY_ID", *result.Credentials.AccessKeyId)
 	out.AddEnvVar("AWS_SECRET_ACCESS_KEY", *result.Credentials.SecretAccessKey)
 	out.AddEnvVar("AWS_SESSION_TOKEN", *result.Credentials.SessionToken)
-	out.AddEnvVar("AWS_DEFAULT_REGION", in.ItemFields[FieldNameDefaultRegion])
+	if region, ok := in.ItemFields[FieldNameDefaultRegion]; ok {
+		out.AddEnvVar("AWS_DEFAULT_REGION", region)
+	}
+
 }
 
 func (p STSProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {


### PR DESCRIPTION
A typo was messing the MFA provisioner. Also default region was getting ignored in the Sts provisioner.