### PR TITLE
Add Lacework plugin

### DIFF
--- a/plugins/lacework/api_key.go
+++ b/plugins/lacework/api_key.go
@@ -1,0 +1,109 @@
+package lacework
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+	"github.com/BurntSushi/toml"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://docs.lacework.com/console/api-access-keys"),
+		ManagementURL: sdk.URL("https://login.lacework.net/ui?redirectUrl=/investigation/settings/apikeys"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Account,
+				MarkdownDescription: "The subdomain used to access your Lacework account.",
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Specific:  []rune{'.'},
+					},
+				},
+			},
+			{
+				Name:                fieldname.APIKeyID,
+				MarkdownDescription: "The API key used to authenticate to Lacework.",
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Uppercase: true,
+						Digits:    true,
+						Specific:  []rune{'-'},
+					},
+				},
+			},
+			{
+				Name:                fieldname.APISecret,
+				MarkdownDescription: "The API secret used to authenticate to Lacework.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 33,
+					Prefix: "_",
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryLaceworkConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"LW_ACCOUNT":    fieldname.Account,
+	"LW_API_KEY":    fieldname.APIKeyID,
+	"LW_API_SECRET": fieldname.APISecret,
+}
+
+func TryLaceworkConfigFile() sdk.Importer {
+	return importer.TryFile("~/.lacework.toml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		parsedFile := make(map[string]toml.Primitive)
+		metaData, err := toml.Decode(string(contents), &parsedFile)
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for profileName, rawConfig := range parsedFile {
+			var config ProfileConfig
+			err = metaData.PrimitiveDecode(rawConfig, &config)
+			if err != nil {
+				continue // skip sections that don't define credentials
+			}
+
+			if profileName == "default" {
+				profileName = ""
+			}
+
+			out.AddCandidate(sdk.ImportCandidate{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Account:   config.Account,
+					fieldname.APIKeyID:  config.APIKey,
+					fieldname.APISecret: config.APISecret,
+				},
+				NameHint: profileName,
+			})
+		}
+	})
+}
+
+type Config struct {
+	Profiles map[string]ProfileConfig
+}
+
+type ProfileConfig struct {
+	Account   string `toml:"account"`
+	APIKey    string `toml:"api_key"`
+	APISecret string `toml:"api_secret"`
+}

--- a/plugins/lacework/api_key_test.go
+++ b/plugins/lacework/api_key_test.go
@@ -1,0 +1,71 @@
+package lacework
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"LW_ACCOUNT":    "example",
+				"LW_API_KEY":    "EXAMPLE_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE",
+				"LW_API_SECRET": "_89368245c62f8d6d35e7c6626example",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Account:   "example",
+						fieldname.APIKeyID:  "EXAMPLE_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE",
+						fieldname.APISecret: "_89368245c62f8d6d35e7c6626example",
+					},
+				},
+			},
+		},
+		"Lacework config file": {
+			Files: map[string]string{
+				"~/.lacework.toml": plugintest.LoadFixture(t, "lacework.toml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Account:   "example",
+						fieldname.APIKeyID:  "EXAMPLE_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE",
+						fieldname.APISecret: "_89368245c62f8d6d35e7c6626example",
+					},
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Account:   "example2",
+						fieldname.APIKeyID:  "EXAMPLE2_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE",
+						fieldname.APISecret: "_69ee92b3c71a6b27436a648acexample",
+					},
+					NameHint: "example",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Account:   "example",
+				fieldname.APIKeyID:  "EXAMPLE_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE",
+				fieldname.APISecret: "_89368245c62f8d6d35e7c6626example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"LW_ACCOUNT":    "example",
+					"LW_API_KEY":    "EXAMPLE_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE",
+					"LW_API_SECRET": "_89368245c62f8d6d35e7c6626example",
+				},
+			},
+		},
+	})
+}

--- a/plugins/lacework/lacework.go
+++ b/plugins/lacework/lacework.go
@@ -1,0 +1,22 @@
+package lacework
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func LaceworkCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Lacework CLI",
+		Runs:      []string{"lacework"},
+		DocsURL:   sdk.URL("https://docs.lacework.com/cli/"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/lacework/plugin.go
+++ b/plugins/lacework/plugin.go
@@ -1,0 +1,22 @@
+package lacework
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "lacework",
+		Platform: schema.PlatformInfo{
+			Name:     "Lacework",
+			Homepage: sdk.URL("https://www.lacework.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			LaceworkCLI(),
+		},
+	}
+}

