### PR TITLE
Fix charset validation for `ValueComposition`

### DIFF
--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -130,7 +130,7 @@ func (c CredentialType) Validate() (bool, ValidationReport) {
 		comp := f.Composition
 		if comp != nil {
 			cs := comp.Charset
-			if cs.Lowercase && cs.Uppercase && cs.Digits && cs.Symbols && len(cs.Specific) == 0 {
+			if !cs.Lowercase && !cs.Uppercase && !cs.Digits && !cs.Symbols && len(cs.Specific) == 0 {
 				allCompositionsValid = false
 			}
 		}


### PR DESCRIPTION
It'll be possible that a credential consists of all possible types of characters. The validation should report an error if none is allowed instead.