### PR TITLE
Avoid "is up to date" message for non-file make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 plugins_dir := ~/.op/plugins/local
 
+.PHONY: new-plugin registry %/example-secrets %/validate %/build test
+
 new-plugin:
 	go run cmd/contrib/main.go $@
 


### PR DESCRIPTION
Without these PHONY targets, as an example,a file called `test` will cause `make test` to do nothing.

See https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html for more info.

## How to test

1. `touch test`
2. `make test`

Without these changes, `make test` will output:
```
make: `test' is up to date.
```

Same for all other make commands.