### PR TITLE
Add helper to sanitize importer name hint

### DIFF
--- a/plugins/aws/access_key.go
+++ b/plugins/aws/access_key.go
@@ -144,7 +144,7 @@ func TryCredentialsFile() sdk.Importer {
 			if fields[fieldname.AccessKeyID] != "" && fields[fieldname.SecretAccessKey] != "" {
 				out.AddCandidate(sdk.ImportCandidate{
 					Fields:   fields,
-					NameHint: profileName,
+					NameHint: importer.SanitizeNameHint(profileName),
 				})
 			}
 		}

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -17,7 +17,6 @@ func TestAccessKeyImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "default",
 					Fields: map[sdk.FieldName]string{
 						fieldname.AccessKeyID:     "AKIADEFFODNN7EXAMPLE",
 						fieldname.SecretAccessKey: "DEFlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -44,7 +43,6 @@ func TestAccessKeyImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "default",
 					Fields: map[sdk.FieldName]string{
 						fieldname.AccessKeyID:     "AKIADEFFODNN7EXAMPLE",
 						fieldname.SecretAccessKey: "DEFlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -71,7 +69,6 @@ func TestAccessKeyImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "default",
 					Fields: map[sdk.FieldName]string{
 						fieldname.AccessKeyID:     "AKIADEFFODNN7EXAMPLE",
 						fieldname.SecretAccessKey: "DEFlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -98,7 +95,6 @@ func TestAccessKeyImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "default",
 					Fields: map[sdk.FieldName]string{
 						fieldname.AccessKeyID:     "AKIADEFFODNN7EXAMPLE",
 						fieldname.SecretAccessKey: "DEFlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -122,7 +118,6 @@ func TestAccessKeyImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "default",
 					Fields: map[sdk.FieldName]string{
 						fieldname.AccessKeyID:     "AKIADEFFODNN7EXAMPLE",
 						fieldname.SecretAccessKey: "DEFlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -143,7 +138,6 @@ func TestAccessKeyImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "default",
 					Fields: map[sdk.FieldName]string{
 						fieldname.AccessKeyID:     "AKIADEFFODNN7EXAMPLE",
 						fieldname.SecretAccessKey: "DEFlrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",

--- a/plugins/gitlab/personal_access_token.go
+++ b/plugins/gitlab/personal_access_token.go
@@ -85,7 +85,7 @@ func TryGlabConfigFile() sdk.Importer {
 
 			out.AddCandidate(sdk.ImportCandidate{
 				Fields:   fields,
-				NameHint: nameHint,
+				NameHint: importer.SanitizeNameHint(nameHint),
 			})
 		}
 	})

--- a/plugins/heroku/api_key.go
+++ b/plugins/heroku/api_key.go
@@ -63,7 +63,7 @@ func TryNetrcFile() sdk.Importer {
 				if login != "" && password != "" && machine != "" {
 					if machine == "api.heroku.com" || machine == "git.heroku.com" {
 						out.AddCandidate(sdk.ImportCandidate{
-							NameHint: login,
+							NameHint: importer.SanitizeNameHint(login),
 							Fields: map[sdk.FieldName]string{
 								fieldname.APIKey: password,
 							},

--- a/plugins/stripe/secret_key.go
+++ b/plugins/stripe/secret_key.go
@@ -2,7 +2,6 @@ package stripe
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/1Password/shell-plugins/sdk"
@@ -85,6 +84,8 @@ func TryStripeConfigFile() sdk.Importer {
 				continue // skip sections that don't define credentials
 			}
 
+			nameHint := importer.SanitizeNameHint(project)
+
 			// We only support secret keys for now.
 			// Support for publishable and restricted keys will be added later.
 			if strings.HasPrefix(config.LiveModeAPIKey, "sk_") {
@@ -93,16 +94,22 @@ func TryStripeConfigFile() sdk.Importer {
 						fieldname.Key:  config.LiveModeAPIKey,
 						fieldname.Mode: ModeLive,
 					},
-					NameHint: project,
+					NameHint: nameHint,
 				})
 			}
 			if strings.HasPrefix(config.TestModeAPIKey, "sk_") {
+				// Mention "test" in name hint
+				if nameHint != "" {
+					nameHint += " - "
+				}
+				nameHint += "test"
+
 				out.AddCandidate(sdk.ImportCandidate{
 					Fields: map[sdk.FieldName]string{
 						fieldname.Key:  config.TestModeAPIKey,
 						fieldname.Mode: ModeTest,
 					},
-					NameHint: fmt.Sprintf("%s – test", project),
+					NameHint: nameHint,
 				})
 			}
 		}

--- a/plugins/stripe/secret_key_test.go
+++ b/plugins/stripe/secret_key_test.go
@@ -34,21 +34,20 @@ func TestSecretKeyImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "default – test",
+					NameHint: "test",
 					Fields: map[sdk.FieldName]string{
 						fieldname.Key:  "sk_uKVoEC2LqU1aXSbKM1ptxFB3QxWiSTMTnbr0CGvkEBMFOs2vetsHc148WMhtrVRAAsP4fcRd35Fz7ykqbhLoa04ZoA7AcRKvUEXAMPLE",
 						fieldname.Mode: ModeTest,
 					},
 				},
 				{
-					NameHint: "default",
 					Fields: map[sdk.FieldName]string{
 						fieldname.Key:  "sk_TEm8TYekzqaEKmSIDRb4PXJQAoq94iL6PZx4C1RQlr1Ls5kn67RVRJjhBfmejEX8OS4T7GxCWBnqBuIG20SzdEwopINxyEL05EXAMPLE",
 						fieldname.Mode: ModeLive,
 					},
 				},
 				{
-					NameHint: "custom – test",
+					NameHint: "custom - test",
 					Fields: map[sdk.FieldName]string{
 						fieldname.Key:  "sk_9Q9YiSK3uWDqSiNYLakhI6s3f6uHQekczqqdfpRsOI0Zwc6ozOMNAzNfVSNlhnA6IipOakrnF8gdhJ5sC97acFy9d0UbhKe2WEXAMPLE",
 						fieldname.Mode: ModeTest,

--- a/sdk/importer/helpers.go
+++ b/sdk/importer/helpers.go
@@ -13,3 +13,21 @@ func TryAll(importers ...sdk.Importer) sdk.Importer {
 		}
 	}
 }
+
+const maxNameHintLength = 24
+
+// SanitizeNameHint can be used to sanitize the name hint before passing it to the import candidate to
+// improve the suggested item title.
+func SanitizeNameHint(nameHint string) string {
+	// Omit the name hint if it's "default", which doesn't add much value in the item name
+	if nameHint == "default" {
+		return ""
+	}
+
+	// Avoid name hints that are too long
+	if len(nameHint) > maxNameHintLength {
+		nameHint = nameHint[:maxNameHintLength-1] + "…"
+	}
+
+	return nameHint
+}


### PR DESCRIPTION
Turns the common pattern of omitting "default" as the name hint into a helper function in the importer package.