### PR TITLE
Add support for Sourcegraph

### DIFF
--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -28,7 +28,7 @@ func AccessToken() schema.CredentialType {
 				Optional: true,
 			},
 			{
-				Name:                fieldname.HostAddress,
+				Name:                fieldname.Endpoint,
 				MarkdownDescription: "Base URL for your Sourcegraph instance.",
 				Secret:              false,
 				Composition: &schema.ValueComposition{
@@ -59,6 +59,6 @@ func AccessToken() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"SRC_ENDPOINT":     fieldname.HostAddress,
+	"SRC_ENDPOINT":     fieldname.Endpoint,
 	"SRC_ACCESS_TOKEN": fieldname.Token,
 }

--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -16,13 +16,13 @@ func AccessToken() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Username,
-				MarkdownDescription: "Your Sourcegraph username.",
+				MarkdownDescription: "Username on your Sourcegraph instance.",
 				Secret:              false,
 				Composition: &schema.ValueComposition{
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
-						Symbols:   true,
+						Specific:  []rune{'.', '-', '_'},
 					},
 				},
 				Optional: true,

--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -1,0 +1,64 @@
+package sourcegraph
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.AccessToken,
+		DocsURL: sdk.URL("https://docs.sourcegraph.com/cli"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Username,
+				MarkdownDescription: "Your Sourcegraph username.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+				Optional: true,
+			},
+			{
+				Name:                fieldname.HostAddress,
+				MarkdownDescription: "Base URL for your Sourcegraph instance.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Sourcegraph.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 40,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SRC_ENDPOINT":     fieldname.HostAddress,
+	"SRC_ACCESS_TOKEN": fieldname.Token,
+}

--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -25,7 +25,6 @@ func AccessToken() schema.CredentialType {
 						Specific:  []rune{'.', '-', '_'},
 					},
 				},
-				Optional: true,
 			},
 			{
 				Name:                fieldname.Endpoint,

--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -15,18 +15,6 @@ func AccessToken() schema.CredentialType {
 		DocsURL: sdk.URL("https://docs.sourcegraph.com/cli"),
 		Fields: []schema.CredentialField{
 			{
-				Name:                fieldname.Username,
-				MarkdownDescription: "Username on your Sourcegraph instance.",
-				Secret:              false,
-				Composition: &schema.ValueComposition{
-					Charset: schema.Charset{
-						Lowercase: true,
-						Digits:    true,
-						Specific:  []rune{'.', '-', '_'},
-					},
-				},
-			},
-			{
 				Name:                fieldname.Endpoint,
 				MarkdownDescription: "Base URL for your Sourcegraph instance.",
 				Secret:              false,

--- a/plugins/sourcegraph/access_token_test.go
+++ b/plugins/sourcegraph/access_token_test.go
@@ -12,8 +12,8 @@ func TestAccessTokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.HostAddress: "https://sourcegraph.com",
-				fieldname.Token:       "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+				fieldname.Endpoint: "https://sourcegraph.com",
+				fieldname.Token:    "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{

--- a/plugins/sourcegraph/access_token_test.go
+++ b/plugins/sourcegraph/access_token_test.go
@@ -24,3 +24,22 @@ func TestAccessTokenProvisioner(t *testing.T) {
 		},
 	})
 }
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"SRC_ENDPOINT":     "https://sourcegraph.com",
+				"SRC_ACCESS_TOKEN": "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Endpoint: "https://sourcegraph.com",
+						fieldname.Token:    "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/sourcegraph/access_token_test.go
+++ b/plugins/sourcegraph/access_token_test.go
@@ -1,0 +1,26 @@
+package sourcegraph
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.HostAddress: "https://sourcegraph.com",
+				fieldname.Token:       "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SRC_ENDPOINT":     "https://sourcegraph.com",
+					"SRC_ACCESS_TOKEN": "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+				},
+			},
+		},
+	})
+}

--- a/plugins/sourcegraph/plugin.go
+++ b/plugins/sourcegraph/plugin.go
@@ -1,0 +1,22 @@
+package sourcegraph
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "sourcegraph",
+		Platform: schema.PlatformInfo{
+			Name:     "Sourcegraph",
+			Homepage: sdk.URL("https://sourcegraph.com"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			SourcegraphCLI(),
+		},
+	}
+}

