### PR TITLE
Add support for tunnelto with config file importer and file-based provisioning

### DIFF
--- a/plugins/tunnelto/api_key.go
+++ b/plugins/tunnelto/api_key.go
@@ -29,6 +29,54 @@ func APIKey() schema.CredentialType {
 					},
 				},
 			},
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "Host address to forward incoming traffic to.",
+				Secret:              false,
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Port,
+				MarkdownDescription: "Port on the host address to forward incoming traffic to.",
+				Secret:              false,
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Digits: true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Scheme,
+				MarkdownDescription: "Protocol (http or https) to use for the local host.",
+				Secret:              false,
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Subdomain,
+				MarkdownDescription: "Subdomain to use for the tunnel.",
+				Secret:              false,
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
 		},
 		DefaultProvisioner: provision.Arguments(argumentsMapping),
 		Importer: importer.TryAll(
@@ -37,7 +85,11 @@ func APIKey() schema.CredentialType {
 }
 
 var argumentsMapping = map[string]sdk.FieldName{
-	"--key": fieldname.APIKey,
+	"--key":       fieldname.APIKey,
+	"--host":      fieldname.Host,
+	"--port":      fieldname.Port,
+	"--scheme":    fieldname.Scheme,
+	"--subdomain": fieldname.Subdomain,
 }
 
 func TrytunneltodevConfigFile() sdk.Importer {

--- a/plugins/tunnelto/api_key.go
+++ b/plugins/tunnelto/api_key.go
@@ -30,13 +30,14 @@ func APIKey() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.TempFile(
-			provision.FieldAsFile(fieldname.APIKey),
-			provision.AtFixedPath("~/.tunnelto/key.token"),
-		),
+		DefaultProvisioner: provision.Arguments(argumentsMapping),
 		Importer: importer.TryAll(
 			TrytunneltodevConfigFile(),
 		)}
+}
+
+var argumentsMapping = map[string]sdk.FieldName{
+	"--key": fieldname.APIKey,
 }
 
 func TrytunneltodevConfigFile() sdk.Importer {

--- a/plugins/tunnelto/api_key.go
+++ b/plugins/tunnelto/api_key.go
@@ -1,0 +1,54 @@
+package tunnelto
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		ManagementURL: sdk.URL("https://dashboard.tunnelto.dev/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to tunnelto.dev.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 22,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			provision.FieldAsFile(fieldname.APIKey),
+			provision.AtFixedPath("~/.tunnelto/key.token"),
+		),
+		Importer: importer.TryAll(
+			TrytunneltodevConfigFile(),
+		)}
+}
+
+func TrytunneltodevConfigFile() sdk.Importer {
+	return importer.TryFile("~/.tunnelto/key.token", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		if contents.ToString() == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.APIKey: contents.ToString(),
+			},
+		})
+	})
+}

