### PR TITLE
Add plugin for OpenAI CLI

### DIFF
--- a/plugins/openai/api_key.go
+++ b/plugins/openai/api_key.go
@@ -1,0 +1,39 @@
+package openai
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://beta.openai.com/docs"),
+		ManagementURL: sdk.URL("https://beta.openai.com/account/api-keys"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to OpenAI.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 51,
+					Prefix: "sk-",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"OPENAI_API_KEY": fieldname.APIKey,
+}

--- a/plugins/openai/api_key_test.go
+++ b/plugins/openai/api_key_test.go
@@ -1,0 +1,41 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "sk-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"OPENAI_API_KEY": "sk-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"OPENAI_API_KEY": "sk-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "sk-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/openai/openai.go
+++ b/plugins/openai/openai.go
@@ -1,0 +1,22 @@
+package openai
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func OpenAICLI() schema.Executable {
+	return schema.Executable{
+		Name:      "OpenAI CLI",
+		Runs:      []string{"openai"},
+		DocsURL:   sdk.URL("https://pypi.org/project/openai/"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/openai/plugin.go
+++ b/plugins/openai/plugin.go
@@ -1,0 +1,22 @@
+package openai
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "openai",
+		Platform: schema.PlatformInfo{
+			Name:     "OpenAI",
+			Homepage: sdk.URL("https://openai.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			OpenAICLI(),
+		},
+	}
+}


### PR DESCRIPTION
This PR adds a new plugin for the CLI in [OpenAI](https://openai.com/)'s Python [libary](https://pypi.org/project/openai/).

This CLI uses a single API Key environment variable, so the plugin simply provisions that.

## Testing steps

- [Install the OpenAI CLI](https://pypi.org/project/openai/)
- [Create an OpenAI account](https://beta.openai.com/signup)
- From your account, [create a new API Key](https://beta.openai.com/account/api-keys)
  - Either create a new vault item with this key, or manually create one during plugin init
- Checkout this branch: `git pull && git checkout jh/add-openai`
- Build the plugin `make openai/build`
- Init the plugin: `op plugin init openai`, source plugins
  - If you haven't created a vault item, this is where you'll manually create one with you API Key
- Run a command, for example: `openai api completions.create -e ada -p "Hello world"`

The command should successfully execute. Using the above example, the result would be:

<img width="606" alt="CleanShot 2023-01-17 at 19 31 32@2x" src="https://user-images.githubusercontent.com/6392049/213077098-1fc830d1-7980-4a8c-b554-a0fcdeafa290.png">

## Example secrets:

```
API Key:
  API Key: sk-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE
```