--- a/plugins/sourcegraph/src.go
+++ b/plugins/sourcegraph/src.go
@@ -9,10 +9,13 @@ import (
 
 func SourcegraphCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Sourcegraph CLI",
-		Runs:      []string{"src"},
-		DocsURL:   sdk.URL("https://docs.sourcegraph.com/cli"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "Sourcegraph CLI",
+		Runs:    []string{"src"},
+		DocsURL: sdk.URL("https://docs.sourcegraph.com/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.AccessToken,

--- a/plugins/sourcegraph/src.go
+++ b/plugins/sourcegraph/src.go
@@ -1,0 +1,22 @@
+package sourcegraph
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func SourcegraphCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Sourcegraph CLI",
+		Runs:      []string{"src"},
+		DocsURL:   sdk.URL("https://docs.sourcegraph.com/cli"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -23,6 +23,7 @@ const (
 	Credentials     = sdk.FieldName("Credentials")
 	Database        = sdk.FieldName("Database")
 	DefaultRegion   = sdk.FieldName("Default Region")
+	Endpoint        = sdk.FieldName("Endpoint")
 	Host            = sdk.FieldName("Host")
 	HostAddress     = sdk.FieldName("Host Address")
 	Key             = sdk.FieldName("Key")
@@ -66,6 +67,7 @@ func ListAll() []sdk.FieldName {
 		Credentials,
 		Database,
 		DefaultRegion,
+		Endpoint,
 		Host,
 		HostAddress,
 		Key,


### PR DESCRIPTION
This PR adds support for the Sourcegraph CLI. Fixes https://github.com/1Password/shell-plugins/issues/144.

Couple of notes:

- The CLI does not support config file imports. The CLI always expects the Sourcegraph instance host address and the access token to be set as environment variables.
- The `ManagementURL` isn't set for now because it's dynamic depending on the Sourcegraph instance host address **and** the username. In my case, it is https://sourcegraph.com/users/arun/settings/tokens. This case is similar to what happened with ReadMe, so based on [this advise](https://github.com/1Password/shell-plugins/pull/106#discussion_r1049357649) from @SimonBarendse, I haven't included `ManagementURL` field. When Shell Plugins support setting of dynamic `ManagementURL`s, we can update this plugin.

Here's a quick visualization of the plugin flow:

```
➜  shell-plugins git:(add/sourcegraph) src login

❌ Problem: No access token is configured.

🛠  To fix: Create an access token at https://sourcegraph.com/user/settings/tokens, then set the following environment variables:

   SRC_ENDPOINT=https://sourcegraph.com
   SRC_ACCESS_TOKEN=(the access token you just created)

   To verify that it's working, run this command again.

➜  shell-plugins git:(add/sourcegraph) op plugin init src
############################################################################
# WARNING: 'sourcegraph' is not from the official registry.                #
# Only proceed if you are the developer of 'sourcegraph'.                  #
# Otherwise, delete the file at /Users/arun/.op/plugins/local/sourcegraph. #
############################################################################

Sourcegraph CLI [test build]
Authenticate with Sourcegraph Access Token.

? Locate your Sourcegraph Access Token: Sourcegraph Access Token (Personal)

? Configure when "Sourcegraph Access Token" will be used to authenticate: Prompt me for each new terminal session

The last step is to set up an alias for src.
You can do so by running the following command:

  source /Users/arun/.op/plugins.sh

Afterwards, run any src command to see it in action!
➜  shell-plugins git:(add/sourcegraph) source ~/.op/plugins.sh
➜  shell-plugins git:(add/sourcegraph) src login
############################################################################
# WARNING: 'sourcegraph' is not from the official registry.                #
# Only proceed if you are the developer of 'sourcegraph'.                  #
# Otherwise, delete the file at /Users/arun/.op/plugins/local/sourcegraph. #
############################################################################

✔️  Authenticated as arun on https://sourcegraph.com
```

Happy to address any feedback, thanks!