### PR TITLE
Create RPC function response structs which are wrapping sdk outputs

### DIFF
--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -76,11 +76,21 @@ type ImportCredentialRequest struct {
 	sdk.ImportOutput
 }
 
+type ImportCredentialResponse struct {
+	*sdk.ImportOutput
+	Panic *Panic
+}
+
 // ProvisionCredentialRequest augments sdk.ProvisionInput with a CredentialID so Provision() can be called over RPC.
 type ProvisionCredentialRequest struct {
 	ProvisionerID
 	sdk.ProvisionInput
 	sdk.ProvisionOutput
+}
+
+type ProvisionCredentialResponse struct {
+	*sdk.ProvisionOutput
+	Panic *Panic
 }
 
 // DeprovisionCredentialRequest augments sdk.DeprovisionInput with a CredentialID so Deprovision() can be called over RPC.
@@ -90,9 +100,19 @@ type DeprovisionCredentialRequest struct {
 	sdk.DeprovisionOutput
 }
 
+type DeprovisionCredentialResponse struct {
+	*sdk.DeprovisionOutput
+	Panic *Panic
+}
+
 // ExecutableNeedsAuthRequest augments sdk.NeedsAuthenticationInput with the ID of an executable so NeedsAuth() can be
 // called over RPC. ExecutableID resembles the slice index of the executable in schema.Plugin.
 type ExecutableNeedsAuthRequest struct {
 	ExecutableID
 	sdk.NeedsAuthenticationInput
+}
+
+type Panic struct {
+	Error string
+	Stack []byte
 }

--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -113,6 +113,6 @@ type ExecutableNeedsAuthRequest struct {
 }
 
 type Panic struct {
-	Error string
-	Stack []byte
+	RecoveredString string
+	Stack           []byte
 }

--- a/sdk/rpc/proto/protocol.go
+++ b/sdk/rpc/proto/protocol.go
@@ -77,7 +77,7 @@ type ImportCredentialRequest struct {
 }
 
 type ImportCredentialResponse struct {
-	*sdk.ImportOutput
+	sdk.ImportOutput
 	Panic *Panic
 }
 
@@ -89,7 +89,7 @@ type ProvisionCredentialRequest struct {
 }
 
 type ProvisionCredentialResponse struct {
-	*sdk.ProvisionOutput
+	sdk.ProvisionOutput
 	Panic *Panic
 }
 
@@ -101,7 +101,7 @@ type DeprovisionCredentialRequest struct {
 }
 
 type DeprovisionCredentialResponse struct {
-	*sdk.DeprovisionOutput
+	sdk.DeprovisionOutput
 	Panic *Panic
 }
 

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -3,10 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/rpc/proto"
 	"github.com/1Password/shell-plugins/sdk/schema"
-	"runtime/debug"
 )
 
 type errFunctionFieldNotSet struct {

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -196,7 +196,7 @@ func (t *RPCServer) getProvisioner(provisionerID proto.ProvisionerID) (sdk.Provi
 
 func getPanicDiagnostics(err any) *proto.Panic {
 	return &proto.Panic{
-		Error: fmt.Sprintf("your locally built plugin failed with the following panic: %s", err),
-		Stack: debug.Stack(),
+		RecoveredString: fmt.Sprintf("%s", err),
+		Stack:           debug.Stack(),
 	}
 }


### PR DESCRIPTION
RPC call responses are wrapping Provision, Deprovision and Import outputs, and are adding a Panic field meant to be set when panics arise in the RPC level. 


This is a better solution than https://github.com/1Password/shell-plugins/pull/121. It also requires protocol update to v4 hence it will get merged in `protocol-v4` to get shipped with more future similar changes.

This increases flexibility of handling these types of characteristic panics in the CLI.


See this dicussion for further details: https://github.com/1Password/shell-plugins/pull/121/files#r1055291768