### PR TITLE
Add validation check that ensures that each plugin only has 1 executable

### DIFF
--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -73,8 +73,14 @@ func (p Plugin) Validate() (bool, ValidationReport) {
 	})
 
 	report.AddCheck(ValidationCheck{
-		Description: "Has no more than one credential type defined",
+		Description: "Has no more than one credential type defined. Plugins with multiple credential types are not supported yet",
 		Assertion:   len(p.Credentials) == 1,
+		Severity:    ValidationSeverityError,
+	})
+
+	report.AddCheck(ValidationCheck{
+		Description: "Has no more than one executable defined. Plugins with multiple executables are not supported yet",
+		Assertion:   len(p.Executables) == 1,
 		Severity:    ValidationSeverityError,
 	})
 

--- a/sdk/schema/validation_test.go
+++ b/sdk/schema/validation_test.go
@@ -2,8 +2,9 @@ package schema
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsTitleCaseWord(t *testing.T) {


### PR DESCRIPTION
This check will be removed in the future, when we add support for multiple executables per plugin.