### PR TITLE
Revert "Revert using any instead of interface{}"

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -118,7 +118,7 @@ func newPlugin() error {
 					return suggestions
 				},
 			},
-			Validate: func(ans interface{}) error {
+			Validate: func(ans any) error {
 				if str, ok := ans.(string); ok {
 					hasUpper := false
 					for _, char := range str {

--- a/sdk/importer/file_importer.go
+++ b/sdk/importer/file_importer.go
@@ -42,7 +42,7 @@ func (fc FileContents) ToString() string {
 	return string(fc)
 }
 
-func (fc FileContents) ToJSON(result interface{}) error {
+func (fc FileContents) ToJSON(result any) error {
 	err := json.Unmarshal(fc, result)
 	if err != nil {
 		return err
@@ -51,7 +51,7 @@ func (fc FileContents) ToJSON(result interface{}) error {
 	return nil
 }
 
-func (fc FileContents) ToYAML(result interface{}) error {
+func (fc FileContents) ToYAML(result any) error {
 	err := yaml.Unmarshal(fc, result)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func (fc FileContents) ToYAML(result interface{}) error {
 	return nil
 }
 
-func (fc FileContents) ToTOML(result interface{}) error {
+func (fc FileContents) ToTOML(result any) error {
 	err := toml.Unmarshal(fc, result)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func (fc FileContents) ToTOML(result interface{}) error {
 	return nil
 }
 
-func (fc FileContents) ToXML(result interface{}) error {
+func (fc FileContents) ToXML(result any) error {
 	err := xml.Unmarshal(fc, result)
 	if err != nil {
 		return err

--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -144,7 +144,7 @@ func (in *ProvisionInput) FromTempDir(path ...string) string {
 
 // Get returns the cached value at the specified key if it exists. The data can be returned either as a []byte
 // or unmarshaled as JSON.
-func (c CacheState) Get(key string, out interface{}) (ok bool) {
+func (c CacheState) Get(key string, out any) (ok bool) {
 	entry, ok := c[key]
 	if !ok {
 		return false
@@ -166,7 +166,7 @@ func (c CacheState) Get(key string, out interface{}) (ok bool) {
 
 // Put puts data into the cache at the specified key and with the specified TTL, which will be applied to the provision step of
 // all consecutive runs, until the TTL is met or Remove is called. The data will be stored as a []byte or marshaled as JSON.
-func (c *CacheOperations) Put(key string, data interface{}, expiresAt time.Time) error {
+func (c *CacheOperations) Put(key string, data any, expiresAt time.Time) error {
 	var marshaled []byte
 	var err error
 

--- a/sdk/rpc/server/plugin.go
+++ b/sdk/rpc/server/plugin.go
@@ -16,7 +16,7 @@ type RPCPlugin struct {
 
 // Server registers the RPC provider server with the RPC server that
 // go-plugin is setting up.
-func (p *RPCPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p *RPCPlugin) Server(*plugin.MuxBroker) (any, error) {
 	pl, err := p.RPCPlugin()
 	if err != nil {
 		return nil, err
@@ -26,6 +26,6 @@ func (p *RPCPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
 }
 
 // Client always returns an error; we're only implementing a server.
-func (p *RPCPlugin) Client(*plugin.MuxBroker, *rpc.Client) (interface{}, error) {
+func (p *RPCPlugin) Client(*plugin.MuxBroker, *rpc.Client) (any, error) {
 	return nil, errors.New("only server is implemented")
 }


### PR DESCRIPTION
Since we now use an up to date version of `go` consistently across all the closed-source code, using `interface{}` instead of `any` should not be a problem anymore.