### PR TITLE
Fix extension of WEBP variant of usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ No more plaintext credentials in your home directory. Automatically authenticate
 ## 🪄 Usage
 
  <picture>
-   <source srcset="https://user-images.githubusercontent.com/1965218/206192140-cfa3103e-701c-46c1-9d7c-bd6a404b8823.gif" type="image/webp" />
+   <source srcset="https://developer.1password.com/videos/aws.webp" type="image/webp" />
    <img src="https://user-images.githubusercontent.com/7430639/205337855-41604aca-0ddb-4eab-a5f0-fb9107e09d8d.gif" alt="Example of 1Password Shell Plugins with AWS: user runs an `aws` command, a Touch ID prompt shows up, and `aws` is automatically authenticated" style="max-width: 100%; display: inline-block;" />
 </picture>
 


### PR DESCRIPTION
For some browsers, the WEBP image with a .gif extension would not display  correctly, probably because the content type was guessed incorrectly.

By replacing the image with one that has the .webp extension, this problem  should be resolved.