### PR TITLE
Don't auth for `--key` arg in ReadMe plugin

### DIFF
--- a/plugins/readme/rdme.go
+++ b/plugins/readme/rdme.go
@@ -15,6 +15,8 @@ func ReadMeCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 
+			needsauth.NotWhenContainsArgs("--key"),
+
 			needsauth.IfAny(
 				needsauth.ForCommand("openapi"),
 

--- a/plugins/readme/rdme_test.go
+++ b/plugins/readme/rdme_test.go
@@ -28,5 +28,9 @@ func TestRdmeNeedsAuth(t *testing.T) {
 			Args:              []string{"openapi", "--version", "2.0"},
 			ExpectedNeedsAuth: true,
 		},
+		"no for openapi with --key flag": {
+			Args:              []string{"openapi", "--key", "rdme_test"},
+			ExpectedNeedsAuth: false,
+		},
 	})
 }


### PR DESCRIPTION
Noticed an issue where 1Password prompts for authentication in the `rdme` CLI when the user passes in the `--key` argument, which shouldn't be happening. This PR fixes that!

This PR recreates the work I did in https://github.com/1Password/shell-plugins/pull/135.