### PR TITLE
Add ArgoCD support

### DIFF
--- a/plugins/argocd/argocd.go
+++ b/plugins/argocd/argocd.go
@@ -1,0 +1,22 @@
+package argocd
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ArgocdCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Argo CD CLI",
+		Runs:      []string{"argocd"},
+		DocsURL:   sdk.URL("https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd/"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AuthToken,
+			},
+		},
+	}
+}

--- a/plugins/argocd/auth_token.go
+++ b/plugins/argocd/auth_token.go
@@ -1,0 +1,102 @@
+package argocd
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AuthToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AuthToken,
+		DocsURL:       sdk.URL("https://argo-cd.readthedocs.io/en/stable/user-guide/environment-variables/"),
+		ManagementURL: nil,
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.AuthToken,
+				MarkdownDescription: "Auth Token used to authenticate to Argo CD.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Specific:  []rune{'.', '-', '_'},
+					},
+				},
+			},
+			{
+				Name:                fieldname.Address,
+				MarkdownDescription: "Address of the ArgoCD server without https:// prefix.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(envVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(envVarMapping),
+			TryArgocdConfigFile(),
+		)}
+}
+
+var envVarMapping = map[string]sdk.FieldName{
+	"ARGOCD_AUTH_TOKEN": fieldname.AuthToken,
+	"ARGOCD_SERVER":     fieldname.Address,
+}
+
+func TryArgocdConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/argocd/config", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToYAML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for _, context := range config.Contexts {
+			fields := make(map[sdk.FieldName]string)
+			nameHint := context.Name
+
+			for _, server := range config.Servers {
+				if server.ServerAddress == context.Server && server.ServerAddress != "" {
+					fields[fieldname.Address] = server.ServerAddress
+				}
+			}
+
+			for _, user := range config.Users {
+				if user.Name == context.User && user.AuthenticationToken != "" {
+					fields[fieldname.AuthToken] = user.AuthenticationToken
+				}
+			}
+
+			out.AddCandidate(sdk.ImportCandidate{
+				Fields:   fields,
+				NameHint: importer.SanitizeNameHint(nameHint),
+			})
+		}
+	})
+}
+
+type Config struct {
+	Contexts []Context
+	Servers  []Server
+	Users    []User
+}
+
+type Context struct {
+	Name   string `yaml:"name"`
+	Server string `yaml:"server"`
+	User   string `yaml:"user"`
+}
+
+type Server struct {
+	ServerAddress string `yaml:"server"`
+}
+
+type User struct {
+	Name                string `yaml:"name"`
+	AuthenticationToken string `yaml:"auth-token"`
+}

