### PR TITLE
New Plugin:  SAPBTP cli 

### DIFF
--- a/plugins/sapbtp/btp.go
+++ b/plugins/sapbtp/btp.go
@@ -1,0 +1,26 @@
+package sapbtp
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func SAPBTPCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "SAP BTP CLI",
+		Runs:    []string{"btp"},
+		DocsURL: sdk.URL("https://help.sap.com/docs/btp/sap-business-technology-platform/account-administration-using-sap-btp-command-line-interface-btp-cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.ForCommand("login"),
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.Credentials,
+			},
+		},
+	}
+}

--- a/plugins/sapbtp/credentials.go
+++ b/plugins/sapbtp/credentials.go
@@ -1,0 +1,39 @@
+package sapbtp
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func Credentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.Credentials,
+		DocsURL:       sdk.URL("https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/cc1c676b43904066abb2a4838cbd0c37.html"),
+		ManagementURL: sdk.URL("https://account.hana.ondemand.com/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Username,
+				MarkdownDescription: " SAP BTP Username (email address)",
+				Optional:            false,
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{Uppercase: true, Lowercase: true, Digits: true},
+					Prefix:  "",
+				},
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: " SAP BTP Password",
+				Optional:            false,
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{Uppercase: true, Lowercase: true, Digits: true},
+					Prefix:  "",
+				},
+			},
+		},
+		DefaultProvisioner: BTPProvisioner(),
+	}
+}

--- a/plugins/sapbtp/credentials_test.go
+++ b/plugins/sapbtp/credentials_test.go
@@ -1,0 +1,28 @@
+package sapbtp
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestCredentialsProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, Credentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Username: "john.doe@email.com",
+				fieldname.Password: "CpfSh78WLKpO6teQitmYbH7EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{
+					"--user",
+					"john.doe@email.com",
+					"--password",
+					"CpfSh78WLKpO6teQitmYbH7EXAMPLE",
+				},
+			},
+		},
+	})
+}

--- a/plugins/sapbtp/plugin.go
+++ b/plugins/sapbtp/plugin.go
@@ -1,0 +1,22 @@
+package sapbtp
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "sapbtp",
+		Platform: schema.PlatformInfo{
+			Name:     "SAP BTP",
+			Homepage: sdk.URL("https://help.sap.com/docs/BTP"),
+		},
+		Credentials: []schema.CredentialType{
+			Credentials(),
+		},
+		Executables: []schema.Executable{
+			SAPBTPCLI(),
+		},
+	}
+}

--- a/plugins/sapbtp/provisioner.go
+++ b/plugins/sapbtp/provisioner.go
@@ -24,13 +24,12 @@ func (p btpProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, ou
 		out.AddArgs("--password", password)
 	}
 
-	return
 }
 
 func (p btpProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
-	// Nothing to do here: environment variables get wiped automatically when the process exits.
+	// Nothing to do here: command line args are wiped when process exits
 }
 
 func (p btpProvisioner) Description() string {
-	return "Provision command line variables --user and --password with BTP cli"
+	return "Provision command line variables --user and --password with BTP cli's login command."
 }

--- a/plugins/sapbtp/provisioner.go
+++ b/plugins/sapbtp/provisioner.go
@@ -1,0 +1,36 @@
+package sapbtp
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+type btpProvisioner struct {
+}
+
+func BTPProvisioner() sdk.Provisioner {
+	return btpProvisioner{}
+}
+
+func (p btpProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+
+	if username, ok := in.ItemFields[fieldname.Username]; ok {
+		out.AddArgs("--user", username)
+	}
+
+	if password, ok := in.ItemFields[fieldname.Password]; ok {
+		out.AddArgs("--password", password)
+	}
+
+	return
+}
+
+func (p btpProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Nothing to do here: environment variables get wiped automatically when the process exits.
+}
+
+func (p btpProvisioner) Description() string {
+	return "Provision command line variables --user and --password with BTP cli"
+}


### PR DESCRIPTION
# Summary

Provides support for a new plugin for [SAP's BTP CLI](https://help.sap.com/docs/btp/sap-business-technology-platform/account-administration-using-sap-btp-command-line-interface-btp-cli).

**NOTE:** Plugin name is SAPBTP, but the CLI command is `btp`. 

# Setup 
1.  Setup an [SAP BTP account](https://account.hana.ondemand.com/) - (trial, free or paid) 
2. Provision user - standard using SAP's Account IDP
3.  Download and setup the [SAP BTP Command Line Interface (btp CLI)](https://tools.hana.ondemand.com/#cloud)
4. Build and test the SAPBTP plugin locally according to [these instructions](https://developer.1password.com/docs/cli/shell-plugins/contribute/).
```bash
$ make sapbtp/validate
$ make sapbtp/build
```


# Importer

The BTP CLI config file maintains the current setting and the refresh token created on the initial credentialed login.  This is not particularly useful for populating credentials, and an importer is not currently implemented. 

# Provisioner 

The BTP CLI authentication is done with an explicit login using the `login` command.  The current plugin will only trigger on that CLI command and adds the `--user` and `--password` arguments to the command line.  Additional login arguments such as `--url` and `--subdomain` can still be provided or entered as per the standard flow. 

## Example
```zsh
$ btp login --url https://cpcli.cf.eu10.hana.ondemand.com --subdomain t5822952trial-ga

###############################################################################
# WARNING: 'sapbtp' is not from the official registry.                        #
# Only proceed if you are the developer of 'sapbtp'.                          #
# Otherwise, delete the file at /Users/username/.op/plugins/local/sapbtp. #
###############################################################################
Connecting to CLI server at https://cpcli.cf.eu10.hana.ondemand.com...
Autocomplete script has been updated to include the latest commands. Restart your terminal session to load the newest autocomplete information.

Authentication successful

Current target:
  t5822952trial (global account, subdomain: t5822952trial-ga)

We stored your configuration file at: /Users/username/Library/Application Support/.btp/config.json

Tips:
    Commands are executed in the target, unless specified otherwise using a parameter. To change the target, use 'btp target'.
    To provide feedback about the btp CLI, use 'btp feedback' to open our survey.

OK
```

