### PR TITLE
Fix use of CredentialUsage.Provisioner for locally built plugins

### DIFF
--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -27,18 +27,32 @@ func (c CredentialID) String() string {
 	return fmt.Sprintf("plugin.Credentials[%d]", c)
 }
 
+// CredentialUsageID uniquely identifies a CredentialUsage within a plugin.
+type CredentialUsageID struct {
+	Executable ExecutableID
+	Usage      int
+}
+
+func (c CredentialUsageID) String() string {
+	return fmt.Sprintf("%s.Uses[%d]", c.Executable, c.Usage)
+}
+
 // ProvisionerID uniquely identifies a provisioner within a plugin.
 type ProvisionerID struct {
-	Plugin     string
-	Credential sdk.CredentialName
-	Executable *ExecutableID
+	// IsCredentialProvisioner is set to true if the ProvisionerID identifies the DefaultProvisioner of a credential.
+	// It is set to false if the ProvisionerID identifies the Provisioner of an executable's CredentialUsage.
+	IsCredentialProvisioner bool
+	// If IsCredentialProvisioner is true, Credential is the slice index of the credential in schema.Plugin.
+	Credential CredentialID
+	// If IsCredentialProvisioner is false, CredentialUsage identifies the Provisioner within the schema.Plugin.
+	CredentialUsage CredentialUsageID
 }
 
 func (p ProvisionerID) String() string {
-	if p.Executable == nil {
-		return fmt.Sprintf("plugin.Credentials[%s].DefaultProvisioner", p.Credential)
+	if p.IsCredentialProvisioner {
+		return fmt.Sprintf("%s.DefaultProvisioner", p.Credential)
 	}
-	return fmt.Sprintf("plugin.Credentials[%s].Provisioner[%d]", p.Credential, *p.Executable)
+	return fmt.Sprintf("%s.Provisioner", p.CredentialUsage)
 }
 
 // GetPluginResponse augments schema.Plugin with information about which credentials have the (optional) Importer set

--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Version          uint = 2
+	Version          uint = 3
 	MagicCookieKey        = "OP_PLUGIN_MAGIC_COOKIE"
 	MagicCookieValue      = "ThisIsNotForSecurityPurposesButToImproveUserExperience"
 )

