### PR TITLE
Add plugin for nixpkgs-review

### DIFF
--- a/plugins/nprev/nixpkgs-review.go
+++ b/plugins/nprev/nixpkgs-review.go
@@ -1,0 +1,25 @@
+package nprev
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func NixPkgsCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "nixpkgs-review CLI",
+		Runs:    []string{"nixpkgs-review"},
+		DocsURL: sdk.URL("https://github.com/Mic92/nixpkgs-review"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/nprev/personal_access_token.go
+++ b/plugins/nprev/personal_access_token.go
@@ -1,0 +1,32 @@
+package nprev
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAccessToken,
+		DocsURL:       sdk.URL("https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"),
+		ManagementURL: sdk.URL("https://github.com/settings/tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "GitHub Token used to authenticate to NixPkgs.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"GITHUB_TOKEN": fieldname.Token,
+}

--- a/plugins/nprev/personal_access_token_test.go
+++ b/plugins/nprev/personal_access_token_test.go
@@ -1,0 +1,41 @@
+package nprev
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "xCvmSyzKwxMpEYPHzilWCZhEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GITHUB_TOKEN": "xCvmSyzKwxMpEYPHzilWCZhEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"GITHUB_TOKEN": "xCvmSyzKwxMpEYPHzilWCZhEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "xCvmSyzKwxMpEYPHzilWCZhEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/nprev/plugin.go
+++ b/plugins/nprev/plugin.go
@@ -1,0 +1,22 @@
+package nprev
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "nprev",
+		Platform: schema.PlatformInfo{
+			Name:     "NixPkgs",
+			Homepage: sdk.URL("https://github.com/Mic92/nixpkgs-review"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			NixPkgsCLI(),
+		},
+	}
+}


### PR DESCRIPTION
This adds basic support for [nixpkgs-review](https://github.com/Mic92/nixpkgs-review), a tool for testing [nixpkgs](https://github.com/nixos/nixpkgs) changes.

`nixpkgs-review` simply looks for the `GITHUB_TOKEN` environment variable, so we don't need to peak into any files.

Not sure if this falls into the "Unofficial CLIs are less likely to get accepted at this moment." category. The official nixpkgs documentation references `nixpkgs-review` [here](https://nixos.org/manual/nixpkgs/unstable/#submitting-changes-tested-compilation).