--- a/plugins/lacework/test-fixtures/lacework.toml
+++ b/plugins/lacework/test-fixtures/lacework.toml
@@ -1,0 +1,11 @@
+[default]
+  account = "example"
+  api_key = "EXAMPLE_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE"
+  api_secret = "_89368245c62f8d6d35e7c6626example"
+  version = 2
+
+[example]
+  account = "example2"
+  api_key = "EXAMPLE2_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE"
+  api_secret = "_69ee92b3c71a6b27436a648acexample"
+  version = 2

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -6,6 +6,7 @@ import "github.com/1Password/shell-plugins/sdk"
 const (
 	APIHost         = sdk.FieldName("API Host")
 	APIKey          = sdk.FieldName("API Key")
+	APIKeyID        = sdk.FieldName("API Key ID")
 	APISecret       = sdk.FieldName("API Secret")
 	AccessKeyID     = sdk.FieldName("Access Key ID")
 	Account         = sdk.FieldName("Account")


### PR DESCRIPTION
Adds support for the [Lacework CLI](https://docs.lacework.com/cli/), including import from the config file produced by `lacework configure`.

```
➜  shell-plugins git:(lacework) make lacework/validate
# BETA NOTICE: The plugin ecosystem is in beta and is subject to change.
# You may have to update or recompile your local builds every now and then to keep them
# compatible with the 1Password CLI updates.

go run cmd/contrib/main.go lacework/validate
# Plugin: lacework

✔ Has plugin name set
✔ Plugin name only using lowercase characters or digits
✔ Plugin name not longer than 20 characters
✔ Has platform name set
✔ Has platform homepage URL set
✔ Has a credential type or executable defined
✔ Has no more than one credential type defined. Plugins with multiple credential types are not supported yet
✔ Has no more than one executable defined. Plugins with multiple executables are not supported yet

# Credential: API Key

✔ Has name set
✔ Name is using title case
✔ Has documentation URL set
✔ Has management URL set
✔ Has at least 1 field
✔ All fields have name set
✔ All field names are using title case
✔ All fields have a description set
✔ All specified value compositions are valid
✔ Has at least 1 field that is secret
✔ Has a provisioner set
✔ Has an importer set

# Executable: Lacework CLI

✔ Has name set
✔ Has documentation URL set
✔ Has specified which commands need authentication
✔ Has executable command set
✔ Has a credential type defined
```

```
➜  shell-plugins git:(lacework) make test
go test ./...
?   	github.com/1Password/shell-plugins/cmd/contrib	[no test files]
?   	github.com/1Password/shell-plugins/cmd/contrib/build	[no test files]
ok  	github.com/1Password/shell-plugins/plugins	(cached)
ok  	github.com/1Password/shell-plugins/plugins/aws	(cached)
ok  	github.com/1Password/shell-plugins/plugins/circleci	(cached)
ok  	github.com/1Password/shell-plugins/plugins/datadog	(cached)
ok  	github.com/1Password/shell-plugins/plugins/digitalocean	(cached)
?   	github.com/1Password/shell-plugins/plugins/fossa	[no test files]
ok  	github.com/1Password/shell-plugins/plugins/github	(cached)
ok  	github.com/1Password/shell-plugins/plugins/gitlab	(cached)
ok  	github.com/1Password/shell-plugins/plugins/heroku	(cached)
ok  	github.com/1Password/shell-plugins/plugins/lacework	(cached)
ok  	github.com/1Password/shell-plugins/plugins/mysql	(cached)
ok  	github.com/1Password/shell-plugins/plugins/okta	(cached)
ok  	github.com/1Password/shell-plugins/plugins/postgresql	(cached)
ok  	github.com/1Password/shell-plugins/plugins/sentry	(cached)
ok  	github.com/1Password/shell-plugins/plugins/snyk	(cached)
ok  	github.com/1Password/shell-plugins/plugins/stripe	(cached)
?   	github.com/1Password/shell-plugins/plugins/tugboat	[no test files]
ok  	github.com/1Password/shell-plugins/plugins/twilio	(cached)
ok  	github.com/1Password/shell-plugins/plugins/vault	(cached)
ok  	github.com/1Password/shell-plugins/sdk	(cached)
ok  	github.com/1Password/shell-plugins/sdk/example	(cached)
?   	github.com/1Password/shell-plugins/sdk/importer	[no test files]
?   	github.com/1Password/shell-plugins/sdk/needsauth	[no test files]
ok  	github.com/1Password/shell-plugins/sdk/plugintest	(cached)
?   	github.com/1Password/shell-plugins/sdk/provision	[no test files]
?   	github.com/1Password/shell-plugins/sdk/rpc/proto	[no test files]
?   	github.com/1Password/shell-plugins/sdk/rpc/server	[no test files]
ok  	github.com/1Password/shell-plugins/sdk/schema	(cached)
?   	github.com/1Password/shell-plugins/sdk/schema/credname	[no test files]
?   	github.com/1Password/shell-plugins/sdk/schema/fieldname	[no test files]
```