### PR TITLE
Improve needsauth helper package

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -518,7 +518,10 @@ func {{ .PlatformNameUpperCamelCase }}CLI() schema.Executable {
 		Name:      "{{ .PlatformName }} CLI", // TODO: Check if this is correct
 		Runs:      []string{"{{ .Executable }}"},
 		DocsURL:   sdk.URL("https://{{ .Name }}.com/docs/cli"), // TODO: Replace with actual URL
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		{{- if .CredentialName }}
 		Uses: []schema.CredentialUsage{
 			{

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -504,7 +504,7 @@ func {{ .PlatformNameUpperCamelCase }}CLI() schema.Executable {
 		Name:      "{{ .PlatformName }} CLI", // TODO: Check if this is correct
 		Runs:      []string{"{{ .Executable }}"},
 		DocsURL:   sdk.URL("https://{{ .Name }}.com/docs/cli"), // TODO: Replace with actual URL
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/aws/aws.go
+++ b/plugins/aws/aws.go
@@ -9,10 +9,13 @@ import (
 
 func AWSCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "AWS CLI",
-		Runs:      []string{"aws"},
-		DocsURL:   sdk.URL("https://aws.amazon.com/cli/"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "AWS CLI",
+		Runs:    []string{"aws"},
+		DocsURL: sdk.URL("https://aws.amazon.com/cli/"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.AccessKey,

--- a/plugins/aws/aws.go
+++ b/plugins/aws/aws.go
@@ -12,7 +12,7 @@ func AWSCLI() schema.Executable {
 		Name:    "AWS CLI",
 		Runs:    []string{"aws"},
 		DocsURL: sdk.URL("https://aws.amazon.com/cli/"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/cargo/cargo.go
+++ b/plugins/cargo/cargo.go
@@ -7,18 +7,16 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
 
-var commands = [][]string{
-	{"publish"},
-	{"yank"},
-	{"owner"},
-}
-
 func CargoCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Cargo CLI",
-		Runs:      []string{"cargo"},
-		DocsURL:   sdk.URL("https://doc.rust-lang.org/cargo/index.html"),
-		NeedsAuth: needsauth.ForCommands(commands...),
+		Name:    "Cargo CLI",
+		Runs:    []string{"cargo"},
+		DocsURL: sdk.URL("https://doc.rust-lang.org/cargo/index.html"),
+		NeedsAuth: needsauth.OnlyFor(
+			needsauth.ForCommand("publish"),
+			needsauth.ForCommand("yank"),
+			needsauth.ForCommand("owner"),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIToken,

--- a/plugins/cargo/cargo.go
+++ b/plugins/cargo/cargo.go
@@ -12,8 +12,8 @@ func CargoCLI() schema.Executable {
 		Name:    "Cargo CLI",
 		Runs:    []string{"cargo"},
 		DocsURL: sdk.URL("https://doc.rust-lang.org/cargo/index.html"),
-		NeedsAuth: needsauth.For(
-			needsauth.OnlyFor(
+		NeedsAuth: needsauth.IfAll(
+			needsauth.IfAny(
 				needsauth.ForCommand("publish"),
 				needsauth.ForCommand("yank"),
 				needsauth.ForCommand("owner"),

--- a/plugins/cargo/cargo.go
+++ b/plugins/cargo/cargo.go
@@ -12,10 +12,13 @@ func CargoCLI() schema.Executable {
 		Name:    "Cargo CLI",
 		Runs:    []string{"cargo"},
 		DocsURL: sdk.URL("https://doc.rust-lang.org/cargo/index.html"),
-		NeedsAuth: needsauth.OnlyFor(
-			needsauth.ForCommand("publish"),
-			needsauth.ForCommand("yank"),
-			needsauth.ForCommand("owner"),
+		NeedsAuth: needsauth.For(
+			needsauth.OnlyFor(
+				needsauth.ForCommand("publish"),
+				needsauth.ForCommand("yank"),
+				needsauth.ForCommand("owner"),
+			),
+			needsauth.NotForHelp(),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/circleci/circleci.go
+++ b/plugins/circleci/circleci.go
@@ -12,7 +12,7 @@ func CircleCICLI() schema.Executable {
 		Name:    "CircleCI CLI",
 		Runs:    []string{"circleci"},
 		DocsURL: sdk.URL("https://circleci.com/docs/local-cli/"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 			needsauth.NotForExactArgs("config"),

--- a/plugins/circleci/circleci.go
+++ b/plugins/circleci/circleci.go
@@ -14,7 +14,8 @@ func CircleCICLI() schema.Executable {
 		DocsURL: sdk.URL("https://circleci.com/docs/local-cli/"),
 		NeedsAuth: needsauth.For(
 			needsauth.NotForHelpOrVersion(),
-			needsauth.NotForArgs("config"),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("config"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/digitalocean/doctl.go
+++ b/plugins/digitalocean/doctl.go
@@ -12,7 +12,7 @@ func DigitalOceanCLI() schema.Executable {
 		Name:    "DigitalOcean CLI",
 		Runs:    []string{"doctl"},
 		DocsURL: sdk.URL("https://docs.digitalocean.com/reference/doctl"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/digitalocean/doctl.go
+++ b/plugins/digitalocean/doctl.go
@@ -9,10 +9,13 @@ import (
 
 func DigitalOceanCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "DigitalOcean CLI",
-		Runs:      []string{"doctl"},
-		DocsURL:   sdk.URL("https://docs.digitalocean.com/reference/doctl"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "DigitalOcean CLI",
+		Runs:    []string{"doctl"},
+		DocsURL: sdk.URL("https://docs.digitalocean.com/reference/doctl"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.PersonalAccessToken,

--- a/plugins/fossa/fossa.go
+++ b/plugins/fossa/fossa.go
@@ -9,10 +9,13 @@ import (
 
 func FOSSACLI() schema.Executable {
 	return schema.Executable{
-		Name:      "FOSSA CLI",
-		Runs:      []string{"fossa"},
-		DocsURL:   sdk.URL("https://github.com/fossas/fossa-cli"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "FOSSA CLI",
+		Runs:    []string{"fossa"},
+		DocsURL: sdk.URL("https://github.com/fossas/fossa-cli"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIKey,

--- a/plugins/fossa/fossa.go
+++ b/plugins/fossa/fossa.go
@@ -12,7 +12,7 @@ func FOSSACLI() schema.Executable {
 		Name:    "FOSSA CLI",
 		Runs:    []string{"fossa"},
 		DocsURL: sdk.URL("https://github.com/fossas/fossa-cli"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/github/gh.go
+++ b/plugins/github/gh.go
@@ -9,10 +9,13 @@ import (
 
 func GitHubCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "GitHub CLI",
-		Runs:      []string{"gh"},
-		DocsURL:   sdk.URL("https://cli.github.com"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "GitHub CLI",
+		Runs:    []string{"gh"},
+		DocsURL: sdk.URL("https://cli.github.com"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.PersonalAccessToken,

--- a/plugins/github/gh.go
+++ b/plugins/github/gh.go
@@ -12,7 +12,7 @@ func GitHubCLI() schema.Executable {
 		Name:    "GitHub CLI",
 		Runs:    []string{"gh"},
 		DocsURL: sdk.URL("https://cli.github.com"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/gitlab/glab.go
+++ b/plugins/gitlab/glab.go
@@ -12,7 +12,7 @@ func GitLabCLI() schema.Executable {
 		Name:    "GitLab CLI",
 		Runs:    []string{"glab"},
 		DocsURL: sdk.URL("https://glab.readthedocs.io"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/gitlab/glab.go
+++ b/plugins/gitlab/glab.go
@@ -9,10 +9,13 @@ import (
 
 func GitLabCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "GitLab CLI",
-		Runs:      []string{"glab"},
-		DocsURL:   sdk.URL("https://glab.readthedocs.io"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "GitLab CLI",
+		Runs:    []string{"glab"},
+		DocsURL: sdk.URL("https://glab.readthedocs.io"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.PersonalAccessToken,

--- a/plugins/heroku/heroku.go
+++ b/plugins/heroku/heroku.go
@@ -12,7 +12,7 @@ func HerokuCLI() schema.Executable {
 		Name:    "Heroku CLI",
 		Runs:    []string{"heroku"},
 		DocsURL: sdk.URL("https://devcenter.heroku.com/articles/heroku-cli"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/heroku/heroku.go
+++ b/plugins/heroku/heroku.go
@@ -9,10 +9,13 @@ import (
 
 func HerokuCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Heroku CLI",
-		Runs:      []string{"heroku"},
-		DocsURL:   sdk.URL("https://devcenter.heroku.com/articles/heroku-cli"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "Heroku CLI",
+		Runs:    []string{"heroku"},
+		DocsURL: sdk.URL("https://devcenter.heroku.com/articles/heroku-cli"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIKey,

--- a/plugins/homebrew/brew.go
+++ b/plugins/homebrew/brew.go
@@ -12,9 +12,9 @@ func HomebrewCLI() schema.Executable {
 		Name:    "Homebrew CLI",
 		Runs:    []string{"brew"},
 		DocsURL: sdk.URL("https://brew.sh/"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
-			needsauth.OnlyFor(
+			needsauth.IfAny(
 				needsauth.ForCommand("search"),
 				needsauth.ForCommand("bump-cask-pr"),
 				needsauth.ForCommand("bump-formula-pr"),

--- a/plugins/homebrew/brew.go
+++ b/plugins/homebrew/brew.go
@@ -7,19 +7,20 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
 
-var commands = [][]string{
-	{"search"},
-
-	{"bump-cask-pr"},
-	{"bump-formula-pr"},
-}
-
 func HomebrewCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Homebrew CLI",
-		Runs:      []string{"brew"},
-		DocsURL:   sdk.URL("https://brew.sh/"),
-		NeedsAuth: needsauth.ForCommands(commands...),
+		Name:    "Homebrew CLI",
+		Runs:    []string{"brew"},
+		DocsURL: sdk.URL("https://brew.sh/"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForHelpOrVersion(),
+			needsauth.OnlyFor(
+				needsauth.ForCommand("search"),
+				needsauth.ForCommand("bump-cask-pr"),
+				needsauth.ForCommand("bump-formula-pr"),
+			),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.PersonalAccessToken,

--- a/plugins/homebrew/brew.go
+++ b/plugins/homebrew/brew.go
@@ -13,7 +13,6 @@ func HomebrewCLI() schema.Executable {
 		Runs:    []string{"brew"},
 		DocsURL: sdk.URL("https://brew.sh/"),
 		NeedsAuth: needsauth.For(
-			needsauth.NotWithoutArgs(),
 			needsauth.NotForHelpOrVersion(),
 			needsauth.OnlyFor(
 				needsauth.ForCommand("search"),

--- a/plugins/okta/okta.go
+++ b/plugins/okta/okta.go
@@ -12,7 +12,7 @@ func OktaCLI() schema.Executable {
 		Name:    "Okta CLI",
 		Runs:    []string{"okta"},
 		DocsURL: sdk.URL("https://cli.okta.com"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
 		),

--- a/plugins/okta/okta.go
+++ b/plugins/okta/okta.go
@@ -9,10 +9,13 @@ import (
 
 func OktaCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Okta CLI",
-		Runs:      []string{"okta"},
-		DocsURL:   sdk.URL("https://cli.okta.com"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "Okta CLI",
+		Runs:    []string{"okta"},
+		DocsURL: sdk.URL("https://cli.okta.com"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIToken,

--- a/plugins/readme/api_key_test.go
+++ b/plugins/readme/api_key_test.go
@@ -44,7 +44,7 @@ func TestAPIKeyImporter(t *testing.T) {
 	})
 }
 
-func TestSecretKeyProvisioner(t *testing.T) {
+func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{

--- a/plugins/readme/rdme.go
+++ b/plugins/readme/rdme.go
@@ -7,32 +7,34 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
 
-var commands = [][]string{
-	{"openapi"},
-
-	{"docs"},
-	{"docs:prune"},
-	{"guides"},
-	{"guides:prune"},
-
-	{"changelogs"},
-	{"custompages"},
-
-	{"versions"},
-	{"versions:create"},
-	{"versions:delete"},
-	{"versions:update"},
-
-	{"categories"},
-	{"categories:create"},
-}
-
 func ReadMeCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "ReadMe CLI",
-		Runs:      []string{"rdme"},
-		DocsURL:   sdk.URL("https://docs.readme.com/main/docs/rdme"),
-		NeedsAuth: needsauth.ForCommands(commands...),
+		Name:    "ReadMe CLI",
+		Runs:    []string{"rdme"},
+		DocsURL: sdk.URL("https://docs.readme.com/main/docs/rdme"),
+		NeedsAuth: needsauth.For(
+			needsauth.NotForHelpOrVersion(),
+
+			needsauth.OnlyFor(
+				needsauth.ForCommand("openapi"),
+
+				needsauth.ForCommand("docs"),
+				needsauth.ForCommand("docs:prune"),
+				needsauth.ForCommand("guides"),
+				needsauth.ForCommand("guides:prune"),
+
+				needsauth.ForCommand("changelogs"),
+				needsauth.ForCommand("custompages"),
+
+				needsauth.ForCommand("versions"),
+				needsauth.ForCommand("versions:create"),
+				needsauth.ForCommand("versions:delete"),
+				needsauth.ForCommand("versions:update"),
+
+				needsauth.ForCommand("categories"),
+				needsauth.ForCommand("categories:create"),
+			),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIKey,

--- a/plugins/readme/rdme.go
+++ b/plugins/readme/rdme.go
@@ -12,10 +12,10 @@ func ReadMeCLI() schema.Executable {
 		Name:    "ReadMe CLI",
 		Runs:    []string{"rdme"},
 		DocsURL: sdk.URL("https://docs.readme.com/main/docs/rdme"),
-		NeedsAuth: needsauth.For(
+		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 
-			needsauth.OnlyFor(
+			needsauth.IfAny(
 				needsauth.ForCommand("openapi"),
 
 				needsauth.ForCommand("docs"),

--- a/plugins/readme/rdme_test.go
+++ b/plugins/readme/rdme_test.go
@@ -1,0 +1,32 @@
+package readme
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+)
+
+func TestRdmeNeedsAuth(t *testing.T) {
+	plugintest.TestNeedsAuth(t, ReadMeCLI().NeedsAuth, map[string]plugintest.NeedsAuthCase{
+		"yes for docs command": {
+			Args:              []string{"docs"},
+			ExpectedNeedsAuth: true,
+		},
+		"no for docs command help": {
+			Args:              []string{"docs", "--help"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for open command": {
+			Args:              []string{"open"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for version": {
+			Args:              []string{"--version"},
+			ExpectedNeedsAuth: false,
+		},
+		"yes for openapi with --version flag": {
+			Args:              []string{"openapi", "--version", "2.0"},
+			ExpectedNeedsAuth: true,
+		},
+	})
+}

--- a/sdk/needsauth/helpers.go
+++ b/sdk/needsauth/helpers.go
@@ -78,24 +78,24 @@ func NotForExactArgs(argsToSkip ...string) sdk.NeedsAuthentication {
 
 // NotWhenContainsArgs returns a NeedsAuthentication rule to not require authentication when
 // the exact sequence of argsToSkip is present somewhere in the command-line args.
-func NotWhenContainsArgs(argsToSkip ...string) sdk.NeedsAuthentication {
+func NotWhenContainsArgs(argsSequence ...string) sdk.NeedsAuthentication {
 	return func(in sdk.NeedsAuthenticationInput) bool {
-		if len(argsToSkip) == 0 {
+		if len(argsSequence) == 0 {
 			return true
 		}
 
-		if len(argsToSkip) > len(in.CommandArgs) {
+		if len(argsSequence) > len(in.CommandArgs) {
 			return true
 		}
 
 		for i := range in.CommandArgs {
-			if i+len(argsToSkip) > len(in.CommandArgs) {
+			if i+len(argsSequence) > len(in.CommandArgs) {
 				return true
 			}
 
 			matches := true
-			for i, argsToCompare := range in.CommandArgs[i : i+len(argsToSkip)] {
-				if argsToCompare != argsToSkip[i] {
+			for i, argsToCompare := range in.CommandArgs[i : i+len(argsSequence)] {
+				if argsToCompare != argsSequence[i] {
 					matches = false
 				}
 			}

--- a/sdk/needsauth/helpers.go
+++ b/sdk/needsauth/helpers.go
@@ -1,9 +1,11 @@
 package needsauth
 
-import "github.com/1Password/shell-plugins/sdk"
+import (
+	"github.com/1Password/shell-plugins/sdk"
+)
 
-// For returns a NeedsAuthentication rule that iterates over other NeedsAuthentication rules
-// until there's one that opts out of the authentication requirement.
+// For returns a NeedsAuthentication that opts in to the authentication requirement, unless there's
+// one rule specified that opts out to the authentication requirement.
 func For(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
 	return func(in sdk.NeedsAuthenticationInput) bool {
 		for _, rule := range rules {
@@ -15,22 +17,33 @@ func For(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
 	}
 }
 
-// ForCommands returns a NeedsAuthentication rule to require authentication for
-// certain (sub)command, e.g. ["account"] or ["account", "list"], ["account", "delete"].
-func ForCommands(commands ...[]string) sdk.NeedsAuthentication {
+// OnlyFor returns a NeedsAuthentication rule that only opts in of the authentication requirement if there's
+// at least one rule specified that opts in to the authentication requirement.
+func OnlyFor(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
 	return func(in sdk.NeedsAuthenticationInput) bool {
-		for _, command := range commands {
-			if len(command) > len(in.CommandArgs) {
-				continue
+		for _, rule := range rules {
+			if rule(in) {
+				return true
 			}
+		}
+		return false
+	}
+}
 
-			for i := range command {
-				if command[i] != in.CommandArgs[i] {
-					break
-				}
-				if i == len(command)-1 {
-					return true
-				}
+// ForCommand returns a NeedsAuthentication rule to require authentication for
+// certain (sub)command, e.g. ["account"] or ["account", "list"].
+func ForCommand(command ...string) sdk.NeedsAuthentication {
+	return func(in sdk.NeedsAuthenticationInput) bool {
+		if len(command) > len(in.CommandArgs) {
+			return false
+		}
+
+		for i := range command {
+			if command[i] != in.CommandArgs[i] {
+				return false
+			}
+			if i == len(command)-1 {
+				return true
 			}
 		}
 
@@ -45,15 +58,52 @@ func Always() sdk.NeedsAuthentication {
 	}
 }
 
-// NotForArgs returns a NeedsAuthentication rule to not require authentication when
-// certain command-line args or flags are present.
-func NotForArgs(argsToSkip ...string) sdk.NeedsAuthentication {
+// NotForExactArgs returns a NeedsAuthentication rule to opt out of authentication when
+// the command-line args are an exact match with the passed in args.
+func NotForExactArgs(argsToSkip ...string) sdk.NeedsAuthentication {
 	return func(in sdk.NeedsAuthenticationInput) bool {
-		for _, commandArg := range in.CommandArgs {
-			for _, ignoreArg := range argsToSkip {
-				if commandArg == ignoreArg {
-					return false
+		if len(in.CommandArgs) != len(argsToSkip) {
+			return true
+		}
+
+		for i, commandArg := range in.CommandArgs {
+			if commandArg != argsToSkip[i] {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+// NotWhenContainsArgs returns a NeedsAuthentication rule to not require authentication when
+// the exact sequence of argsToSkip is present somewhere in the command-line args.
+func NotWhenContainsArgs(argsToSkip ...string) sdk.NeedsAuthentication {
+	return func(in sdk.NeedsAuthenticationInput) bool {
+		if len(argsToSkip) == 0 {
+			return true
+		}
+
+		if len(argsToSkip) > len(in.CommandArgs) {
+			return true
+		}
+
+		for i := range in.CommandArgs {
+			if i+len(argsToSkip) > len(in.CommandArgs) {
+				return true
+			}
+
+			matches := true
+			for i, argsToCompare := range in.CommandArgs[i : i+len(argsToSkip)] {
+				if argsToCompare != argsToSkip[i] {
+					matches = false
 				}
+			}
+
+			// If the argsToSkip are found in the command-line args, return that the command
+			// does not not require authentication
+			if matches {
+				return false
 			}
 		}
 		return true

--- a/sdk/needsauth/helpers.go
+++ b/sdk/needsauth/helpers.go
@@ -4,9 +4,9 @@ import (
 	"github.com/1Password/shell-plugins/sdk"
 )
 
-// For returns a NeedsAuthentication that opts in to the authentication requirement, unless there's
-// one rule specified that opts out of the authentication requirement.
-func For(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
+// IfAll returns a NeedsAuthentication that opts in to the authentication requirement only if
+// all the specified rules opt in to the authentication requirement.
+func IfAll(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
 	return func(in sdk.NeedsAuthenticationInput) bool {
 		for _, rule := range rules {
 			if !rule(in) {
@@ -17,9 +17,9 @@ func For(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
 	}
 }
 
-// OnlyFor returns a NeedsAuthentication rule that only opts in of the authentication requirement if there's
-// at least one rule specified that opts in to the authentication requirement.
-func OnlyFor(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
+// IfAny returns a NeedsAuthentication rule that only opts in to the authentication requirement
+// if at least one specified rule opts in to the authentication requirement.
+func IfAny(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
 	return func(in sdk.NeedsAuthenticationInput) bool {
 		for _, rule := range rules {
 			if rule(in) {
@@ -111,7 +111,7 @@ func NotWhenContainsArgs(argsToSkip ...string) sdk.NeedsAuthentication {
 }
 
 func NotForHelp() sdk.NeedsAuthentication {
-	return For(
+	return IfAll(
 		NotWhenContainsArgs("-h"),
 		NotWhenContainsArgs("--help"),
 		NotWhenContainsArgs("-help"),
@@ -120,7 +120,7 @@ func NotForHelp() sdk.NeedsAuthentication {
 }
 
 func NotForVersion() sdk.NeedsAuthentication {
-	return For(
+	return IfAll(
 		NotForExactArgs("-v"),
 		NotForExactArgs("--version"),
 		NotForExactArgs("-version"),
@@ -134,5 +134,5 @@ func NotWithoutArgs() sdk.NeedsAuthentication {
 }
 
 func NotForHelpOrVersion() sdk.NeedsAuthentication {
-	return For(NotForHelp(), NotForVersion())
+	return IfAll(NotForHelp(), NotForVersion())
 }

--- a/sdk/needsauth/helpers.go
+++ b/sdk/needsauth/helpers.go
@@ -5,7 +5,7 @@ import (
 )
 
 // For returns a NeedsAuthentication that opts in to the authentication requirement, unless there's
-// one rule specified that opts out to the authentication requirement.
+// one rule specified that opts out of the authentication requirement.
 func For(rules ...sdk.NeedsAuthentication) sdk.NeedsAuthentication {
 	return func(in sdk.NeedsAuthenticationInput) bool {
 		for _, rule := range rules {

--- a/sdk/needsauth/helpers.go
+++ b/sdk/needsauth/helpers.go
@@ -111,11 +111,26 @@ func NotWhenContainsArgs(argsToSkip ...string) sdk.NeedsAuthentication {
 }
 
 func NotForHelp() sdk.NeedsAuthentication {
-	return NotForArgs("-h", "--help", "-help", "help")
+	return For(
+		NotWhenContainsArgs("-h"),
+		NotWhenContainsArgs("--help"),
+		NotWhenContainsArgs("-help"),
+		NotWhenContainsArgs("help"),
+	)
 }
 
 func NotForVersion() sdk.NeedsAuthentication {
-	return NotForArgs("-v", "--version", "-version", "version")
+	return For(
+		NotForExactArgs("-v"),
+		NotForExactArgs("--version"),
+		NotForExactArgs("-version"),
+		NotForExactArgs("version"),
+		NotForExactArgs("-V"),
+	)
+}
+
+func NotWithoutArgs() sdk.NeedsAuthentication {
+	return NotForExactArgs()
 }
 
 func NotForHelpOrVersion() sdk.NeedsAuthentication {

--- a/sdk/needsauth/helpers_test.go
+++ b/sdk/needsauth/helpers_test.go
@@ -115,14 +115,14 @@ func TestComplexChain(t *testing.T) {
 	// * Not for "--version" and "--help", or when no args are specified
 	// * Never when the "--local" flag is specified
 
-	needsAuth := /*needsauth.*/ For(
+	needsAuth := /*needsauth.*/ IfAll(
 		/*needsauth.*/ NotWithoutArgs(),
 		/*needsauth.*/ NotForHelpOrVersion(),
 		/*needsauth.*/ NotWhenContainsArgs("--local"),
-		/*needsauth.*/ OnlyFor(
+		/*needsauth.*/ IfAny(
 			/*needsauth.*/ ForCommand("auth"),
 			/*needsauth.*/ ForCommand("install"),
-			/*needsauth.*/ For(
+			/*needsauth.*/ IfAll(
 				/*needsauth.*/ ForCommand("publish"),
 				/*needsauth.*/ NotWhenContainsArgs("--dry-run"),
 			),

--- a/sdk/needsauth/helpers_test.go
+++ b/sdk/needsauth/helpers_test.go
@@ -1,0 +1,194 @@
+package needsauth
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+)
+
+func TestNoArg(t *testing.T) {
+	plugintest.TestNeedsAuth(t, NotWithoutArgs(), map[string]plugintest.NeedsAuthCase{
+		"yes with args": {
+			Args:              []string{"foo"},
+			ExpectedNeedsAuth: true,
+		},
+		"not without command": {
+			Args:              []string{},
+			ExpectedNeedsAuth: false,
+		},
+	})
+}
+
+func TestHelp(t *testing.T) {
+	plugintest.TestNeedsAuth(t, NotForHelp(), map[string]plugintest.NeedsAuthCase{
+		"no for exact help flag": {
+			Args:              []string{"--help"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for exact help short flag": {
+			Args:              []string{"-h"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for help flag in command": {
+			Args:              []string{"foo", "--help"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for help short flag in command": {
+			Args:              []string{"foo", "-h"},
+			ExpectedNeedsAuth: false,
+		},
+		"yes without help": {
+			Args:              []string{"foo"},
+			ExpectedNeedsAuth: true,
+		},
+	})
+}
+
+func TestVersion(t *testing.T) {
+	plugintest.TestNeedsAuth(t, NotForVersion(), map[string]plugintest.NeedsAuthCase{
+		"not for exact version flag": {
+			Args:              []string{"--version"},
+			ExpectedNeedsAuth: false,
+		},
+		"not for exact version short flag": {
+			Args:              []string{"-v"},
+			ExpectedNeedsAuth: false,
+		},
+		"yes when --version flag is part of a command": {
+			Args:              []string{"deploy", "--version", "1.0.0"},
+			ExpectedNeedsAuth: true,
+		},
+		"yes when -v is part of a command": {
+			Args:              []string{"run", "-v", "$PWD:/app", "foo"},
+			ExpectedNeedsAuth: true,
+		},
+	})
+}
+
+func TestContainsArgs(t *testing.T) {
+	plugintest.TestNeedsAuth(t, NotWhenContainsArgs("--mode", "dry-run"), map[string]plugintest.NeedsAuthCase{
+		"yes by default": {
+			Args:              []string{"deploy"},
+			ExpectedNeedsAuth: true,
+		},
+		"yes when only one of the args is present": {
+			Args:              []string{"deploy", "--mode", "live"},
+			ExpectedNeedsAuth: true,
+		},
+		"yes when both args are present, but not in sequence": {
+			Args:              []string{"deploy", "--mode", "live", "--app-name", "dry-run"},
+			ExpectedNeedsAuth: true,
+		},
+		"no when all args are present in sequence": {
+			Args:              []string{"deploy", "--mode", "dry-run"},
+			ExpectedNeedsAuth: false,
+		},
+	})
+}
+
+func TestForCommand(t *testing.T) {
+	plugintest.TestNeedsAuth(t, NotWhenContainsArgs("--mode", "dry-run"), map[string]plugintest.NeedsAuthCase{
+		"yes by default": {
+			Args:              []string{"deploy"},
+			ExpectedNeedsAuth: true,
+		},
+		"yes when only one of the args is present": {
+			Args:              []string{"deploy", "--mode", "live"},
+			ExpectedNeedsAuth: true,
+		},
+		"yes when both args are present, but not in sequence": {
+			Args:              []string{"deploy", "--mode", "live", "--app-name", "dry-run"},
+			ExpectedNeedsAuth: true,
+		},
+		"no when all args are present in sequence": {
+			Args:              []string{"deploy", "--mode", "dry-run"},
+			ExpectedNeedsAuth: false,
+		},
+	})
+}
+
+func TestComplexChain(t *testing.T) {
+	// Example of a fictitious package manager that requires authentication for:
+	// * The "publish" command, unless the "--dry-run" flag is present
+	// * The "install" command
+	// * The "auth" subcommands
+	// * Not for "--version" and "--help", or when no args are specified
+	// * Never when the "--local" flag is specified
+
+	needsAuth := /*needsauth.*/ For(
+		/*needsauth.*/ NotWithoutArgs(),
+		/*needsauth.*/ NotForHelpOrVersion(),
+		/*needsauth.*/ NotWhenContainsArgs("--local"),
+		/*needsauth.*/ OnlyFor(
+			/*needsauth.*/ ForCommand("auth"),
+			/*needsauth.*/ ForCommand("install"),
+			/*needsauth.*/ For(
+				/*needsauth.*/ ForCommand("publish"),
+				/*needsauth.*/ NotWhenContainsArgs("--dry-run"),
+			),
+		),
+	)
+
+	plugintest.TestNeedsAuth(t, needsAuth, map[string]plugintest.NeedsAuthCase{
+		"no without args": {
+			Args:              []string{},
+			ExpectedNeedsAuth: false,
+		},
+		"no for help": {
+			Args:              []string{"--help"},
+			ExpectedNeedsAuth: false,
+		},
+		"yes for publish command": {
+			Args:              []string{"publish", "my-app"},
+			ExpectedNeedsAuth: true,
+		},
+		"no for publish help": {
+			Args:              []string{"publish", "--help"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for publish dry run": {
+			Args:              []string{"publish", "my-app", "--dry-run"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for publish local": {
+			Args:              []string{"publish", "--local"},
+			ExpectedNeedsAuth: false,
+		},
+		"yes for install command with args": {
+			Args:              []string{"install"},
+			ExpectedNeedsAuth: true,
+		},
+		"no for local install command": {
+			Args:              []string{"install", "--local"},
+			ExpectedNeedsAuth: false,
+		},
+		"yes for install command with a specific app version": {
+			Args:              []string{"install", "--version", "1.0.0"},
+			ExpectedNeedsAuth: true,
+		},
+		"no for version command": {
+			Args:              []string{"--version"},
+			ExpectedNeedsAuth: false,
+		},
+		"yes for auth command": {
+			Args:              []string{"auth"},
+			ExpectedNeedsAuth: true,
+		},
+		"yes for auth subcommand": {
+			Args:              []string{"auth", "whoami"},
+			ExpectedNeedsAuth: true,
+		},
+		"no for auth help": {
+			Args:              []string{"auth", "--help"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for config command": {
+			Args:              []string{"config"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for other install command": {
+			Args:              []string{"shell-completions", "install", "--shell", "bash"},
+			ExpectedNeedsAuth: false,
+		},
+	})
+}

--- a/sdk/plugintest/importer_test_helper.go
+++ b/sdk/plugintest/importer_test_helper.go
@@ -15,8 +15,11 @@ import (
 // setting the environment variables, and configuring the home path using the temp dir.
 func TestImporter(t *testing.T, importer sdk.Importer, cases map[string]ImportCase) {
 	t.Helper()
+
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
 			if c.ExpectedOutput != nil && len(c.ExpectedCandidates) > 0 {
 				t.Fatal("ExpectedOutput and ExpectedCandidates can't both be set in the same test case")
 			}

--- a/sdk/plugintest/needs_auth_test_helper.go
+++ b/sdk/plugintest/needs_auth_test_helper.go
@@ -1,0 +1,26 @@
+package plugintest
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/stretchr/testify/assert"
+)
+
+type NeedsAuthCase struct {
+	Args              []string
+	ExpectedNeedsAuth bool
+}
+
+func TestNeedsAuth(t *testing.T, rule sdk.NeedsAuthentication, cases map[string]NeedsAuthCase) {
+	t.Helper()
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+			in := sdk.NeedsAuthenticationInput{
+				CommandArgs: c.Args,
+			}
+			assert.Equal(t, c.ExpectedNeedsAuth, rule(in), name)
+		})
+	}
+}

--- a/sdk/plugintest/provisioner_test_helper.go
+++ b/sdk/plugintest/provisioner_test_helper.go
@@ -16,6 +16,8 @@ func TestProvisioner(t *testing.T, provisioner sdk.Provisioner, cases map[string
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
 			if c.ExpectedOutput.Environment == nil {
 				c.ExpectedOutput.Environment = make(map[string]string)
 			}


### PR DESCRIPTION
This PR makes the following improvements to the `needsauth` package and related functionality:

- Remove the ability from `needsauth` helper functions to specify multiple patterns in a single rule. This removes confusion, as seen in #107.
- Make the `--version` detection more strict, to only opt out of authentication if the version arg is the only arg present, to avoid false positives such as: `deploy --version 1.0.0`.
- Also consider `-V` for the version check.
- Add a `needsauth` helper to check for invocations with empty args, which often brings up the help text, so should not require authentication.
- Add this new empty-args helper to a bunch of plugins that follow this pattern.
- Add a test helper to the `plugintest` package to easily add test cases for `NeedsAuth` entries.
- Add tests for the `needsauth` package using the new test helper.
