### PR TITLE
Add more ways to get in contact for help

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,19 @@ No more plaintext credentials in your home directory. Automatically authenticate
 
 ## 👫 Contributing
 
-This repository contains the list of available plugins, as well as the SDK to create new plugins.
-
 Is your favorite CLI not listed yet? Learn how to [build a shell plugin](https://developer.1password.com/docs/cli/shell-plugins/contribute) yourself and [open a PR](https://github.com/1Password/shell-plugins/pulls)!
 
-If you need help when building a plugin, create an issue on GitHub or join our [Developer Slack workspace](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA) to tell us about your plugin proposal and we can advise you on the most suitable approach for your use case.
-
 For the contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Not sure where or how to get started? We're happy to help! You can:
+- Book a free [pairing session](https://calendly.com/d/grs-x2h-pmb/1password-shell-plugins-pairing-session) with one of our teammates
+- Join the Developer [Slack](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA) workspace, and ask us any questions there
+
+## 💚 Community & Support
+
+- Join the Developer [Slack](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA) workspace
+- Subscribe to the [Newsletter](https://1password.com/dev-subscribe/)
+- File an [issue](https://github.com/1Password/shell-plugins/issues/new/choose) for bugs and feature requests
 
 ## 📣 Beta Notice
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Not sure where or how to get started? We're happy to help! You can:
 ## 💚 Community & Support
 
 - Join the Developer [Slack](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA) workspace
-- Subscribe to the [Newsletter](https://1password.com/dev-subscribe/)
+- Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/)
 - File an [issue](https://github.com/1Password/shell-plugins/issues/new/choose) for bugs and feature requests
 - Join our [Community Office Hours](https://1password.zoom.us/meeting/register/tJIqdeqtqT4jHterIHSSJ63tY719lUrJCufe) for Shell Plugins on January 17 at 12:00 Noon Eastern (New York City) time for live help and support in getting started using or building a Shell Plugin
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ For the contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Not sure where or how to get started? We're happy to help! You can:
 - Book a free [pairing session](https://calendly.com/d/grs-x2h-pmb/1password-shell-plugins-pairing-session) with one of our teammates
-- Join the Developer [Slack](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA) workspace, and ask us any questions there
+- Join the [Developer Slack workspace](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA), and ask us any questions there
 
 ## 💚 Community & Support
 
 - File an [issue](https://github.com/1Password/shell-plugins/issues/new/choose) for bugs and feature requests
-- Join the Developer [Slack](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA) workspace
+- Join the [Developer Slack workspace](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA)
 - Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/)
 - Join our [Community Office Hours](https://1password.zoom.us/meeting/register/tJIqdeqtqT4jHterIHSSJ63tY719lUrJCufe) on January 17 at 12:00 Noon Eastern (New York City) time for live help and support in getting started using or building a Shell Plugin
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Not sure where or how to get started? We're happy to help! You can:
 
 ## 💚 Community & Support
 
+- File an [issue](https://github.com/1Password/shell-plugins/issues/new/choose) for bugs and feature requests
 - Join the Developer [Slack](https://join.slack.com/t/1password-devs/shared_invite/zt-1halo11ps-6o9pEv96xZ3LtX_VE0fJQA) workspace
 - Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/)
-- File an [issue](https://github.com/1Password/shell-plugins/issues/new/choose) for bugs and feature requests
-- Join our [Community Office Hours](https://1password.zoom.us/meeting/register/tJIqdeqtqT4jHterIHSSJ63tY719lUrJCufe) for Shell Plugins on January 17 at 12:00 Noon Eastern (New York City) time for live help and support in getting started using or building a Shell Plugin
+- Join our [Community Office Hours](https://1password.zoom.us/meeting/register/tJIqdeqtqT4jHterIHSSJ63tY719lUrJCufe) on January 17 at 12:00 Noon Eastern (New York City) time for live help and support in getting started using or building a Shell Plugin
 
 ## 📣 Beta Notice
 


### PR DESCRIPTION
We're super eager to help anyone wanting to start contributing. I've added a link to book a pairing session with one of our teammates and another mention of the Slack space where we're hanging out to help.

In addition, I've added a section on community & support, where I've added the Slack space, the newsletter and filing issues, so it's clear for folks visiting the README how they can get involved and stay up-to-date, if they so wish.