--- a/plugins/argocd/auth_token.go
+++ b/plugins/argocd/auth_token.go
@@ -61,14 +61,14 @@ func TryArgocdConfigFile() sdk.Importer {
 			nameHint := context.Name
 
 			for _, server := range config.Servers {
-				if server.ServerAddress == context.Server && server.ServerAddress != "" {
-					fields[fieldname.Address] = server.ServerAddress
+				if server.Server == context.Server && server.Server != "" {
+					fields[fieldname.Address] = server.Server
 				}
 			}
 
 			for _, user := range config.Users {
-				if user.Name == context.User && user.AuthenticationToken != "" {
-					fields[fieldname.AuthToken] = user.AuthenticationToken
+				if user.Name == context.User && user.AuthToken != "" {
+					fields[fieldname.AuthToken] = user.AuthToken
 				}
 			}
 
@@ -93,10 +93,10 @@ type Context struct {
 }
 
 type Server struct {
-	ServerAddress string `yaml:"server"`
+	Server string `yaml:"server"`
 }
 
 type User struct {
-	Name                string `yaml:"name"`
-	AuthenticationToken string `yaml:"auth-token"`
+	Name      string `yaml:"name"`
+	AuthToken string `yaml:"auth-token"`
 }

--- a/plugins/argocd/auth_token_test.go
+++ b/plugins/argocd/auth_token_test.go
@@ -1,0 +1,55 @@
+package argocd
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAuthTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AuthToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.AuthToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhcmdvY2QiLCJzdWIiOiJhZG1pbjphcGlLZXkiLCJuYmYiOjE2NzM3MjE0MDMsImlhdCI6MTY3MzcyMTQwMywianRpIjoiNTI5ODcwMTEtNGRiNy00ZmIxLWE4Y2MtMTk5NGViYTRjZDU0In0.ApWbS8sQbtp1l_ILaRO94izPv9AML2vnv1F3EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"ARGOCD_AUTH_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhcmdvY2QiLCJzdWIiOiJhZG1pbjphcGlLZXkiLCJuYmYiOjE2NzM3MjE0MDMsImlhdCI6MTY3MzcyMTQwMywianRpIjoiNTI5ODcwMTEtNGRiNy00ZmIxLWE4Y2MtMTk5NGViYTRjZDU0In0.ApWbS8sQbtp1l_ILaRO94izPv9AML2vnv1F3EXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAuthTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AuthToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"ARGOCD_AUTH_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhcmdvY2QiLCJzdWIiOiJhZG1pbjphcGlLZXkiLCJuYmYiOjE2NzM3MjE0MDMsImlhdCI6MTY3MzcyMTQwMywianRpIjoiNTI5ODcwMTEtNGRiNy00ZmIxLWE4Y2MtMTk5NGViYTRjZDU0In0.ApWbS8sQbtp1l_ILaRO94izPv9AML2vnv1F3EXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.AuthToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhcmdvY2QiLCJzdWIiOiJhZG1pbjphcGlLZXkiLCJuYmYiOjE2NzM3MjE0MDMsImlhdCI6MTY3MzcyMTQwMywianRpIjoiNTI5ODcwMTEtNGRiNy00ZmIxLWE4Y2MtMTk5NGViYTRjZDU0In0.ApWbS8sQbtp1l_ILaRO94izPv9AML2vnv1F3EXAMPLE",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files: map[string]string{
+				"~/.config/argocd/config": plugintest.LoadFixture(t, "config"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					NameHint: "test-context",
+					Fields: map[sdk.FieldName]string{
+						fieldname.AuthToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhcmdvY2QiLCJzdWIiOiJhZG1pbjphcGlLZXkiLCJuYmYiOjE2NzM3MjE0MDMsImlhdCI6MTY3MzcyMTQwMywianRpIjoiNTI5ODcwMTEtNGRiNy00ZmIxLWE4Y2MtMTk5NGViYTRjZDU0In0.ApWbS8sQbtp1l_ILaRO94izPv9AML2vnv1F3EXAMPLE",
+						fieldname.Address:   "argocd.test.domain",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/argocd/plugin.go
+++ b/plugins/argocd/plugin.go
@@ -1,0 +1,22 @@
+package argocd
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "argocd",
+		Platform: schema.PlatformInfo{
+			Name:     "Argo CD",
+			Homepage: sdk.URL("https://argo-cd.readthedocs.io/en/stable/"),
+		},
+		Credentials: []schema.CredentialType{
+			AuthToken(),
+		},
+		Executables: []schema.Executable{
+			ArgocdCLI(),
+		},
+	}
+}

--- a/plugins/argocd/test-fixtures/config
+++ b/plugins/argocd/test-fixtures/config
@@ -1,0 +1,10 @@
+contexts:
+- name: test-context
+  server: argocd.test.domain
+  user: test-user
+current-context: test-context
+servers:
+- server: argocd.test.domain
+users:
+- name: test-user
+  auth-token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhcmdvY2QiLCJzdWIiOiJhZG1pbjphcGlLZXkiLCJuYmYiOjE2NzM3MjE0MDMsImlhdCI6MTY3MzcyMTQwMywianRpIjoiNTI5ODcwMTEtNGRiNy00ZmIxLWE4Y2MtMTk5NGViYTRjZDU0In0.ApWbS8sQbtp1l_ILaRO94izPv9AML2vnv1F3EXAMPLE


### PR DESCRIPTION
This PR Adds support for Argo CD CLI and enables authentication using [environment variable](https://argo-cd.readthedocs.io/en/stable/user-guide/environment-variables/).