### PR TITLE
Remove file provisioning security feature opt-outs

### DIFF
--- a/sdk/provision/file_provisioner.go
+++ b/sdk/provision/file_provisioner.go
@@ -13,12 +13,11 @@ import (
 type FileProvisioner struct {
 	sdk.Provisioner
 
-	fileContents            ItemToFileContents
-	outpathFixed            string
-	outpathEnvVar           string
-	setOutpathAsArg         bool
-	outpathPrefixedArgs     []string
-	onlyAllowCurrentProcess bool
+	fileContents        ItemToFileContents
+	outpathFixed        string
+	outpathEnvVar       string
+	setOutpathAsArg     bool
+	outpathPrefixedArgs []string
 }
 
 type ItemToFileContents func(in sdk.ProvisionInput) ([]byte, error)
@@ -38,8 +37,7 @@ func FieldAsFile(fieldName string) ItemToFileContents {
 // a single file.
 func TempFile(fileContents ItemToFileContents, opts ...FileOption) sdk.Provisioner {
 	p := FileProvisioner{
-		fileContents:            fileContents,
-		onlyAllowCurrentProcess: true,
+		fileContents: fileContents,
 	}
 	for _, opt := range opts {
 		opt(&p)
@@ -72,14 +70,6 @@ func SetPathAsArg(prefixedArgs ...string) FileOption {
 	return func(p *FileProvisioner) {
 		p.setOutpathAsArg = true
 		p.outpathPrefixedArgs = prefixedArgs
-	}
-}
-
-// OnlyAllowCurrentProcess can be used to configure whether reading the file should be restricted to the current
-// process only by using a named pipe / FIFO file. Defaults to true on macOS and Linux, ignored on Windows.
-func OnlyAllowCurrentProcess(onlyAllowCurrentProcess bool) FileOption {
-	return func(p *FileProvisioner) {
-		p.onlyAllowCurrentProcess = onlyAllowCurrentProcess
 	}
 }
 

--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 )
 
@@ -68,9 +67,7 @@ type DeprovisionOutput struct {
 
 // OutputFile contains the sensitive file info and contents that the provisioner outputs.
 type OutputFile struct {
-	OnlyAllowCurrentProcess bool
-	Contents                []byte
-	FileMode                os.FileMode
+	Contents []byte
 }
 
 // AddEnvVar adds an environment variable to the provision output.
@@ -86,18 +83,14 @@ func (out *ProvisionOutput) AddArgs(args ...string) {
 // AddSecretFile can be used to add a file containing secrets to the provision output.
 func (out *ProvisionOutput) AddSecretFile(path string, contents []byte) {
 	out.AddFile(path, OutputFile{
-		Contents:                contents,
-		OnlyAllowCurrentProcess: true,
-		FileMode:                0600,
+		Contents: contents,
 	})
 }
 
 // AddNonSecretFile can be used to add a file that does not contain secrets to the provision output.
 func (out *ProvisionOutput) AddNonSecretFile(path string, contents []byte) {
 	out.AddFile(path, OutputFile{
-		Contents:                contents,
-		OnlyAllowCurrentProcess: false,
-		FileMode:                0600,
+		Contents: contents,
 	})
 }
 


### PR DESCRIPTION
This MR removes the possibility of opting out of only allowing the current process to read the provisioned credential file and the possibility to set the file permissions.

This is done to adhere to the current security model and due to the low probability of needing these opt-outs in the near future. In the future we can add them back if needed.