### PR TITLE
Add support for flyctl

### DIFF
--- a/plugins/flyctl/access_token.go
+++ b/plugins/flyctl/access_token.go
@@ -1,0 +1,68 @@
+package flyctl
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://fly.io/docs/flyctl/auth-login/"),
+		ManagementURL: sdk.URL("https://fly.io/user/personal_access_tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Fly.io.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 43,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryFlyctlConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"FLY_ACCESS_TOKEN": fieldname.Token,
+}
+
+func TryFlyctlConfigFile() sdk.Importer {
+	return importer.TryFile("~/.fly/config.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToYAML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.Token == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token: config.Token,
+			},
+		})
+	})
+}
+
+type Config struct {
+	Token string `yaml:"access_token"`
+}

--- a/plugins/flyctl/access_token_test.go
+++ b/plugins/flyctl/access_token_test.go
@@ -1,0 +1,53 @@
+package flyctl
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "DtP7HoOPOBHMP6bE5tx3nguB5r2zPpSbg9hlEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"FLY_ACCESS_TOKEN": "DtP7HoOPOBHMP6bE5tx3nguB5r2zPpSbg9hlEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"FLY_ACCESS_TOKEN": "DtP7HoOPOBHMP6bE5tx3nguB5r2zPpSbg9hlEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "DtP7HoOPOBHMP6bE5tx3nguB5r2zPpSbg9hlEXAMPLE",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files: map[string]string{
+				"~/.fly/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "DtP7HoOPOBHMP6bE5tx3nguB5r2zPpSbg9hlEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/flyctl/fly.go
+++ b/plugins/flyctl/fly.go
@@ -1,0 +1,22 @@
+package flyctl
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func FlyctlCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Flyctl",
+		Runs:      []string{"fly"},
+		DocsURL:   sdk.URL("https://fly.io/docs/flyctl/"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/plugins/flyctl/plugin.go
+++ b/plugins/flyctl/plugin.go
@@ -1,0 +1,22 @@
+package flyctl
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "flyctl",
+		Platform: schema.PlatformInfo{
+			Name:     "Fly.io",
+			Homepage: sdk.URL("https://fly.io/docs/flyctl/"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			FlyctlCLI(),
+		},
+	}
+}

--- a/plugins/flyctl/test-fixtures/config.yml
+++ b/plugins/flyctl/test-fixtures/config.yml
@@ -1,0 +1,2 @@
+access_token: DtP7HoOPOBHMP6bE5tx3nguB5r2zPpSbg9hlEXAMPLE
+wire_guard_state: {}


### PR DESCRIPTION
## Description

Add support for flyctl. Fixes https://github.com/1Password/shell-plugins/issues/93.

## Roadblocks with naming

`Flyctl` is the [actual product name](https://fly.io/docs/flyctl/), while they offer both `fly` and `flyctl` as valid commands. From [this comment](https://community.fly.io/t/timeline-for-flyctl-fly-rename/4453/5), it seems that `fly` will remain the primary command while also retaining `flyctl` as an alias.

For this reason, I named this shell plugin `flyctl` while specifying `fly` as the executable command. Is this fine?

## Other questions

It doesn't seem that running `op plugin init fly` automatically sets up `alias fly="op plugin run -- fly"` on `~/.config/op/plugins.sh` like it happens for `gh` or `aws`. I had to manually add that alias and run `source ~/.config/op/plugins.sh`. Is this normal?

I had to also add `alias flyctl="op plugin run -- fly"` so that the shell plugin can take over when the user runs `flyctl` commands.