### PR TITLE
Add support for cargo

### DIFF
--- a/plugins/cargo/api_token.go
+++ b/plugins/cargo/api_token.go
@@ -46,7 +46,6 @@ func TryCargoConfigFile() sdk.Importer {
 			Fields: map[sdk.FieldName]string{
 				fieldname.Token: config.Registry.Token,
 			},
-			NameHint: importer.SanitizeNameHint("crates.io"),
 		})
 
 	})

--- a/plugins/cargo/api_token.go
+++ b/plugins/cargo/api_token.go
@@ -19,7 +19,7 @@ func APIToken() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,
-				MarkdownDescription: "Token used to authenticate to crates.io.",
+				MarkdownDescription: "Token used to authenticate to crates.io or another cargo registry.",
 				Secret:              true,
 			},
 		},
@@ -49,22 +49,11 @@ func TryCargoConfigFile() sdk.Importer {
 			NameHint: importer.SanitizeNameHint("crates.io"),
 		})
 
-		for regName, configRegistry := range config.Registries {
-			out.AddCandidate(sdk.ImportCandidate{
-				Fields: map[sdk.FieldName]string{
-					fieldname.Token: configRegistry.Token,
-				},
-				NameHint: importer.SanitizeNameHint(regName),
-			})
-
-		}
-
 	})
 }
 
 type Config struct {
-	Registry   ConfigRegistry            `toml:"registry"`
-	Registries map[string]ConfigRegistry `toml:"registries"`
+	Registry ConfigRegistry `toml:"registry"`
 }
 
 type ConfigRegistry struct {

--- a/plugins/cargo/api_token.go
+++ b/plugins/cargo/api_token.go
@@ -1,0 +1,63 @@
+package cargo
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://doc.rust-lang.org/cargo/reference/config.html#credentials"),
+		ManagementURL: sdk.URL("https://crates.io/settings/tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Cargo.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryCargoConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"CARGO_REGISTRY_TOKEN": fieldname.Token,
+}
+
+func TryCargoConfigFile() sdk.Importer {
+	return importer.TryFile("~/.cargo/credentials.toml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToTOML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for _, configRegistry := range config.Registries {
+			out.AddCandidate(sdk.ImportCandidate{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: configRegistry.Token,
+				},
+			})
+
+		}
+
+	})
+}
+
+type Config struct {
+	Registries []ConfigRegistry `toml:"registry"`
+}
+
+type ConfigRegistry struct {
+	Token string `toml:"token"`
+}

--- a/plugins/cargo/api_token.go
+++ b/plugins/cargo/api_token.go
@@ -19,7 +19,7 @@ func APIToken() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,
-				MarkdownDescription: "Token used to authenticate to Cargo.",
+				MarkdownDescription: "Token used to authenticate to crates.io.",
 				Secret:              true,
 			},
 		},
@@ -42,11 +42,19 @@ func TryCargoConfigFile() sdk.Importer {
 			return
 		}
 
-		for _, configRegistry := range config.Registries {
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token: config.Registry.Token,
+			},
+			NameHint: importer.SanitizeNameHint("crates.io"),
+		})
+
+		for regName, configRegistry := range config.Registries {
 			out.AddCandidate(sdk.ImportCandidate{
 				Fields: map[sdk.FieldName]string{
 					fieldname.Token: configRegistry.Token,
 				},
+				NameHint: importer.SanitizeNameHint(regName),
 			})
 
 		}
@@ -55,7 +63,8 @@ func TryCargoConfigFile() sdk.Importer {
 }
 
 type Config struct {
-	Registries []ConfigRegistry `toml:"registry"`
+	Registry   ConfigRegistry            `toml:"registry"`
+	Registries map[string]ConfigRegistry `toml:"registries"`
 }
 
 type ConfigRegistry struct {

--- a/plugins/cargo/api_token.go
+++ b/plugins/cargo/api_token.go
@@ -19,7 +19,7 @@ func APIToken() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,
-				MarkdownDescription: "Token used to authenticate to crates.io or another cargo registry.",
+				MarkdownDescription: "Token used to authenticate to crates.io.",
 				Secret:              true,
 			},
 		},

