### PR TITLE
Reverse env var provisioner and importer order

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -359,8 +359,8 @@ func {{ .CredentialNameUpperCamelCase }}() schema.CredentialType {
 		)}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.{{ .FieldName }}: "{{ .CredentialEnvVarName }}", // TODO: Check if this is correct
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"{{ .CredentialEnvVarName }}": fieldname.{{ .FieldName }}, // TODO: Check if this is correct
 }
 
 // TODO: Check if the platform stores the {{ .CredentialName }} in a local config file, and if so,

--- a/plugins/aws/access_key.go
+++ b/plugins/aws/access_key.go
@@ -63,30 +63,30 @@ func AccessKey() schema.CredentialType {
 		DefaultProvisioner: AWSProvisioner(),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.AccessKeyID:     "AMAZON_ACCESS_KEY_ID",
-				fieldname.SecretAccessKey: "AMAZON_SECRET_ACCESS_KEY",
-				fieldname.DefaultRegion:   "AWS_DEFAULT_REGION",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"AMAZON_ACCESS_KEY_ID":     fieldname.AccessKeyID,
+				"AMAZON_SECRET_ACCESS_KEY": fieldname.SecretAccessKey,
+				"AWS_DEFAULT_REGION":       fieldname.DefaultRegion,
 			}),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.AccessKeyID:     "AWS_ACCESS_KEY",
-				fieldname.SecretAccessKey: "AWS_SECRET_KEY",
-				fieldname.DefaultRegion:   "AWS_DEFAULT_REGION",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"AWS_ACCESS_KEY":     fieldname.AccessKeyID,
+				"AWS_SECRET_KEY":     fieldname.SecretAccessKey,
+				"AWS_DEFAULT_REGION": fieldname.DefaultRegion,
 			}),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.AccessKeyID:     "AWS_ACCESS_KEY",
-				fieldname.SecretAccessKey: "AWS_ACCESS_SECRET",
-				fieldname.DefaultRegion:   "AWS_DEFAULT_REGION",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"AWS_ACCESS_KEY":     fieldname.AccessKeyID,
+				"AWS_ACCESS_SECRET":  fieldname.SecretAccessKey,
+				"AWS_DEFAULT_REGION": fieldname.DefaultRegion,
 			}),
 			TryCredentialsFile(),
 		),
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.AccessKeyID:     "AWS_ACCESS_KEY_ID",
-	fieldname.SecretAccessKey: "AWS_SECRET_ACCESS_KEY",
-	fieldname.DefaultRegion:   "AWS_DEFAULT_REGION",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"AWS_ACCESS_KEY_ID":     fieldname.AccessKeyID,
+	"AWS_SECRET_ACCESS_KEY": fieldname.SecretAccessKey,
+	"AWS_DEFAULT_REGION":    fieldname.DefaultRegion,
 }
 
 // TryCredentialsFile looks for the access key in the ~/.aws/credentials file.

--- a/plugins/circleci/personal_api_token.go
+++ b/plugins/circleci/personal_api_token.go
@@ -30,12 +30,12 @@ func PersonalAPIToken() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.EnvVars(map[sdk.FieldName]string{
-			fieldname.Token: "CIRCLECI_CLI_TOKEN",
+		DefaultProvisioner: provision.EnvVars(map[string]sdk.FieldName{
+			"CIRCLECI_CLI_TOKEN": fieldname.Token,
 		}),
 		Importer: importer.TryAll(
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.Token: "CIRCLECI_CLI_TOKEN",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"CIRCLECI_CLI_TOKEN": fieldname.Token,
 			}),
 			TryCircleCIConfigFile(),
 		),

--- a/plugins/datadog/api_key.go
+++ b/plugins/datadog/api_key.go
@@ -48,9 +48,9 @@ func APIKey() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.APIKey: "DATADOG_API_KEY",
-	fieldname.AppKey: "DATADOG_APP_KEY",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"DATADOG_API_KEY": fieldname.APIKey,
+	"DATADOG_APP_KEY": fieldname.AppKey,
 }
 
 func TryDogrcFile() sdk.Importer {

--- a/plugins/digitalocean/personal_access_token.go
+++ b/plugins/digitalocean/personal_access_token.go
@@ -29,8 +29,8 @@ func PersonalAccessToken() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.EnvVars(map[sdk.FieldName]string{
-			fieldname.Token: "DIGITALOCEAN_ACCESS_TOKEN",
+		DefaultProvisioner: provision.EnvVars(map[string]sdk.FieldName{
+			"DIGITALOCEAN_ACCESS_TOKEN": fieldname.Token,
 		}),
 		Importer: importer.TryAllEnvVars(fieldname.Token, "DIGITALOCEAN_ACCESS_TOKEN"),
 	}

--- a/plugins/fossa/api_key.go
+++ b/plugins/fossa/api_key.go
@@ -33,6 +33,6 @@ func APIKey() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.APIKey: "FOSSA_API_KEY",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"FOSSA_API_KEY": fieldname.APIKey,
 }

--- a/plugins/github/personal_access_token.go
+++ b/plugins/github/personal_access_token.go
@@ -39,26 +39,26 @@ func PersonalAccessToken() schema.CredentialType {
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
 			importer.TryAllEnvVars(fieldname.Token, "GH_TOKEN", "GITHUB_PAT"),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.Host:  "GH_HOST",
-				fieldname.Token: "GH_ENTERPRISE_TOKEN",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"GH_HOST":             fieldname.Host,
+				"GH_ENTERPRISE_TOKEN": fieldname.Token,
 			}),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.Host:  "GH_HOST",
