### PR TITLE
Add support for Fastly with envvar provisioning and config file imports

### DIFF
--- a/plugins/fastly/api_token.go
+++ b/plugins/fastly/api_token.go
@@ -1,0 +1,77 @@
+package fastly
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://docs.fastly.com/en/guides/using-api-tokens"),
+		ManagementURL: sdk.URL("https://manage.fastly.com/account/personal/tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "API Token used to authenticate to Fastly.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 32,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryAllEnvVars(fieldname.Token, "FASTLY_API_TOKEN"),
+			importer.MacOnly(
+				TryFastlyConfigFile("~/Library/Application Support/fastly/config.toml"),
+			),
+			importer.LinuxOnly(
+				TryFastlyConfigFile("~/.config/fastly/config.toml"),
+			),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"FASTLY_API_TOKEN": fieldname.Token,
+}
+
+func TryFastlyConfigFile(path string) sdk.Importer {
+	return importer.TryFile(path, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToTOML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for profileName, configProfile := range config.Profile {
+			out.AddCandidate(sdk.ImportCandidate{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: configProfile.Token,
+				},
+				NameHint: importer.SanitizeNameHint(profileName),
+			})
+		}
+	})
+}
+
+type ConfigProfile struct {
+	Email string `toml:"email"`
+	Token string `toml:"token"`
+}
+
+type Config struct {
+	Profile map[string]ConfigProfile
+}

--- a/plugins/fastly/api_token_test.go
+++ b/plugins/fastly/api_token_test.go
@@ -1,0 +1,93 @@
+package fastly
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "4Oncq0V723ZO8HIqUgOTB77dsEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"FASTLY_API_TOKEN": "4Oncq0V723ZO8HIqUgOTB77dsEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"FASTLY_API_TOKEN": "4Oncq0V723ZO8HIqUgOTB77dsEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "4Oncq0V723ZO8HIqUgOTB77dsEXAMPLE",
+					},
+				},
+			},
+		},
+		"config file on macOS": {
+			OS: "darwin",
+			Files: map[string]string{
+				"~/Library/Application Support/fastly/config.toml": plugintest.LoadFixture(t, "config.toml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "4Oncq0V723ZO8HIqUgOTB77dsEXAMPLE",
+					},
+					NameHint: "first",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "NyK5NwkqXpuf74Le0omvFVUtZEXAMPLE",
+					},
+					NameHint: "second",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "L2IofeJGtvwy1fDSKNj5dEIRgEXAMPLE",
+					},
+					NameHint: "third",
+				},
+			},
+		},
+		"config file on Linux": {
+			OS: "linux",
+			Files: map[string]string{
+				"~/.config/fastly/config.toml": plugintest.LoadFixture(t, "config.toml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "4Oncq0V723ZO8HIqUgOTB77dsEXAMPLE",
+					},
+					NameHint: "first",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "NyK5NwkqXpuf74Le0omvFVUtZEXAMPLE",
+					},
+					NameHint: "second",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "L2IofeJGtvwy1fDSKNj5dEIRgEXAMPLE",
+					},
+					NameHint: "third",
+				},
+			},
+		},
+	})
+}

--- a/plugins/fastly/fastly.go
+++ b/plugins/fastly/fastly.go
@@ -18,6 +18,7 @@ func FastlyCLI() schema.Executable {
 			needsauth.NotWhenContainsArgs("-t"),
 			needsauth.NotWhenContainsArgs("--token"),
 			needsauth.NotWhenContainsArgs("profile"),
+			needsauth.NotWhenContainsArgs("config"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/fastly/fastly.go
+++ b/plugins/fastly/fastly.go
@@ -1,0 +1,28 @@
+package fastly
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func FastlyCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Fastly CLI",
+		Runs:    []string{"fastly"},
+		DocsURL: sdk.URL("https://developer.fastly.com/reference/cli/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("-t"),
+			needsauth.NotWhenContainsArgs("--token"),
+			needsauth.NotWhenContainsArgs("profile"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIToken,
+			},
+		},
+	}
+}

--- a/plugins/fastly/plugin.go
+++ b/plugins/fastly/plugin.go
@@ -1,0 +1,22 @@
+package fastly
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "fastly",
+		Platform: schema.PlatformInfo{
+			Name:     "Fastly",
+			Homepage: sdk.URL("https://fastly.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIToken(),
+		},
+		Executables: []schema.Executable{
+			FastlyCLI(),
+		},
+	}
+}

--- a/plugins/fastly/test-fixtures/config.toml
+++ b/plugins/fastly/test-fixtures/config.toml
@@ -1,0 +1,16 @@
+[profile]
+
+[profile.first]
+default = true
+email = "user@example.com"
+token = "4Oncq0V723ZO8HIqUgOTB77dsEXAMPLE"
+
+[profile.second]
+default = false
+email = "user-2@example.com"
+token = "NyK5NwkqXpuf74Le0omvFVUtZEXAMPLE"
+
+[profile.third]
+default = false
+email = "user-3@example.com"
+token = "L2IofeJGtvwy1fDSKNj5dEIRgEXAMPLE"


### PR DESCRIPTION
This PR adds support for [Fastly CLI](https://github.com/fastly/cli/). Fixes https://github.com/1Password/shell-plugins/issues/133.

## Key things to know:

- Fastly uses `API Token`s to authenticate.
- `FASTLY_API_TOKEN` envvar (environment variable) is the easiest way to authenticate. The CLI also supports `-t`, `--token` as command flags to login, but environment variables are preferred.

## Issues that need to be discussed

### Issue with profile subcommands

`fastly profile` command has a bunch of sub-commands `create`, `delete`, `list`, `switch`, `token` and `update`. Of these commands, except for `list` subcommand, all subcommands can be used in the form of the same environment variable (_I think_), but that's not possible just yet because Shell Plugins does not offer a simple way to switch to another credential:

- https://github.com/1Password/shell-plugins/issues/130

Until that feature is available, I am suggesting that we opt out of 1Password authentication for `fastly profile` commands.

The other command, `fastly profile list` basically looks for the list of available profiles in the config file and operate on the data available there. With Shell Plugins though, the config file will basically be void of these profiles, which in turn means that that command will just fail.

Overall, to me, it makes sense to avoid 1Password authentication for `fastly profile` commands for now. 

### Issue with config file imports

For some reason, I am unable to get MacOnly and LinuxOnly OS-specific config file imports working. It's probably something simple that I am missing. cc @hculea as we previously scheduled a call to discuss this. 🙏🏼 Thank you for any insights!