### PR TITLE
Add ToString helper in importer

### DIFF
--- a/sdk/importer/file_importer.go
+++ b/sdk/importer/file_importer.go
@@ -38,6 +38,10 @@ func TryFile(path string, result func(ctx context.Context, contents FileContents
 
 type FileContents []byte
 
+func (fc FileContents) ToString() string {
+	return string(fc)
+}
+
 func (fc FileContents) ToJSON(result any) error {
 	err := json.Unmarshal(fc, result)
 	if err != nil {


### PR DESCRIPTION
Based on feedback from non-Go devs: a `ToString` helper which is easier to discover for non-Go devs than `string(someByteSlice)`.