--- a/plugins/tunnelto/api_key_test.go
+++ b/plugins/tunnelto/api_key_test.go
@@ -26,3 +26,20 @@ func TestAPIKeyProvisioner(t *testing.T) {
 		},
 	})
 }
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.tunnelto/key.token": plugintest.LoadFixture(t, "key.token"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "XddpK7jZiQ0CpE3EXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/tunnelto/api_key_test.go
+++ b/plugins/tunnelto/api_key_test.go
@@ -1,0 +1,28 @@
+package tunnelto
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"temp file": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "XddpK7jZiQ0CpE3EXAMPLE",
+			},
+			CommandLine: []string{"tunnelto"},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"tunnelto"},
+				Files: map[string]sdk.OutputFile{
+					"~/.tunnelto/key.token": {
+						Contents: []byte(plugintest.LoadFixture(t, "key.token")),
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/tunnelto/plugin.go
+++ b/plugins/tunnelto/plugin.go
@@ -1,0 +1,22 @@
+package tunnelto
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "tunnelto",
+		Platform: schema.PlatformInfo{
+			Name:     "tunnelto.dev",
+			Homepage: sdk.URL("https://tunnelto.dev"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			tunneltodevCLI(),
+		},
+	}
+}

--- a/plugins/tunnelto/test-fixtures/key.token
+++ b/plugins/tunnelto/test-fixtures/key.token
@@ -1,0 +1,1 @@
+XddpK7jZiQ0CpE3EXAMPLE

--- a/plugins/tunnelto/tunnelto.go
+++ b/plugins/tunnelto/tunnelto.go
@@ -1,0 +1,26 @@
+package tunnelto
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func tunneltodevCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "tunnelto.dev CLI",
+		Runs:    []string{"tunnelto"},
+		DocsURL: sdk.URL("https://github.com/agrinman/tunnelto"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWhenContainsArgs("-k"),
+			needsauth.NotWhenContainsArgs("--key"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/tunnelto/tunnelto.go
+++ b/plugins/tunnelto/tunnelto.go
@@ -16,6 +16,7 @@ func tunneltodevCLI() schema.Executable {
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWhenContainsArgs("-k"),
 			needsauth.NotWhenContainsArgs("--key"),
+			needsauth.NotWhenContainsArgs("set-auth"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/sdk/provision/arguments_provisioner.go
+++ b/sdk/provision/arguments_provisioner.go
@@ -1,0 +1,38 @@
+package provision
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+)
+
+// ArgumentsProvisioner provisions secrets as command line arguments
+type ArgumentsProvisioner struct {
+	sdk.Provisioner
+
+	Schema map[string]sdk.FieldName
+}
+
+// Arguments creates an ArgumentsProvisioner that provisions secrets as command line arguments, based
+// on the specified schema of argument flag/name and its value, which is a FieldName.
+func Arguments(schema map[string]sdk.FieldName) sdk.Provisioner {
+	return ArgumentsProvisioner{
+		Schema: schema,
+	}
+}
+
+func (p ArgumentsProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	for argName, fieldName := range p.Schema {
+		if value, ok := in.ItemFields[fieldName]; ok {
+			out.AddArgs(argName, value)
+		}
+	}
+}
+
+func (p ArgumentsProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Nothing to do here: passed argument values get wiped automatically when the process exits.
+}
+
+func (p ArgumentsProvisioner) Description() string {
+	return "Provision secrets as command line arguments"
+}

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -42,6 +42,7 @@ const (
 	Port            = sdk.FieldName("Port")
 	PrivateKey      = sdk.FieldName("Private Key")
 	Region          = sdk.FieldName("Region")
+	Scheme          = sdk.FieldName("Scheme")
 	Secret          = sdk.FieldName("Secret")
 	SecretAccessKey = sdk.FieldName("Secret Access Key")
 	Subdomain       = sdk.FieldName("Subdomain")
@@ -91,8 +92,10 @@ func ListAll() []sdk.FieldName {
 		Port,
 		PrivateKey,
 		Region,
+		Scheme,
 		Secret,
 		SecretAccessKey,
+		Subdomain,
 		Token,
 		URL,
 		User,


### PR DESCRIPTION
This PR adds support for [tunnelto dev](https://tunnelto.dev/). Fixes https://github.com/1Password/shell-plugins/issues/157.

## Key points

- tunnelto supports API Key-based authentication. On [the docs](https://github.com/agrinman/tunnelto) and on the CLI help commands, there are some references to "API Authentication Key" but for simplicity, I have stuck to "API Key"
- `tunnelto set-auth -k key` or `tunnelto set-auth --key key` is the command to set the API Key for authentication.
- The shell plugin supports importing of the API Key from the `~/.tunnelto/key.token` path.
- Provisions the API Key to the same path for authentication.

## Notes

### Environment variable not supported

I am not seeing an environment variable to use for authentication. I reached out @agrinman on email to understand if it's possible. Until that's clear, I suggest we move forward with file-based provisioning.

### 1Password authentication needed for arg-less usage

If an user runs just `tunnelto`, 1Password authentication should be used because that command basically runs `tunnelto --port 8000`

### Not sure how to handle `set-auth` flow

When someone sets up tunnelto after setting up the shell plugin, running `tunnelto set-auth -k key` or `tunnelto set-auth --key key` results in the API Key being stored to `~/.tunnelto/key.token` on the computer. 

And running tunnelto commands after that results in failure because 1Password tries to provision the credential to that path, but a file already exists at that path:

```
➜  ~ tunnelto set-auth -k XddpK7jZiQ0CpE3EXAMPLE
#########################################################################
# WARNING: 'tunnelto' is not from the official registry.                #
# Only proceed if you are the developer of 'tunnelto'.                  #
# Otherwise, delete the file at /Users/arun/.op/plugins/local/tunnelto. #
#########################################################################
Authentication key stored successfully!
➜  ~ cat ~/.tunnelto/key.token
➜  ~ tunnelto
#########################################################################
# WARNING: 'tunnelto' is not from the official registry.                #
# Only proceed if you are the developer of 'tunnelto'.                  #
# Otherwise, delete the file at /Users/arun/.op/plugins/local/tunnelto. #
#########################################################################
[ERROR] 2023/01/31 23:57:40 could not run plugin tunnelto.dev CLI[31;1m [test build][0m: file with path /Users/arun/.tunnelto/key.token already exists, please remove it before proceeding
```

I have already skipped 1Password authentication for `-k` and `--key`. 