--- a/plugins/cargo/api_token_test.go
+++ b/plugins/cargo/api_token_test.go
@@ -1,0 +1,53 @@
+package cargo
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"CARGO_REGISTRY_TOKEN": "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"CARGO_REGISTRY_TOKEN": "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files: map[string]string{
+				"~/.cargo/credentials.toml": plugintest.LoadFixture(t, "credentials.toml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/cargo/api_token_test.go
+++ b/plugins/cargo/api_token_test.go
@@ -46,6 +46,19 @@ func TestAPITokenImporter(t *testing.T) {
 					Fields: map[sdk.FieldName]string{
 						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE",
 					},
+					NameHint: "crates.io",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE2",
+					},
+					NameHint: "reg1",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE3",
+					},
+					NameHint: "reg2",
 				},
 			},
 		},

--- a/plugins/cargo/api_token_test.go
+++ b/plugins/cargo/api_token_test.go
@@ -48,18 +48,6 @@ func TestAPITokenImporter(t *testing.T) {
 					},
 					NameHint: "crates.io",
 				},
-				{
-					Fields: map[sdk.FieldName]string{
-						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE2",
-					},
-					NameHint: "reg1",
-				},
-				{
-					Fields: map[sdk.FieldName]string{
-						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE3",
-					},
-					NameHint: "reg2",
-				},
 			},
 		},
 	})

--- a/plugins/cargo/api_token_test.go
+++ b/plugins/cargo/api_token_test.go
@@ -46,7 +46,6 @@ func TestAPITokenImporter(t *testing.T) {
 					Fields: map[sdk.FieldName]string{
 						fieldname.Token: "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE",
 					},
-					NameHint: "crates.io",
 				},
 			},
 		},

--- a/plugins/cargo/cargo.go
+++ b/plugins/cargo/cargo.go
@@ -7,12 +7,18 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
 
+var commands = [][]string{
+	{"publish"},
+	{"yank"},
+	{"owner"},
+}
+
 func CargoCLI() schema.Executable {
 	return schema.Executable{
 		Name:      "Cargo CLI",
 		Runs:      []string{"cargo"},
 		DocsURL:   sdk.URL("https://doc.rust-lang.org/cargo/index.html"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		NeedsAuth: needsauth.ForCommands(commands...),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIToken,

--- a/plugins/cargo/cargo.go
+++ b/plugins/cargo/cargo.go
@@ -1,0 +1,22 @@
+package cargo
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func CargoCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Cargo CLI",
+		Runs:      []string{"cargo"},
+		DocsURL:   sdk.URL("https://doc.rust-lang.org/cargo/index.html"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIToken,
+			},
+		},
+	}
+}

--- a/plugins/cargo/plugin.go
+++ b/plugins/cargo/plugin.go
@@ -1,0 +1,22 @@
+package cargo
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "cargo",
+		Platform: schema.PlatformInfo{
+			Name:     "Cargo",
+			Homepage: sdk.URL("https://crates.io"),
+		},
+		Credentials: []schema.CredentialType{
+			APIToken(),
+		},
+		Executables: []schema.Executable{
+			CargoCLI(),
+		},
+	}
+}

--- a/plugins/cargo/test-fixtures/credentials.toml
+++ b/plugins/cargo/test-fixtures/credentials.toml
@@ -1,0 +1,2 @@
+[registry]
+token = "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE"

--- a/plugins/cargo/test-fixtures/credentials.toml
+++ b/plugins/cargo/test-fixtures/credentials.toml
@@ -1,2 +1,8 @@
 [registry]
 token = "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE"
+
+[registries.reg1]
+token = "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE2"
+
+[registries.reg2]
+token = "9xAQsMIO2UubpsgD2eUOKqXEXAMPLE3"


### PR DESCRIPTION
Currently don't have the test passing for importing credentials from a file, working on that now.

If I change [registry] to [[registry]] it passes, but that's not how the file is created by cargo. 

Resolves #81