### PR TITLE
add support for Databricks

### DIFF
--- a/plugins/databricks/databricks.go
+++ b/plugins/databricks/databricks.go
@@ -1,0 +1,22 @@
+package databricks
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func DatabricksCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Databricks CLI",
+		Runs:      []string{"databricks"},
+		DocsURL:   sdk.URL("https://docs.databricks.com/dev-tools/cli/"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/databricks/personal_access_token.go
+++ b/plugins/databricks/personal_access_token.go
@@ -15,9 +15,6 @@ func PersonalAccessToken() schema.CredentialType {
 	return schema.CredentialType{
 		Name:    credname.PersonalAccessToken,
 		DocsURL: sdk.URL("https://docs.databricks.com/dev-tools/auth.html"),
-		// The management URL is spesific to each deployment of Databricks, but this
-		// link describes how to manage tokens provided you are logged in.
-		ManagementURL: sdk.URL("https://docs.databricks.com/dev-tools/auth.html"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Host,

--- a/plugins/databricks/personal_access_token.go
+++ b/plugins/databricks/personal_access_token.go
@@ -1,0 +1,118 @@
+package databricks
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.PersonalAccessToken,
+		DocsURL: sdk.URL("https://docs.databricks.com/dev-tools/auth.html"),
+		// The management URL is spesific to each deployment of Databricks, but this
+		// link describes how to manage tokens provided you are logged in.
+		ManagementURL: sdk.URL("https://docs.databricks.com/dev-tools/auth.html"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "The host URL of your Databricks instance. Should start with https://",
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Uppercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+					Prefix: "https://",
+				},
+			},
+			{
+				Name:                fieldname.Username,
+				MarkdownDescription: "The username of the user to authenticate as. This is only required if you are using username/password authentication.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "The password of the user to authenticate as. This is only required if you are using username/password authentication.",
+				Optional:            true,
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Personal access token used to authenticate to Databricks.",
+				Secret:              true,
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Length: 38,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+						Specific:  []rune{'-'},
+					},
+					Prefix: "dapi",
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryDatabricksConfigFile(),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"DATABRICKS_HOST":     fieldname.Host,
+	"DATABRICKS_TOKEN":    fieldname.Token,
+	"DATABRICKS_USERNAME": fieldname.Username,
+	"DATABRICKS_PASSWORD": fieldname.Password,
+}
+
+func TryDatabricksConfigFile() sdk.Importer {
+	return importer.TryFile("~/.databrickscfg", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		credentialsFile, err := contents.ToINI()
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for _, section := range credentialsFile.Sections() {
+			profileName := section.Name()
+			fields := make(map[sdk.FieldName]string)
+
+			if section.HasKey("host") && section.Key("host").Value() != "" {
+				fields[fieldname.Host] = section.Key("host").Value()
+			}
+			if section.HasKey("username") && section.Key("username").Value() != "" {
+				fields[fieldname.Username] = section.Key("username").Value()
+			}
+			if section.HasKey("password") && section.Key("password").Value() != "" {
+				fields[fieldname.Password] = section.Key("password").Value()
+			}
+			if section.HasKey("token") && section.Key("token").Value() != "" {
+				fields[fieldname.Token] = section.Key("token").Value()
+			}
+
+			// add only candidates with required credential fields
+			if fields[fieldname.Host] != "" && (fields[fieldname.Token] != "" || (fields[fieldname.Username] != "" && fields[fieldname.Password] != "")) {
+				out.AddCandidate(sdk.ImportCandidate{
+					Fields:   fields,
+					NameHint: importer.SanitizeNameHint(profileName),
+				})
+			}
+		}
+	})
+}
+
+type Config struct {
+	Host     string
+	Username string
+	Password string
+	Token    string
+}

--- a/plugins/databricks/personal_access_token.go
+++ b/plugins/databricks/personal_access_token.go
@@ -30,21 +30,9 @@ func PersonalAccessToken() schema.CredentialType {
 				},
 			},
 			{
-				Name:                fieldname.Username,
-				MarkdownDescription: "The username of the user to authenticate as. This is only required if you are using username/password authentication.",
-				Optional:            true,
-			},
-			{
-				Name:                fieldname.Password,
-				MarkdownDescription: "The password of the user to authenticate as. This is only required if you are using username/password authentication.",
-				Optional:            true,
-				Secret:              true,
-			},
-			{
 				Name:                fieldname.Token,
 				MarkdownDescription: "Personal access token used to authenticate to Databricks.",
 				Secret:              true,
-				Optional:            true,
 				Composition: &schema.ValueComposition{
 					Length: 38,
 					Charset: schema.Charset{
@@ -65,10 +53,8 @@ func PersonalAccessToken() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"DATABRICKS_HOST":     fieldname.Host,
-	"DATABRICKS_TOKEN":    fieldname.Token,
-	"DATABRICKS_USERNAME": fieldname.Username,
-	"DATABRICKS_PASSWORD": fieldname.Password,
+	"DATABRICKS_HOST":  fieldname.Host,
+	"DATABRICKS_TOKEN": fieldname.Token,
 }
 
 func TryDatabricksConfigFile() sdk.Importer {
@@ -86,18 +72,12 @@ func TryDatabricksConfigFile() sdk.Importer {
 			if section.HasKey("host") && section.Key("host").Value() != "" {
 				fields[fieldname.Host] = section.Key("host").Value()
 			}
-			if section.HasKey("username") && section.Key("username").Value() != "" {
-				fields[fieldname.Username] = section.Key("username").Value()
-			}
-			if section.HasKey("password") && section.Key("password").Value() != "" {
-				fields[fieldname.Password] = section.Key("password").Value()
-			}
 			if section.HasKey("token") && section.Key("token").Value() != "" {
 				fields[fieldname.Token] = section.Key("token").Value()
 			}
 
 			// add only candidates with required credential fields
-			if fields[fieldname.Host] != "" && (fields[fieldname.Token] != "" || (fields[fieldname.Username] != "" && fields[fieldname.Password] != "")) {
+			if fields[fieldname.Host] != "" && fields[fieldname.Token] != "" {
 				out.AddCandidate(sdk.ImportCandidate{
 					Fields:   fields,
 					NameHint: importer.SanitizeNameHint(profileName),
@@ -108,8 +88,6 @@ func TryDatabricksConfigFile() sdk.Importer {
 }
 
 type Config struct {
-	Host     string
-	Username string
-	Password string
-	Token    string
+	Host  string
+	Token string
 }

--- a/plugins/databricks/personal_access_token_test.go
+++ b/plugins/databricks/personal_access_token_test.go
@@ -1,0 +1,72 @@
+package databricks
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const example_token = "dapif13ac4b49d1cb31f69f678e39602e381-2"
+
+func TestDatabricksPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Host:  "https://myinstance.databricks.com",
+				fieldname.Token: example_token,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"DATABRICKS_HOST":  "https://myinstance.databricks.com",
+					"DATABRICKS_TOKEN": example_token,
+				},
+			},
+		},
+	})
+}
+
+func TestDatabricksPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"DATABRICKS_HOST":  "https://myinstance.databricks.com",
+				"DATABRICKS_TOKEN": example_token,
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:  "https://myinstance.databricks.com",
+						fieldname.Token: example_token,
+					},
+				},
+			},
+		},
+	})
+
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.databrickscfg": plugintest.LoadFixture(t, "databrickscfg"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					NameHint: "DEFAULT",
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:     "https://myinstance.azuredatabricks.net/",
+						fieldname.Username: "bob@company.com",
+						fieldname.Password: "password123",
+					},
+				},
+				{
+					NameHint: "secondprofile",
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:  "https://myinstance.databricks.com/",
+						fieldname.Token: example_token,
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/databricks/personal_access_token_test.go
+++ b/plugins/databricks/personal_access_token_test.go
@@ -8,18 +8,19 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
 
+const example_host = "https://myinstance.databricks.com"
 const example_token = "dapif13ac4b49d1cb31f69f678e39602e381-2"
 
 func TestDatabricksPersonalAccessTokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.Host:  "https://myinstance.databricks.com",
+				fieldname.Host:  example_host,
 				fieldname.Token: example_token,
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"DATABRICKS_HOST":  "https://myinstance.databricks.com",
+					"DATABRICKS_HOST":  example_host,
 					"DATABRICKS_TOKEN": example_token,
 				},
 			},