--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -39,17 +39,17 @@ func (c CredentialUsageID) String() string {
 
 // ProvisionerID uniquely identifies a provisioner within a plugin.
 type ProvisionerID struct {
-	// IsCredentialProvisioner is set to true if the ProvisionerID identifies the DefaultProvisioner of a credential.
+	// IsDefaultProvisioner is set to true if the ProvisionerID identifies the DefaultProvisioner of a credential.
 	// It is set to false if the ProvisionerID identifies the Provisioner of an executable's CredentialUsage.
-	IsCredentialProvisioner bool
-	// If IsCredentialProvisioner is true, Credential is the slice index of the credential in schema.Plugin.
+	IsDefaultProvisioner bool
+	// If IsDefaultProvisioner is true, Credential is the slice index of the credential in schema.Plugin.
 	Credential CredentialID
-	// If IsCredentialProvisioner is false, CredentialUsage identifies the Provisioner within the schema.Plugin.
+	// If IsDefaultProvisioner is false, CredentialUsage identifies the Provisioner within the schema.Plugin.
 	CredentialUsage CredentialUsageID
 }
 
 func (p ProvisionerID) String() string {
-	if p.IsCredentialProvisioner {
+	if p.IsDefaultProvisioner {
 		return fmt.Sprintf("%s.DefaultProvisioner", p.Credential)
 	}
 	return fmt.Sprintf("%s.Provisioner", p.CredentialUsage)

--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -64,6 +64,9 @@ type GetPluginResponse struct {
 	CredentialHasImporter map[CredentialID]bool
 	// ExecutableHasNeedAuth contains a true value for all executables that have their NeedsAuth field set.
 	ExecutableHasNeedAuth map[ExecutableID]bool
+	// CredentialUsageHasProvisioner contains a true value for all CredentialUsage objects that have their Provisioner
+	// field set.
+	CredentialUsageHasProvisioner map[CredentialUsageID]bool
 }
 
 // ImportCredentialRequest augments sdk.ImportInput with a CredentialID so Import() can be called over RPC.

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -50,9 +50,11 @@ func newServer(p schema.Plugin) *RPCServer {
 		for usageID, credentialUse := range p.Executables[i].Uses {
 			executableID := proto.ExecutableID(i)
 			s.provisioners[proto.ProvisionerID{
-				Plugin:     credentialUse.Plugin,
-				Credential: credentialUse.Name,
-				Executable: &executableID,
+				IsCredentialProvisioner: false,
+				CredentialUsage: proto.CredentialUsageID{
+					Executable: executableID,
+					Usage:      usageID,
+				},
 			}] = credentialUse.Provisioner
 			p.Executables[i].Uses[usageID].Provisioner = nil
 		}
@@ -63,9 +65,8 @@ func newServer(p schema.Plugin) *RPCServer {
 		c.Importer = nil
 
 		s.provisioners[proto.ProvisionerID{
-			Plugin:     p.Name,
-			Credential: c.Name,
-			Executable: nil,
+			IsCredentialProvisioner: true,
+			Credential:              id,
 		}] = c.DefaultProvisioner
 		c.DefaultProvisioner = nil
 	}

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -50,7 +50,7 @@ func newServer(p schema.Plugin) *RPCServer {
 		for usageID, credentialUse := range p.Executables[i].Uses {
 			executableID := proto.ExecutableID(i)
 			s.provisioners[proto.ProvisionerID{
-				IsCredentialProvisioner: false,
+				IsDefaultProvisioner: false,
 				CredentialUsage: proto.CredentialUsageID{
 					Executable: executableID,
 					Usage:      usageID,
@@ -65,8 +65,8 @@ func newServer(p schema.Plugin) *RPCServer {
 		c.Importer = nil
 
 		s.provisioners[proto.ProvisionerID{
-			IsCredentialProvisioner: true,
-			Credential:              id,
+			IsDefaultProvisioner: true,
+			Credential:           id,
 		}] = c.DefaultProvisioner
 		c.DefaultProvisioner = nil
 	}
@@ -92,7 +92,7 @@ func (t *RPCServer) GetPlugin(_ int, resp *proto.GetPluginResponse) error {
 		resp.CredentialHasImporter[credentialID] = importer != nil
 	}
 	for provisionerID, provisioner := range t.provisioners {
-		if !provisionerID.IsCredentialProvisioner {
+		if !provisionerID.IsDefaultProvisioner {
 			resp.CredentialUsageHasProvisioner[provisionerID.CredentialUsage] = provisioner != nil
 		}
 	}

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -80,15 +80,21 @@ func newServer(p schema.Plugin) *RPCServer {
 // replacing those values with an implementation that calls these functions over RPC.
 func (t *RPCServer) GetPlugin(_ int, resp *proto.GetPluginResponse) error {
 	*resp = proto.GetPluginResponse{
-		CredentialHasImporter: map[proto.CredentialID]bool{},
-		ExecutableHasNeedAuth: map[proto.ExecutableID]bool{},
-		Plugin:                t.p,
+		CredentialHasImporter:         map[proto.CredentialID]bool{},
+		ExecutableHasNeedAuth:         map[proto.ExecutableID]bool{},
+		CredentialUsageHasProvisioner: map[proto.CredentialUsageID]bool{},
+		Plugin:                        t.p,
 	}
 	for executableID, needsAuth := range t.needsAuth {
 		resp.ExecutableHasNeedAuth[executableID] = needsAuth != nil
 	}
 	for credentialID, importer := range t.importers {
 		resp.CredentialHasImporter[credentialID] = importer != nil
+	}
+	for provisionerID, provisioner := range t.provisioners {
+		if !provisionerID.IsCredentialProvisioner {
+			resp.CredentialUsageHasProvisioner[provisionerID.CredentialUsage] = provisioner != nil
+		}
 	}
 
 	return nil

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -47,13 +47,14 @@ func newServer(p schema.Plugin) *RPCServer {
 	for i := range p.Executables {
 		s.needsAuth[proto.ExecutableID(i)] = p.Executables[i].NeedsAuth
 		p.Executables[i].NeedsAuth = nil
-		for _, credentialUse := range p.Executables[i].Uses {
+		for usageID, credentialUse := range p.Executables[i].Uses {
 			executableID := proto.ExecutableID(i)
 			s.provisioners[proto.ProvisionerID{
 				Plugin:     credentialUse.Plugin,
 				Credential: credentialUse.Name,
 				Executable: &executableID,
 			}] = credentialUse.Provisioner
+			p.Executables[i].Uses[usageID].Provisioner = nil
 		}
 	}
 


### PR DESCRIPTION
There are a few problems with how the `Provisioner` field of the `CredentialUsage` struct is currently exposed for locally built plugins:
- The `Executable` field of `ProvisionerID` is a pointer, which means it has a different value for each invocation of a plugin. This is especially problematic because `ProvisionerID` is used as the key of a map.
- `ProvisionerID` contains an unused `Plugin` field.
- `Credential` in `ProvisionerID` is not guaranteed to be unique.
- The `Provisioner` field of `CredentialUsage` is not set to `nil` before transferring it over RPC.
- Whether or not the `Provisioner` field is set is not encoded in `proto.GetPluginResponse`. This

This all combined led to plugins using this field panicking on startup and the `Provision` field not being accessible by the CLI.

To fix this, the `ProvisionerID` has been rewritten to not use any pointers, but use slice indices instead and `proto.GetPluginResponse` now includes `CredentialUsageHasProvisioner` which encodes whether the `Provisioner` field is set.

Because these changes are not backwards-compatible, `proto.Version` has been bumped to `3`.