### PR TITLE
Add prefix to AWS access key ID

### DIFF
--- a/plugins/aws/access_key.go
+++ b/plugins/aws/access_key.go
@@ -27,6 +27,7 @@ func AccessKey() schema.CredentialType {
 				MarkdownDescription: "The ID of the access key used to authenticate to AWS.",
 				Composition: &schema.ValueComposition{
 					Length: 20,
+					Prefix: "AKIA",
 					Charset: schema.Charset{
 						Uppercase: true,
 						Digits:    true,


### PR DESCRIPTION
More info in the [AWS docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#:~:text=EC2%20instance%20profile-,AKIA,-Access%20key).