### PR TITLE
Add `brew bump` sub-command to NeedsAuth list

### DIFF
--- a/plugins/homebrew/brew.go
+++ b/plugins/homebrew/brew.go
@@ -16,6 +16,7 @@ func HomebrewCLI() schema.Executable {
 			needsauth.NotForHelpOrVersion(),
 			needsauth.IfAny(
 				needsauth.ForCommand("search"),
+				needsauth.ForCommand("bump"),
 				needsauth.ForCommand("bump-cask-pr"),
 				needsauth.ForCommand("bump-formula-pr"),
 			),


### PR DESCRIPTION
This is a "smarter" wrapper around the `brew-bump-*` subcommands that auto-detects the latest version, checks for existing PRs, etc.