### PR TITLE
Fix Field Name case on the template-generated tests

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -444,7 +444,7 @@ func Test{{ .CredentialNameUpperCamelCase }}Provisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, {{ .CredentialNameUpperCamelCase }}().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
-				fieldname.{{ .FieldName }}: "{{ .TestCredentialExample }}",
+				fieldname.{{ .FieldNameUpperCamelCase }}: "{{ .TestCredentialExample }}",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
@@ -464,7 +464,7 @@ func Test{{ .CredentialNameUpperCamelCase }}Importer(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.{{ .FieldName }}: "{{ .TestCredentialExample }}",
+						fieldname.{{ .FieldNameUpperCamelCase }}: "{{ .TestCredentialExample }}",
 					},
 				},
 			},


### PR DESCRIPTION
This PR updates the field name on the `make new-plugin`-generated tests from `FieldName` to `FieldNameUpperCamelCase`, to avoid the breakage described below. In the below example, the correct field name should be "APIKey", not "API Key".

**Before:**
<img width="970" alt="Screenshot 2023-01-31 at 4 17 21 PM" src="https://user-images.githubusercontent.com/18581859/215914508-b71dd8a6-6ff3-4698-a3c5-68eef1a8b599.png">

**After:**

<img width="970" alt="Screenshot 2023-01-31 at 4 22 57 PM" src="https://user-images.githubusercontent.com/18581859/215914519-2ec0d672-c35c-4602-a2fe-86a0aecaa05e.png">