-				fieldname.Token: "GITHUB_ENTERPRISE_TOKEN",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"GH_HOST":                 fieldname.Host,
+				"GITHUB_ENTERPRISE_TOKEN": fieldname.Token,
 			}),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.Host:  "GH_HOST",
-				fieldname.Token: "GH_TOKEN",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"GH_HOST":  fieldname.Host,
+				"GH_TOKEN": fieldname.Token,
 			}),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.Host:  "GH_HOST",
-				fieldname.Token: "GITHUB_TOKEN",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"GH_HOST":      fieldname.Host,
+				"GITHUB_TOKEN": fieldname.Token,
 			}),
 		),
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Token: "GITHUB_TOKEN",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"GITHUB_TOKEN": fieldname.Token,
 }

--- a/plugins/gitlab/personal_access_token.go
+++ b/plugins/gitlab/personal_access_token.go
@@ -50,10 +50,10 @@ func PersonalAccessToken() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Token:   "GITLAB_TOKEN",
-	fieldname.Host:    "GITLAB_HOST",
-	fieldname.APIHost: "GITLAB_API_HOST",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"GITLAB_TOKEN":    fieldname.Token,
+	"GITLAB_HOST":     fieldname.Host,
+	"GITLAB_API_HOST": fieldname.APIHost,
 }
 
 func TryGlabConfigFile() sdk.Importer {

--- a/plugins/heroku/api_key.go
+++ b/plugins/heroku/api_key.go
@@ -32,8 +32,8 @@ func APIKey() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.EnvVars(map[sdk.FieldName]string{
-			fieldname.APIKey: "HEROKU_API_KEY",
+		DefaultProvisioner: provision.EnvVars(map[string]sdk.FieldName{
+			"HEROKU_API_KEY": fieldname.APIKey,
 		}),
 		Importer: importer.TryAll(
 			importer.TryAllEnvVars(fieldname.APIKey, "HEROKU_API_KEY"),

--- a/plugins/okta/api_token.go
+++ b/plugins/okta/api_token.go
@@ -43,9 +43,9 @@ func APIToken() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Token:  "OKTA_CLIENT_TOKEN",
-	fieldname.OrgURL: "OKTA_CLIENT_ORGURL",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"OKTA_CLIENT_TOKEN":  fieldname.Token,
+	"OKTA_CLIENT_ORGURL": fieldname.OrgURL,
 }
 
 func TryOktaConfigFile() sdk.Importer {

--- a/plugins/postgresql/database_credentials.go
+++ b/plugins/postgresql/database_credentials.go
@@ -43,10 +43,10 @@ func DatabaseCredentials() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Host:     "PGHOST",
-	fieldname.Port:     "PGPORT",
-	fieldname.User:     "PGUSER",
-	fieldname.Password: "PGPASSWORD",
-	fieldname.Database: "PGDATABASE",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"PGHOST":     fieldname.Host,
+	"PGPORT":     fieldname.Port,
+	"PGUSER":     fieldname.User,
+	"PGPASSWORD": fieldname.Password,
+	"PGDATABASE": fieldname.Database,
 }

--- a/plugins/sentry/auth_token.go
+++ b/plugins/sentry/auth_token.go
@@ -41,9 +41,9 @@ func AuthToken() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Token:        "SENTRY_AUTH_TOKEN",
-	fieldname.Organization: "SENTRY_ORG",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SENTRY_AUTH_TOKEN": fieldname.Token,
+	"SENTRY_ORG":        fieldname.Organization,
 }
 
 func TrySentryclircFile() sdk.Importer {

--- a/plugins/snyk/api_token.go
+++ b/plugins/snyk/api_token.go
@@ -35,8 +35,8 @@ func APIToken() schema.CredentialType {
 		)}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Token: "SNYK_TOKEN",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SNYK_TOKEN": fieldname.Token,
 }
 
 func TrySnykConfigFile() sdk.Importer {

--- a/plugins/stripe/secret_key.go
+++ b/plugins/stripe/secret_key.go
@@ -54,8 +54,8 @@ const (
 	ModeTest = "test"
 )
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Key: "STRIPE_API_KEY",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"STRIPE_API_KEY": fieldname.Key,
 }
 
 type Config struct {

--- a/plugins/twilio/api_key.go
+++ b/plugins/twilio/api_key.go
@@ -63,8 +63,8 @@ func APIKey() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.AccountSID: "TWILIO_ACCOUNT_SID",
-	fieldname.APIKey:     "TWILIO_API_KEY",
-	fieldname.APISecret:  "TWILIO_API_SECRET",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"TWILIO_ACCOUNT_SID": fieldname.AccountSID,
+	"TWILIO_API_KEY":     fieldname.APIKey,
+	"TWILIO_API_SECRET":  fieldname.APISecret,
 }

--- a/plugins/vault/auth_token.go
+++ b/plugins/vault/auth_token.go
@@ -39,10 +39,10 @@ func AuthToken() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[sdk.FieldName]string{
-	fieldname.Token:     "VAULT_TOKEN",
-	fieldname.Address:   "VAULT_ADDR",
-	fieldname.Namespace: "VAULT_NAMESPACE",
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"VAULT_TOKEN":     fieldname.Token,
+	"VAULT_ADDR":      fieldname.Address,
+	"VAULT_NAMESPACE": fieldname.Namespace,
 }
 
 func TryVaultTokenFile() sdk.Importer {

--- a/sdk/example/api_token.go
+++ b/sdk/example/api_token.go
@@ -40,18 +40,18 @@ func APIToken() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.EnvVars(map[sdk.FieldName]string{
-			fieldname.AccountID: "EXAMPLE_ACCOUNT_ID",
-			fieldname.Token:     "EXAMPLE_API_TOKEN",
+		DefaultProvisioner: provision.EnvVars(map[string]sdk.FieldName{
+			"EXAMPLE_ACCOUNT_ID": fieldname.AccountID,
+			"EXAMPLE_API_TOKEN":  fieldname.Token,
 		}),
 		Importer: importer.TryAll(
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.AccountID: "EXAMPLE_ACCOUNT_ID",
-				fieldname.Token:     "EXAMPLE_API_TOKEN",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"EXAMPLE_ACCOUNT_ID": fieldname.AccountID,
+				"EXAMPLE_API_TOKEN":  fieldname.Token,
 			}),
-			importer.TryEnvVarPair(map[sdk.FieldName]string{
-				fieldname.AccountID: "EXAMPLE_ACCOUNT_ID",
-				fieldname.Token:     "EXAMPLE_TOKEN",
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"EXAMPLE_ACCOUNT_ID": fieldname.AccountID,
+				"EXAMPLE_TOKEN":      fieldname.Token,
 			}),
 		),
 	}

--- a/sdk/importer/env_var_importer.go
+++ b/sdk/importer/env_var_importer.go
@@ -27,12 +27,12 @@ func TryAllEnvVars(fieldName sdk.FieldName, possibleEnvVarNames ...string) sdk.I
 
 // TryEnvVarPair tries the specified environment variables and adds an import candidate if at least
 // one environment variable is set.
-func TryEnvVarPair(pairPossibilities map[sdk.FieldName]string) sdk.Importer {
+func TryEnvVarPair(pairPossibilities map[string]sdk.FieldName) sdk.Importer {
 	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
 		var envVarNames []string
 		candidateFields := make(map[sdk.FieldName]string)
 
-		for fieldName, possibleEnvVarName := range pairPossibilities {
+		for possibleEnvVarName, fieldName := range pairPossibilities {
 			if value := os.Getenv(possibleEnvVarName); value != "" {
 				candidateFields[fieldName] = value
 			}

--- a/sdk/provision/env_var_provisioner.go
+++ b/sdk/provision/env_var_provisioner.go
@@ -12,19 +12,19 @@ import (
 type EnvVarProvisioner struct {
 	sdk.Provisioner
 
-	Schema map[sdk.FieldName]string
+	Schema map[string]sdk.FieldName
 }
 
 // EnvVars creates an EnvVarProvisioner that provisions secrets as environment variables, based
 // on the specified schema of field name and environment variable name.
-func EnvVars(schema map[sdk.FieldName]string) sdk.Provisioner {
+func EnvVars(schema map[string]sdk.FieldName) sdk.Provisioner {
 	return EnvVarProvisioner{
 		Schema: schema,
 	}
 }
 
 func (p EnvVarProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
-	for fieldName, envVarName := range p.Schema {
+	for envVarName, fieldName := range p.Schema {
 		if value, ok := in.ItemFields[fieldName]; ok {
 			out.AddEnvVar(envVarName, value)
 		}
@@ -37,7 +37,7 @@ func (p EnvVarProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionIn
 
 func (p EnvVarProvisioner) Description() string {
 	var envVarNames []string
-	for _, envVarName := range p.Schema {
+	for envVarName := range p.Schema {
 		envVarNames = append(envVarNames, envVarName)
 	}
 


### PR DESCRIPTION
This PR proposes to reverse the key-value order of the maps used in the env var provisioner and importer.
Reasoning is that it feels more familiar to see the env var name as the key in a map. Secondly, we'd now have the freedom to provision the same field to two different environment variables:
```go
"ENV_VAR":       fieldname.Token,
"OTHER_ENV_VAR": fieldname.Token,
```
