### PR TITLE
Survey credential name validation and transform improvments

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -118,33 +118,8 @@ func newPlugin() error {
 					return suggestions
 				},
 			},
-			Validate: func(ans any) error {
-				if str, ok := ans.(string); ok {
-					if len(str) == 0 {
-						return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
-					}
-
-					words := strings.Split(str, " ")
-					for _, word := range words {
-						if unicode.IsLower(int32(word[0])) {
-							return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
-						}
-					}
-				}
-
-				return nil
-			},
-			Transform: func(ans any) (newAns any) {
-				if str, ok := ans.(string); ok {
-					for _, name := range credname.ListAll() {
-						if strings.EqualFold(name.String(), str) {
-							return string(name)
-						}
-					}
-				}
-
-				return ans
-			},
+			Validate:  validateCredentialName,
+			Transform: transformCredentialName,
 		},
 		{
 			Name:   "ExampleCredential",
@@ -540,3 +515,32 @@ func init() {
 {{- end }}
 }
 `
+
+func validateCredentialName(ans any) error {
+	if str, ok := ans.(string); ok {
+		if len(str) == 0 {
+			return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
+		}
+
+		words := strings.Split(str, " ")
+		for _, word := range words {
+			if unicode.IsLower(int32(word[0])) {
+				return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
+			}
+		}
+	}
+
+	return nil
+}
+
+func transformCredentialName(ans any) (newAns any) {
+	if str, ok := ans.(string); ok {
+		for _, name := range credname.ListAll() {
+			if strings.EqualFold(name.String(), str) {
+				return string(name)
+			}
+		}
+	}
+
+	return ans
+}

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -118,17 +118,20 @@ func newPlugin() error {
 					return suggestions
 				},
 			},
-			Validate: func(ans any) error {
+			Validate: func(ans interface{}) error {
 				if str, ok := ans.(string); ok {
-					hasUpper := false
-					for _, char := range str {
-						if unicode.IsUpper(char) {
-							hasUpper = true
+					credNamesContainStr := false
+					for _, name := range credname.ListAll() {
+						if strings.ToLower(name.String()) == strings.ToLower(str) {
+							credNamesContainStr = true
+							break
 						}
 					}
-					if !hasUpper {
-						return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
+
+					if !credNamesContainStr {
+						return errors.New(`credential name must be one of the suggested, e.g. "Access Key" or "Personal Access Token"`)
 					}
+
 					return nil
 				}
 

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -120,9 +120,7 @@ func newPlugin() error {
 			},
 			Validate: func(ans interface{}) error {
 				if str, ok := ans.(string); ok {
-
 					credNamesContainStr := false
-
 					for _, name := range credname.ListAll() {
 						if strings.EqualFold(name.String(), str) {
 							credNamesContainStr = true

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -137,6 +137,17 @@ func newPlugin() error {
 
 				return nil
 			},
+			Transform: func(ans interface{}) (newAns interface{}) {
+				if str, ok := ans.(string); ok {
+					for _, name := range credname.ListAll() {
+						if strings.ToLower(name.String()) == strings.ToLower(str) {
+							return string(name)
+						}
+					}
+				}
+
+				return ans
+			},
 		},
 		{
 			Name:   "ExampleCredential",

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -118,7 +118,7 @@ func newPlugin() error {
 					return suggestions
 				},
 			},
-			Validate: func(ans interface{}) error {
+			Validate: func(ans any) error {
 				if str, ok := ans.(string); ok {
 					if len(str) == 0 {
 						return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
@@ -134,7 +134,7 @@ func newPlugin() error {
 
 				return nil
 			},
-			Transform: func(ans interface{}) (newAns interface{}) {
+			Transform: func(ans any) (newAns any) {
 				if str, ok := ans.(string); ok {
 					for _, name := range credname.ListAll() {
 						if strings.EqualFold(name.String(), str) {

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -120,9 +120,11 @@ func newPlugin() error {
 			},
 			Validate: func(ans interface{}) error {
 				if str, ok := ans.(string); ok {
+
 					credNamesContainStr := false
+
 					for _, name := range credname.ListAll() {
-						if strings.ToLower(name.String()) == strings.ToLower(str) {
+						if strings.EqualFold(name.String(), str) {
 							credNamesContainStr = true
 							break
 						}
@@ -140,7 +142,7 @@ func newPlugin() error {
 			Transform: func(ans interface{}) (newAns interface{}) {
 				if str, ok := ans.(string); ok {
 					for _, name := range credname.ListAll() {
-						if strings.ToLower(name.String()) == strings.ToLower(str) {
+						if strings.EqualFold(name.String(), str) {
 							return string(name)
 						}
 					}

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -120,19 +120,16 @@ func newPlugin() error {
 			},
 			Validate: func(ans interface{}) error {
 				if str, ok := ans.(string); ok {
-					credNamesContainStr := false
-					for _, name := range credname.ListAll() {
-						if strings.EqualFold(name.String(), str) {
-							credNamesContainStr = true
-							break
+					if len(str) == 0 {
+						return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
+					}
+
+					words := strings.Split(str, " ")
+					for _, word := range words {
+						if unicode.IsLower(int32(word[0])) {
+							return errors.New(`credential name must be titlecased, e.g. "Access Key" or "Personal Access Token"`)
 						}
 					}
-
-					if !credNamesContainStr {
-						return errors.New(`credential name must be one of the suggested, e.g. "Access Key" or "Personal Access Token"`)
-					}
-
-					return nil
 				}
 
 				return nil

--- a/cmd/contrib/main_test.go
+++ b/cmd/contrib/main_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateCredentialName(t *testing.T) {

--- a/cmd/contrib/main_test.go
+++ b/cmd/contrib/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidateCredentialName(t *testing.T) {
+	err := validateCredentialName(any("Custom Credential Token"))
+	assert.Nil(t, err)
+}
+
+func TestValidateCredentialNameReturnError(t *testing.T) {
+	cases := map[string]string{
+		"when no value provided":           "",
+		"when first word not capitalized":  "custom Credential Token",
+		"when middle word not capitalized": "Custom credential Token",
+		"when last word not capitalized":   "Custom Credential token",
+		"when lowercase string provided":   "custom credential token",
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := validateCredentialName(any(tc))
+			assert.NotNil(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This PR improves validation for `Credential Name` in a survey, when user runs `make new-plugin`. 
It also applies `Transform` function on user input. Therefore users are able to provide input in any case (upper, lower, camel etc.). 

`Validate` function checks that provided string is in TitleCase.
The user has to re-enter value/select from suggested if not passed. The error appears in a console in this case.

`Transfrom` function finds the corresponding value among defined credential names and returns it. Returns provided value otherwise.