### PR TITLE
Add assume role support for AWS via profiles

### DIFF
--- a/plugins/aws/provisioner.go
+++ b/plugins/aws/provisioner.go
@@ -93,9 +93,7 @@ func findRoleArnIfSpecified(in sdk.ProvisionInput, out *sdk.ProvisionOutput) str
 						}
 
 						// remove the --profile flag so the aws cli does not use it
-						out.CommandLine[i] = ""
-						out.CommandLine[i+1] = ""
-
+						out.CommandLine = out.CommandLine[0:i]
 						return key.Value()
 					}
 				}

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -14,6 +14,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 )
 
+const (
+	MFACacheKey               = "sts-mfa"
+	assumeRoleWithMFACacheKey = "sts-assume-role-mfa"
+)
+
 type STSProvisioner struct {
 	TOTPCode  string
 	MFASerial string
@@ -21,19 +26,6 @@ type STSProvisioner struct {
 }
 
 func (p STSProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
-	var cached types.Credentials
-	if ok := in.Cache.Get("sts", &cached); ok {
-		out.AddEnvVar("AWS_ACCESS_KEY_ID", *cached.AccessKeyId)
-		out.AddEnvVar("AWS_SECRET_ACCESS_KEY", *cached.SecretAccessKey)
-		out.AddEnvVar("AWS_SESSION_TOKEN", *cached.SessionToken)
-
-		if region, ok := in.ItemFields[fieldname.DefaultRegion]; ok {
-			out.AddEnvVar("AWS_DEFAULT_REGION", region)
-		}
-
-		return
-	}
-
 	config := aws.NewConfig()
 	config.Credentials = credentials.NewStaticCredentialsProvider(in.ItemFields[fieldname.AccessKeyID], in.ItemFields[fieldname.SecretAccessKey], "")
 
@@ -42,33 +34,100 @@ func (p STSProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, ou
 		region = os.Getenv("AWS_DEFAULT_REGION")
 	}
 	if len(region) == 0 {
-		out.AddError(errors.New("region is required for the AWS Shell Plugin MFA workflow: set 'default region' in 1Password or set the 'AWS_DEFAULT_REGION' environment variable yourself"))
+		out.AddError(errors.New("region is required for the AWS Shell Plugin MFA or Assume Role workflows: set 'default region' in 1Password or set the 'AWS_DEFAULT_REGION' environment variable yourself"))
 		return
 	}
 	config.Region = region
 
 	stsProvider := sts.NewFromConfig(*config)
-	input := &sts.GetSessionTokenInput{
-		DurationSeconds: aws.Int32(900), // minimum expiration time - 15 minutes
-		SerialNumber:    aws.String(p.MFASerial),
-		TokenCode:       aws.String(p.TOTPCode),
+	var awsTemporaryCredentials *types.Credentials
+
+	if p.RoleArn != "" && p.MFASerial != "" && p.TOTPCode != "" {
+		if useCache := tryUsingCachedCredentials(assumeRoleWithMFACacheKey, in, out); useCache {
+			return
+		}
+
+		input := &sts.AssumeRoleInput{
+			DurationSeconds: aws.Int32(900), // minimum expiration time - 15 minutes
+			SerialNumber:    aws.String(p.MFASerial),
+			TokenCode:       aws.String(p.TOTPCode),
+			RoleArn:         aws.String(p.RoleArn),
+			RoleSessionName: aws.String("1password-shell-plugin"),
+		}
+
+		resp, err := stsProvider.AssumeRole(ctx, input)
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		awsTemporaryCredentials = resp.Credentials
+		err = out.Cache.Put(assumeRoleWithMFACacheKey, *awsTemporaryCredentials, *awsTemporaryCredentials.Expiration)
+		if err != nil {
+			out.AddError(fmt.Errorf("failed to serialize aws sts credentials: %w", err))
+		}
+	} else if p.RoleArn == "" {
+		if useCache := tryUsingCachedCredentials(MFACacheKey, in, out); useCache {
+			return
+		}
+		input := &sts.GetSessionTokenInput{
+			DurationSeconds: aws.Int32(900), // minimum expiration time - 15 minutes
+			SerialNumber:    aws.String(p.MFASerial),
+			TokenCode:       aws.String(p.TOTPCode),
+		}
+
+		resp, err := stsProvider.GetSessionToken(ctx, input)
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		awsTemporaryCredentials = resp.Credentials
+		err = out.Cache.Put(MFACacheKey, *awsTemporaryCredentials, *awsTemporaryCredentials.Expiration)
+		if err != nil {
+			out.AddError(fmt.Errorf("failed to serialize aws sts credentials: %w", err))
+		}
+	} else {
+		input := &sts.AssumeRoleInput{
+			DurationSeconds: aws.Int32(900), // minimum expiration time - 15 minutes
+			RoleArn:         aws.String(p.RoleArn),
+			RoleSessionName: aws.String("1password-shell-plugin"),
+		}
+
+		resp, err := stsProvider.AssumeRole(ctx, input)
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		awsTemporaryCredentials = resp.Credentials
 	}
 
-	result, err := stsProvider.GetSessionToken(ctx, input)
-	if err != nil {
-		out.AddError(err)
-		return
-	}
-
-	out.AddEnvVar("AWS_ACCESS_KEY_ID", *result.Credentials.AccessKeyId)
-	out.AddEnvVar("AWS_SECRET_ACCESS_KEY", *result.Credentials.SecretAccessKey)
-	out.AddEnvVar("AWS_SESSION_TOKEN", *result.Credentials.SessionToken)
+	out.AddEnvVar("AWS_ACCESS_KEY_ID", *awsTemporaryCredentials.AccessKeyId)
+	out.AddEnvVar("AWS_SECRET_ACCESS_KEY", *awsTemporaryCredentials.SecretAccessKey)
+	out.AddEnvVar("AWS_SESSION_TOKEN", *awsTemporaryCredentials.SessionToken)
 	out.AddEnvVar("AWS_DEFAULT_REGION", region)
 
-	err = out.Cache.Put("sts", *result.Credentials, *result.Credentials.Expiration)
+	err := out.Cache.Put("sts", *awsTemporaryCredentials, *awsTemporaryCredentials.Expiration)
 	if err != nil {
 		out.AddError(fmt.Errorf("failed to serialize aws sts credentials: %w", err))
 	}
+}
+
+func tryUsingCachedCredentials(cacheKey string, in sdk.ProvisionInput, out *sdk.ProvisionOutput) bool {
+	var cached types.Credentials
+	if ok := in.Cache.Get(cacheKey, &cached); ok {
+		out.AddEnvVar("AWS_ACCESS_KEY_ID", *cached.AccessKeyId)
+		out.AddEnvVar("AWS_SECRET_ACCESS_KEY", *cached.SecretAccessKey)
+		out.AddEnvVar("AWS_SESSION_TOKEN", *cached.SessionToken)
+
+		if region, ok := in.ItemFields[fieldname.DefaultRegion]; ok {
+			out.AddEnvVar("AWS_DEFAULT_REGION", region)
+		}
+
+		return true
+	}
+	return false
 }
 
 func (p STSProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -17,6 +17,7 @@ import (
 type STSProvisioner struct {
 	TOTPCode  string
 	MFASerial string
+	RoleArn   string
 }
 
 func (p STSProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {


### PR DESCRIPTION
### Summary
This is a continuation of @shyim 's initiative for [adding AWS Assume role support](https://github.com/1Password/shell-plugins/pull/92) (full credits to @shyim !)

The solution described by this workflow is to use the `~/.aws/config` file we are all used to for setting up various profiles, with different roles. Given that role ARNs are not secrets, users can configure these on disk. Of course, all other sensitive information is recommended to remain inside 1Password:

```
[profile user1]
role_arn=arn:aws:iam::account_id_number:role/role-name-you-want-to-assume

[profile user2]
role_arn=arn:aws:iam::account_id_number:role/another-role-name-you-want-to-assume
```

Then assuming a role is as simple as running `aws s3 ls --profile user1` given that all other credentials were properly configured inside 1P. Assume role can be used with MFA support or without via the shell plugin.

### Challenges
The expiring of the OTP token error (`failed with invalid MFA one time pass code`) seems unavoidable (for 30 seconds - worst case scenario) in the case where a user would quickly switch between `assume role with MFA` and `MFA auth` workflows, but only when cache is not populated for both. This is because we would be now using different cache entries for the credentials of these 2 different workflow, while they both rely on the same OTP code. The alternative is even worse: having both these workflows rely on the same cache entry would result in the user not being able to switch between these 2 workflows for 15 minutes - worst case scenario.

This can be solved in time by adding support for different credential types per plugin.