### PR TITLE
Add template for credential importer and provisioner tests

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -471,7 +471,7 @@ func Test{{ .CredentialNameUpperCamelCase }}Importer(t *testing.T) {
 		// and fill the necessary details in the test template below.
 		"config file": {
 			Files: map[string]string{
-				// "~/path/to/config/file.yml": plugintest.LoadFixture(t, "your_local_fixture.yaml"),
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 			// 	{

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -467,7 +467,7 @@ func Test{{ .CredentialNameUpperCamelCase }}Importer(t *testing.T) {
 				},
 			},
 		},
-		// TODO: If you implemented a config file importer, add a test file example in {{ .Name }}/fixtures
+		// TODO: If you implemented a config file importer, add a test file example in {{ .Name }}/test-fixtures
 		// and fill the necessary details in the test template below.
 		"config file": {
 			Files: map[string]string{

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"html/template"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/1Password/shell-plugins/plugins"
@@ -168,17 +166,16 @@ func newPlugin() error {
 
 	if result.ExampleCredential != "" {
 		result.ValueComposition = getValueComposition(result.ExampleCredential)
-		result.TestCredentialExample = result.ExampleCredential
+		result.TestCredentialExample = plugintest.ExampleSecretFromComposition(result.ValueComposition)
 	} else {
-		// If no example credential has been provided, a random 30-character alphanumeric
-		// value is generated to be used within the test suite.
-		lettersAndDigits := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
-		rand.Seed(time.Now().UnixNano())
-		randomString := make([]rune, 30)
-		for i := range randomString {
-			randomString[i] = lettersAndDigits[rand.Intn(len(lettersAndDigits))]
-		}
-		result.TestCredentialExample = string(randomString)
+		result.TestCredentialExample = plugintest.ExampleSecretFromComposition(schema.ValueComposition{
+			Charset: schema.Charset{
+				Uppercase: true,
+				Lowercase: true,
+				Digits:    true,
+			},
+			Length: 30,
+		})
 	}
 
 	result.PlatformNameUpperCamelCase = strings.ReplaceAll(result.PlatformName, " ", "")


### PR DESCRIPTION
This PR adds tests for credential the default credential provisioner and credential importers when generating a new plugin using `make new-plugin`.

For testing, run `make new-plugin` two times. First, omit the credential example, second time, add it. The template should be able to gracefully handle both cases. 

I have a few open questions about wrapping up this MR, which I'll be adding in comments.