### PR TITLE
Add importer helpers to support OS-specific importers

### DIFF
--- a/sdk/importer.go
+++ b/sdk/importer.go
@@ -40,6 +40,9 @@ type ImportSource struct {
 type ImportInput struct {
 	HomeDir string
 	RootDir string
+
+	// Supported values: "darwin", "linux"
+	OS string
 }
 
 type ImportOutput struct {

--- a/sdk/importer/helpers.go
+++ b/sdk/importer/helpers.go
@@ -14,6 +14,26 @@ func TryAll(importers ...sdk.Importer) sdk.Importer {
 	}
 }
 
+func MacOnly(importers ...sdk.Importer) sdk.Importer {
+	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
+		if in.OS == "darwin" {
+			for _, imp := range importers {
+				imp(ctx, in, out)
+			}
+		}
+	}
+}
+
+func LinuxOnly(importers ...sdk.Importer) sdk.Importer {
+	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
+		if in.OS == "linux" {
+			for _, imp := range importers {
+				imp(ctx, in, out)
+			}
+		}
+	}
+}
+
 const maxNameHintLength = 24
 
 // SanitizeNameHint can be used to sanitize the name hint before passing it to the import candidate to

--- a/sdk/plugintest/importer_test_helper.go
+++ b/sdk/plugintest/importer_test_helper.go
@@ -29,6 +29,7 @@ func TestImporter(t *testing.T, importer sdk.Importer, cases map[string]ImportCa
 			in := sdk.ImportInput{
 				HomeDir: filepath.Join(fsRoot, "~"),
 				RootDir: fsRoot,
+				OS:      c.OS,
 			}
 
 			for path, contents := range c.Files {
@@ -71,6 +72,9 @@ type ImportCase struct {
 	// For example: ~/.config/my-pugin/config -> '{"foo":"bar"}'. This is useful in conjunction with the
 	// LoadFixture helper.
 	Files map[string]string
+
+	// OS can be used to test OS-specific importers. Supported values: "darwin", "linux"
+	OS string
 
 	// ExpectedCandidates is a shorthand to set the expected import candidates. Mutually exclusive with ExpectedOutput.
 	ExpectedCandidates []sdk.ImportCandidate


### PR DESCRIPTION
### Usage

```go
Importer: importer.TryAll(
	importer.TryAllEnvVars(fieldname.Token, "EXAMPLE_ACCESS_TOKEN"),
	importer.MacOnly(
		TryExampleConfigFile("~/Library/Application Support/example/config.yml"),
	),
	importer.LinuxOnly(
		TryExampleConfigFile("$XDG_CONFIG_HOME/example/config.yml"),
	),
),
```