### PR TITLE
Make the executable prompt require input

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -100,7 +100,7 @@ func newPlugin() error {
 		},
 		{
 			Name:     "Executable",
-			Prompt:   &survey.Input{Message: `Executable name (e.g. "aws" or "gh")`},
+			Prompt:   &survey.Input{Message: `Executable name (e.g. "aws" or "gh") [required]`},
 			Validate: survey.Required,
 		},
 		{


### PR DESCRIPTION
This make the prompt for inputting the executable name when creating a new plugin requiring an input.
Leaving it empty no longer works. 
This is done since the plugin system requires at least one executable.