@@ -31,13 +32,13 @@ func TestDatabricksPersonalAccessTokenImporter(t *testing.T) {
 	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
 		"environment": {
 			Environment: map[string]string{
-				"DATABRICKS_HOST":  "https://myinstance.databricks.com",
+				"DATABRICKS_HOST":  example_host,
 				"DATABRICKS_TOKEN": example_token,
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Host:  "https://myinstance.databricks.com",
+						fieldname.Host:  example_host,
 						fieldname.Token: example_token,
 					},
 				},
@@ -52,17 +53,16 @@ func TestDatabricksPersonalAccessTokenImporter(t *testing.T) {
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
-					NameHint: "DEFAULT",
+					NameHint: "secondprofile",
 					Fields: map[sdk.FieldName]string{
-						fieldname.Host:     "https://myinstance.azuredatabricks.net/",
-						fieldname.Username: "bob@company.com",
-						fieldname.Password: "password123",
+						fieldname.Host:  example_host,
+						fieldname.Token: example_token,
 					},
 				},
 				{
-					NameHint: "secondprofile",
+					NameHint: "thirdprofile",
 					Fields: map[sdk.FieldName]string{
-						fieldname.Host:  "https://myinstance.databricks.com/",
+						fieldname.Host:  example_host,
 						fieldname.Token: example_token,
 					},
 				},

--- a/plugins/databricks/plugin.go
+++ b/plugins/databricks/plugin.go
@@ -1,0 +1,22 @@
+package databricks
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "databricks",
+		Platform: schema.PlatformInfo{
+			Name:     "Databricks",
+			Homepage: sdk.URL("https://databricks.com"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			DatabricksCLI(),
+		},
+	}
+}

