### PR TITLE
Add plugin for Treasure Data Toolbelt

### DIFF
--- a/plugins/treasuredata/access_key.go
+++ b/plugins/treasuredata/access_key.go
@@ -1,0 +1,68 @@
+package treasuredata
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessKey,
+		DocsURL:       sdk.URL("https://docs.treasuredata.com/display/public/PD/TD+Toolbelt"),
+		ManagementURL: sdk.URL("https://console.treasuredata.com/app/mp/ak"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.User,
+				MarkdownDescription: "User name specified by email",
+			},			
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "APIKey used to authenticate to Treasure Data.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			TryTreasureDataConfigFile("~/.td/td.conf"),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"TD_API_KEY": fieldname.APIKey,
+}
+
+func TryTreasureDataConfigFile(path string) sdk.Importer {
+	return importer.TryFile(path, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		credentialsFile, err := contents.ToINI()
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		fields := make(map[sdk.FieldName]string)
+		for _, section := range credentialsFile.Sections() {
+			if section.HasKey("user") && section.Key("user").Value() != "" {
+				fields[fieldname.User] = section.Key("user").Value()
+			}			
+			if section.HasKey("apikey") && section.Key("apikey").Value() != "" {
+				fields[fieldname.APIKey] = section.Key("apikey").Value()
+			}
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: fields,
+		})
+	})
+}

--- a/plugins/treasuredata/access_key_test.go
+++ b/plugins/treasuredata/access_key_test.go
@@ -1,0 +1,42 @@
+package treasuredata
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAccessKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "1/xxx",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"TD_API_KEY": "1/xxx",
+				},
+			},
+		},
+	})
+}
+
+func TestAccessKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessKey().Importer, map[string]plugintest.ImportCase{
+		"TD config file": {
+			Files: map[string]string{
+				"~/.td/td.conf": plugintest.LoadFixture(t, "td.conf"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.User: "user@example.com",
+						fieldname.APIKey: "1/xxx",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/treasuredata/plugin.go
+++ b/plugins/treasuredata/plugin.go
@@ -1,0 +1,22 @@
+package treasuredata
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "treasuredata",
+		Platform: schema.PlatformInfo{
+			Name:     "Treasure Data",
+			Homepage: sdk.URL("https://www.treasuredata.com/"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessKey(),
+		},
+		Executables: []schema.Executable{
+			TreasureDataCLI(),
+		},
+	}
+}

--- a/plugins/treasuredata/td.go
+++ b/plugins/treasuredata/td.go
@@ -1,0 +1,25 @@
+package treasuredata
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func TreasureDataCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Treasure Data Toolbelkt",
+		Runs:      []string{"td"},
+		DocsURL:   sdk.URL("https://docs.treasuredata.com/display/public/PD/TD+Toolbelt"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessKey,
+			},
+		},
+	}
+}

--- a/plugins/treasuredata/test-fixtures/td.conf
+++ b/plugins/treasuredata/test-fixtures/td.conf
@@ -1,0 +1,3 @@
+[account]
+  user = user@example.com
+  apikey = 1/xxx


### PR DESCRIPTION
# Summary
Add support for a new plugin for the [TreasureData Toolbelt](https://docs.treasuredata.com/display/public/PD/TD+Toolbelt)

# Testing
## Setup
1. Create a TreasureData account through the site [here](https://www.treasuredata.com/).
2. Get the API key for CLI tools according to the [guide](https://docs.treasuredata.com/display/public/PD/Getting+Your+API+Keys).
3. Following the [guide](https://docs.treasuredata.com/display/public/PD/Installing+TD+Toolbelt+and+Treasure+Agent), setup the Treasure Data Toolbelt in your environment 
3. Build and test the TreasureData plugin locally according to [these instructions](https://developer.1password.com/docs/cli/shell-plugins/contribute/). 

```
$ make treasuredata/validate
$ make treasuredata/build
```

# Importer

After installing and setting up Treasure Data Toolbelt, a config file should have been created at `~/.td/td.conf`. 
Initialize the Treasure Data plugin and test the importer using this config file. The credentials should be saved in 1Password successfully by selecting this config file. The entry should have `user` and `api key` fields.


# Provisioner
After initializing the Treasure Data plugin and having your Treasure Data credentials saved in 1Password, run a `td` command. The provisioner should inject `TD_API_KEY` environment so that the tool can refer to the necessary credential at runtime.
Try running the following command.

```
$ td db:list
+---------------------+----------+
| Name                | Count    |
+---------------------+----------+
| sample_datasets     | 0        |
+---------------------+----------+
```

Note: While testing the provisioner, ensure that your credentials are not currently stored in `~/.td/td.conf` nor environment variables.
