### PR TITLE
RPC functions catch panics

### DIFF
--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -132,6 +132,12 @@ func (out *ProvisionOutput) AddError(err error) {
 	out.Diagnostics.Errors = append(out.Diagnostics.Errors, Error{err.Error()})
 }
 
+// AddError can be used to report an error to the deprovision output. If the deprovision output contains one
+// or more errors, provisioning is considered failed.
+func (out *DeprovisionOutput) AddError(err error) {
+	out.Diagnostics.Errors = append(out.Diagnostics.Errors, Error{err.Error()})
+}
+
 // FromHomeDir returns a path with the user's home directory prepended.
 func (in *ProvisionInput) FromHomeDir(path ...string) string {
 	return filepath.Join(append([]string{in.HomeDir}, path...)...)

--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -132,12 +132,6 @@ func (out *ProvisionOutput) AddError(err error) {
 	out.Diagnostics.Errors = append(out.Diagnostics.Errors, Error{err.Error()})
 }
 
-// AddError can be used to report an error to the deprovision output. If the deprovision output contains one
-// or more errors, provisioning is considered failed.
-func (out *DeprovisionOutput) AddError(err error) {
-	out.Diagnostics.Errors = append(out.Diagnostics.Errors, Error{err.Error()})
-}
-
 // FromHomeDir returns a path with the user's home directory prepended.
 func (in *ProvisionInput) FromHomeDir(path ...string) string {
 	return filepath.Join(append([]string{in.HomeDir}, path...)...)

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -3,10 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/rpc/proto"
 	"github.com/1Password/shell-plugins/sdk/schema"
-	"runtime/debug"
 )
 
 type errFunctionFieldNotSet struct {

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -3,11 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
-	"runtime/debug"
-
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/rpc/proto"
 	"github.com/1Password/shell-plugins/sdk/schema"
+	"runtime/debug"
 )
 
 type errFunctionFieldNotSet struct {
@@ -205,6 +204,6 @@ func (t *RPCServer) getProvisioner(provisionerID proto.ProvisionerID) (sdk.Provi
 }
 
 func getPanicDiagnostics(err any) sdk.Diagnostics {
-	caughtPanic := fmt.Errorf("your locally built plugin's importing failed with the following panic: %s; and with stack trace: %s", err, string(debug.Stack()))
+	caughtPanic := fmt.Errorf("locally built plugin panicked: %s\nstack trace:\n%s", err, string(debug.Stack()))
 	return sdk.Diagnostics{Errors: []sdk.Error{{Message: caughtPanic.Error()}}}
 }

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -121,7 +121,7 @@ func (t *RPCServer) CredentialImport(req proto.ImportCredentialRequest, resp *sd
 	defer func() {
 		if err := recover(); err != nil {
 			caughtPanic := fmt.Errorf("your locally built plugin's importing failed with the following panic: %s; and with stack trace: %s", err, string(debug.Stack()))
-			diagnostics := sdk.Diagnostics{Errors: []sdk.Error{{caughtPanic.Error()}}}
+			diagnostics := sdk.Diagnostics{Errors: []sdk.Error{{Message: caughtPanic.Error()}}}
 			resp.Attempts = []*sdk.ImportAttempt{
 				{
 					Candidates:  nil,
@@ -180,7 +180,7 @@ func (t *RPCServer) CredentialProvisionerProvision(req proto.ProvisionCredential
 func (t *RPCServer) CredentialProvisionerDeprovision(req proto.DeprovisionCredentialRequest, resp *sdk.DeprovisionOutput) error {
 	defer func() {
 		if err := recover(); err != nil {
-			resp.AddError(fmt.Errorf("your locally built plugin's deprovisioning failed with the following panic: %s; and with stack trace: %s", err, string(debug.Stack())))
+			resp.Diagnostics.Errors = append(resp.Diagnostics.Errors, sdk.Error{Message: fmt.Sprintf("your locally built plugin's deprovisioning failed with the following panic: %s; and with stack trace: %s", err, string(debug.Stack()))})
 		}
 	}()
 	provisioner, err := t.getProvisioner(req.ProvisionerID)


### PR DESCRIPTION
Panics happening in the shell plugins code called over rpc are no longer ignored. This makes for more useful debug messages in errors.