--- a/plugins/databricks/test-fixtures/databrickscfg
+++ b/plugins/databricks/test-fixtures/databrickscfg
@@ -1,0 +1,10 @@
+[DEFAULT]
+host = https://myinstance.azuredatabricks.net/
+username = bob@company.com
+password = password123
+jobs-api-version = 2.1
+
+[secondprofile]
+host = https://myinstance.databricks.com/
+token = dapif13ac4b49d1cb31f69f678e39602e381-2
+jobs-api-version = 2.0

--- a/plugins/databricks/test-fixtures/databrickscfg
+++ b/plugins/databricks/test-fixtures/databrickscfg
@@ -1,10 +1,17 @@
 [DEFAULT]
-host = https://myinstance.azuredatabricks.net/
+host = https://myinstance.azuredatabricks.net
 username = bob@company.com
 password = password123
 jobs-api-version = 2.1
 
 [secondprofile]
-host = https://myinstance.databricks.com/
+host = https://myinstance.databricks.com
 token = dapif13ac4b49d1cb31f69f678e39602e381-2
 jobs-api-version = 2.0
+
+[thirdprofile]
+host = https://myinstance.databricks.com
+username = bob@company.com
+token = dapif13ac4b49d1cb31f69f678e39602e381-2
+jobs-api-version = 2.1
+


### PR DESCRIPTION
This adds support for the [Databricks CLI](https://docs.databricks.com/dev-tools/cli/index.html). 

This CLI needs to know a "host" URL to the instance of Databricks you're working with, as well as your credentials that are specific to that instance. Personal access tokens are they primary way to authenticate, while username+password is possible but discouraged.

I've tested this on my own config, and both import and usage seems to work just fine 💯  Please let me know if you'd like to see more test cases or anything else before accepting. 

![import](https://user-images.githubusercontent.com/8997458/212314617-8e9611bb-f0f9-46c7-a1d5-4399512817f6.jpg)

A couple notes: 
- I've opted for the "Person Access Token" credentials type, despite username+password being an option. The code here handles both cases, but the label of "Personal Access Token" isn't quite right in both cases. I still think it should be as I've proposed here to encourage the recommended flow, but an alternative would be to use a more generic "Configuration" label. A second opinion here would be nice 🙂 
- When doing `op plugin list`, this plugin shows up with `REQUIRED FIELDS: host`. This is because while you do need to provide _either_ a token _or_ a username and password, neither of them can be marked as required on their own. Probably not a big deal, but resolving it can't really be done without making some changes to `schema.CredentialField` and related code.
- The config files at the moment typically also includes a `jobs-api-version = 2.x` line. This is ignored by the plugin with the following reasoning:
  1. Unlike the other config options, the CLI does not accept setting the API version with an environment variable. In order to support this the plugin would have to make use of the file-based provisioning variant, as well as add a highly specific field definition to the SDK. While possible, I don't believe it is justified given the next two points.
  2. The version _can_ be set with a command line flag, and _is only relevant for the `databricks jobs` subcommand_.
  3. Perhaps most importantly, **this version flag is temporary**, and future versions of the CLI will default to the newer API version. 
