### PR TITLE
datadog config file importer

### DIFF
--- a/plugins/datadog/api_key_test.go
+++ b/plugins/datadog/api_key_test.go
@@ -24,6 +24,19 @@ func TestAPIKeyImporter(t *testing.T) {
 				},
 			},
 		},
+		"config file": {
+			Files: map[string]string{
+				"~/.dogrc": plugintest.LoadFixture(t, ".dogrc"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "fbypf5r8ifaitop8l1v2eij5jexample",
+						fieldname.AppKey: "7czlyi5zub72zsheuctce49pfro8swdcnexample",
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/plugins/datadog/test-fixtures/.dogrc
+++ b/plugins/datadog/test-fixtures/.dogrc
@@ -1,0 +1,3 @@
+[Connection]
+apikey = fbypf5r8ifaitop8l1v2eij5jexample
+appkey = 7czlyi5zub72zsheuctce49pfro8swdcnexample


### PR DESCRIPTION
This PR adds `datadog` config file importer.

The config file location is `~/.dogrc`
