### PR TITLE
Twilio config file importer

### DIFF
--- a/plugins/twilio/api_key.go
+++ b/plugins/twilio/api_key.go
@@ -1,6 +1,8 @@
 package twilio
 
 import (
+	"context"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -62,7 +64,10 @@ func APIKey() schema.CredentialType {
 			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
-		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryTwilioConfigFile(),
+		),
 	}
 }
 
@@ -70,4 +75,39 @@ var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"TWILIO_ACCOUNT_SID": fieldname.AccountSID,
 	"TWILIO_API_KEY":     fieldname.APIKey,
 	"TWILIO_API_SECRET":  fieldname.APISecret,
+}
+
+func TryTwilioConfigFile() sdk.Importer {
+	return importer.TryFile("~/.twilio-cli/config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for name, secrets := range config.Profiles {
+			if secrets.AccountSid == "" || secrets.ApiKey == "" || secrets.ApiSecret == "" {
+				continue
+			}
+
+			out.AddCandidate(sdk.ImportCandidate{
+				NameHint: name,
+				Fields: map[sdk.FieldName]string{
+					fieldname.AccountSID: secrets.AccountSid,
+					fieldname.APIKey:     secrets.ApiKey,
+					fieldname.APISecret:  secrets.ApiSecret,
+				},
+			})
+		}
+	})
+}
+
+type Config struct {
+	Profiles map[string]TwilioProfile `json:"profiles"`
+}
+
+type TwilioProfile struct {
+	AccountSid string `json:"accountSid"`
+	ApiKey     string `json:"apiKey"`
+	ApiSecret  string `json:"apiSecret"`
 }

--- a/plugins/twilio/api_key.go
+++ b/plugins/twilio/api_key.go
@@ -23,6 +23,7 @@ func APIKey() schema.CredentialType {
 					Charset: schema.Charset{
 						Uppercase: true,
 						Digits:    true,
+						Lowercase: true,
 					},
 					Prefix: "AC",
 				},
@@ -36,6 +37,7 @@ func APIKey() schema.CredentialType {
 					Charset: schema.Charset{
 						Uppercase: true,
 						Digits:    true,
+						Lowercase: true,
 					},
 					Prefix: "SK",
 				},
@@ -49,6 +51,7 @@ func APIKey() schema.CredentialType {
 					Charset: schema.Charset{
 						Uppercase: true,
 						Digits:    true,
+						Lowercase: true,
 					},
 				},
 			},

--- a/plugins/twilio/api_key_test.go
+++ b/plugins/twilio/api_key_test.go
@@ -26,6 +26,29 @@ func TestAPIKeyImporter(t *testing.T) {
 				},
 			},
 		},
+		"config file": {
+			Files: map[string]string{
+				"~/.twilio-cli/config.json": plugintest.LoadFixture(t, "config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					NameHint: "prod",
+					Fields: map[sdk.FieldName]string{
+						fieldname.AccountSID: "ACtdgcL157CFBnWjM7ZeJKysIjEEXAMPLE",
+						fieldname.APIKey:     "SK4bqP76ByZgGEuwqm0eTFzYrWBEXAMPLE",
+						fieldname.APISecret:  "1KAe9Vshg4EkUvaBVS8pZwDS1EXAMPLE",
+					},
+				},
+				{
+					NameHint: "dev",
+					Fields: map[sdk.FieldName]string{
+						fieldname.AccountSID: "ACZBgJOUfaX2AuuLMWK7jT3tdS9EXAMPLE",
+						fieldname.APIKey:     "SKrhNjOV2LgR1xatOpVFsMa5fOpEXAMPLE",
+						fieldname.APISecret:  "4ELE8BqwbCrzbyTqu7HNylK00EXAMPLE",
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/plugins/twilio/test-fixtures/config.json
+++ b/plugins/twilio/test-fixtures/config.json
@@ -1,0 +1,18 @@
+{
+  "email": {},
+  "prompts": {},
+  "projects": [],
+  "profiles": {
+    "prod": {
+      "accountSid": "ACtdgcL157CFBnWjM7ZeJKysIjEEXAMPLE",
+      "apiKey": "SK4bqP76ByZgGEuwqm0eTFzYrWBEXAMPLE",
+      "apiSecret": "1KAe9Vshg4EkUvaBVS8pZwDS1EXAMPLE"
+    },
+    "dev": {
+      "accountSid": "ACZBgJOUfaX2AuuLMWK7jT3tdS9EXAMPLE",
+      "apiKey": "SKrhNjOV2LgR1xatOpVFsMa5fOpEXAMPLE",
+      "apiSecret": "4ELE8BqwbCrzbyTqu7HNylK00EXAMPLE"
+    }
+  },
+  "activeProject": null
+}


### PR DESCRIPTION
This PR adds Twilio config file importer.

The config file is located `~/.twilio-cli/config.json`.
It can contain multiple profiles and each of them can be saved as a separate 1password item.