### PR TITLE
Fix local builds that use cache or additional command flags

### DIFF
--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -79,6 +79,7 @@ type ImportCredentialRequest struct {
 type ProvisionCredentialRequest struct {
 	ProvisionerID
 	sdk.ProvisionInput
+	sdk.ProvisionOutput
 }
 
 // DeprovisionCredentialRequest augments sdk.DeprovisionInput with a CredentialID so Deprovision() can be called over RPC.

--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -73,6 +73,7 @@ type GetPluginResponse struct {
 type ImportCredentialRequest struct {
 	CredentialID
 	sdk.ImportInput
+	sdk.ImportOutput
 }
 
 // ProvisionCredentialRequest augments sdk.ProvisionInput with a CredentialID so Provision() can be called over RPC.
@@ -86,6 +87,7 @@ type ProvisionCredentialRequest struct {
 type DeprovisionCredentialRequest struct {
 	ProvisionerID
 	sdk.DeprovisionInput
+	sdk.DeprovisionOutput
 }
 
 // ExecutableNeedsAuthRequest augments sdk.NeedsAuthenticationInput with the ID of an executable so NeedsAuth() can be

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -3,10 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/rpc/proto"
 	"github.com/1Password/shell-plugins/sdk/schema"
-	"runtime/debug"
 )
 
 type errFunctionFieldNotSet struct {

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -151,7 +151,6 @@ func (t *RPCServer) CredentialProvisionerProvision(req proto.ProvisionCredential
 	}
 	*resp = req.ProvisionOutput
 	provisioner.Provision(context.Background(), req.ProvisionInput, resp)
-
 	return nil
 }
 


### PR DESCRIPTION
Related issue: https://github.com/1Password/shell-plugins/issues/90

### Why

The `Cache` and `CommandLine` field were left nil in the provision output response. This caused panics for both plugins using `Cache` and plugins using additional command flags.

Actually, the desired response of the RPC call should be the `ProvisionOutput` exactly as it was passed down from OP (as @Marton6 noted), but for a certain reason the fields of the pointer argument (`output`) of the call were nullified. (were brought to their zero values).

### What

this MR:
- adds a `ProvisionOutput` field to the `ProvisionCredentialRequest`., and uses it as response of the RPC call
- adds functionality for catching a panic from a locally built plugin and outputting it before the OP panic is reached, so that the OP panic doesn't mask the true cause of the problem.