### PR TITLE
Add .idea dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ plugins/plugins.go
 # MacOS finder
 .DS_Store
 
-# CLI specifics
+# 1Password
 .op


### PR DESCRIPTION
A simple addition to gitignore so I can use `git add .` without worrying that the .idea contents will be committed.