### PR TITLE
Draft: New plugin: IBM Cloud CLI

### DIFF
--- a/plugins/ibmcloud/api_key.go
+++ b/plugins/ibmcloud/api_key.go
@@ -1,0 +1,70 @@
+package ibmcloud
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://ibmcloud.com/docs/api_key"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.ibmcloud.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to IBM Cloud.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 44,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryIBMCloudConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"IBMCLOUD_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the API Key in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryIBMCloudConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.APIKey == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.APIKey: config.APIKey,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	APIKey string
+// }

--- a/plugins/ibmcloud/api_key.go
+++ b/plugins/ibmcloud/api_key.go
@@ -14,8 +14,8 @@ import (
 func APIKey() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIKey,
-		DocsURL:       sdk.URL("https://ibmcloud.com/docs/api_key"), // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://console.ibmcloud.com/user/security/tokens"), // TODO: Replace with actual URL
+		DocsURL:       sdk.URL("https://www.ibm.com/docs/en/app-connect/container?topic=servers-creating-cloud-api-key"),
+		ManagementURL: sdk.URL("https://cloud.ibm.com/iam/apikeys"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,
@@ -39,32 +39,29 @@ func APIKey() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"IBMCLOUD_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+	"IBMCLOUD_API_KEY": fieldname.APIKey,
 }
 
-// TODO: Check if the platform stores the API Key in a local config file, and if so,
-// implement the function below to add support for importing it.
 func TryIBMCloudConfigFile() sdk.Importer {
-	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
-		// var config Config
-		// if err := contents.ToYAML(&config); err != nil {
-		// 	out.AddError(err)
-		// 	return
-		// }
+	return importer.TryFile("~/.bluemix/config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
 
-		// if config.APIKey == "" {
-		// 	return
-		// }
+		if config.APIKey == "" {
+			return
+		}
 
-		// out.AddCandidate(sdk.ImportCandidate{
-		// 	Fields: map[sdk.FieldName]string{
-		// 		fieldname.APIKey: config.APIKey,
-		// 	},
-		// })
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.APIKey: config.APIKey,
+			},
+		})
 	})
 }
 
-// TODO: Implement the config file schema
-// type Config struct {
-//	APIKey string
-// }
+type Config struct {
+	APIKey string `json:"APIKey"`
+}

--- a/plugins/ibmcloud/api_key_test.go
+++ b/plugins/ibmcloud/api_key_test.go
@@ -1,0 +1,55 @@
+package ibmcloud
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.APIKey: "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"IBMCLOUD_API_KEY": "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"IBMCLOUD_API_KEY": "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in ibmcloud/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/ibmcloud/api_key_test.go
+++ b/plugins/ibmcloud/api_key_test.go
@@ -2,16 +2,16 @@ package ibmcloud
 
 import (
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+			ItemFields: map[sdk.FieldName]string{
 				fieldname.APIKey: "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -26,7 +26,7 @@ func TestAPIKeyProvisioner(t *testing.T) {
 func TestAPIKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
+			Environment: map[string]string{
 				"IBMCLOUD_API_KEY": "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
@@ -37,18 +37,16 @@ func TestAPIKeyImporter(t *testing.T) {
 				},
 			},
 		},
-		// TODO: If you implemented a config file importer, add a test file example in ibmcloud/test-fixtures
-		// and fill the necessary details in the test template below.
 		"config file": {
 			Files: map[string]string{
-				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+				"~/.bluemix/config.json": plugintest.LoadFixture(t, "config.json"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
-			// 	{
-			// 		Fields: map[sdk.FieldName]string{
-			// 			fieldname.Token: "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
-			// 		},
-			// 	},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
+					},
+				},
 			},
 		},
 	})

--- a/plugins/ibmcloud/ibmcloud.go
+++ b/plugins/ibmcloud/ibmcloud.go
@@ -9,12 +9,18 @@ import (
 
 func IBMCloudCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "IBM Cloud CLI", // TODO: Check if this is correct
-		Runs:      []string{"ibmcloud"},
-		DocsURL:   sdk.URL("https://ibmcloud.com/docs/cli"), // TODO: Replace with actual URL
+		Name:    "IBM Cloud CLI",
+		Runs:    []string{"ibmcloud"},
+		DocsURL: sdk.URL("https://cloud.ibm.com/docs/cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
-			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("-u"),
+			needsauth.NotWhenContainsArgs("-p"),
+			needsauth.NotWhenContainsArgs("--apikey"),
+			needsauth.NotWhenContainsArgs("--cr-token"),
+			needsauth.NotWhenContainsArgs("--profile"),
+			needsauth.NotWhenContainsArgs("--sso"),
+			needsauth.NotWhenContainsArgs("--no-account"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/ibmcloud/ibmcloud.go
+++ b/plugins/ibmcloud/ibmcloud.go
@@ -1,0 +1,25 @@
+package ibmcloud
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func IBMCloudCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "IBM Cloud CLI", // TODO: Check if this is correct
+		Runs:      []string{"ibmcloud"},
+		DocsURL:   sdk.URL("https://ibmcloud.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/ibmcloud/plugin.go
+++ b/plugins/ibmcloud/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "ibmcloud",
 		Platform: schema.PlatformInfo{
 			Name:     "IBM Cloud",
-			Homepage: sdk.URL("https://ibmcloud.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://www.ibm.com/cloud"),
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),

--- a/plugins/ibmcloud/plugin.go
+++ b/plugins/ibmcloud/plugin.go
@@ -1,0 +1,22 @@
+package ibmcloud
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "ibmcloud",
+		Platform: schema.PlatformInfo{
+			Name:     "IBM Cloud",
+			Homepage: sdk.URL("https://ibmcloud.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			IBMCloudCLI(),
+		},
+	}
+}

--- a/plugins/ibmcloud/test-fixtures/config.json
+++ b/plugins/ibmcloud/test-fixtures/config.json
@@ -1,0 +1,69 @@
+{
+  "APIEndpoint": "https://cloud.ibm.com",
+  "APIKey": "tjLKgtZ5MSkC9zhSVGCeSfbxBbqr7KCbkfFaHEXAMPLE",
+  "IsPrivate": false,
+  "IsAccessFromVPC": false,
+  "ConsoleEndpoint": "https://cloud.ibm.com",
+  "ConsolePrivateEndpoint": "",
+  "ConsolePrivateVPCEndpoint": "",
+  "CloudType": "public",
+  "CloudName": "bluemix",
+  "CRIType": "",
+  "Region": "",
+  "RegionID": "",
+  "IAMEndpoint": "https://iam.cloud.ibm.com",
+  "IAMPrivateEndpoint": "",
+  "IAMPrivateVPCEndpoint": "",
+  "IAMToken": "",
+  "IAMRefreshToken": "",
+  "IsLoggedInAsCRI": false,
+  "Account": {
+    "GUID": "",
+    "Name": "",
+    "Owner": ""
+  },
+  "Profile": {
+    "ID": "",
+    "Name": "",
+    "ComputeResource": {
+      "Name": "",
+      "ID": ""
+    },
+    "User": {
+      "Name": "",
+      "ID": ""
+    }
+  },
+  "ResourceGroup": {
+    "GUID": "",
+    "Name": "",
+    "State": "",
+    "Default": false,
+    "QuotaID": ""
+  },
+  "LoginAt": "0001-01-01T00:00:00Z",
+  "CFEETargeted": false,
+  "CFEEEnvID": "",
+  "PluginRepos": [
+    {
+      "Name": "IBM Cloud",
+      "URL": "https://plugins.cloud.ibm.com"
+    }
+  ],
+  "SSLDisabled": false,
+  "Locale": "",
+  "MessageOfTheDayTime": 0,
+  "LastSessionUpdateTime": 0,
+  "Trace": "",
+  "ColorEnabled": "",
+  "HTTPTimeout": 0,
+  "CLIInfoEndpoint": "",
+  "CheckCLIVersionDisabled": false,
+  "UsageStatsDisabled": false,
+  "UsageStatsEnabled": false,
+  "UsageStatsEnabledLastUpdate": "0001-01-01T00:00:00Z",
+  "SDKVersion": "1.0.0",
+  "UpdateCheckInterval": 0,
+  "UpdateRetryCheckInterval": 0,
+  "UpdateNotificationInterval": 0
+}


### PR DESCRIPTION
## Summary

Build a new shell plugin for the IBM Cloud CLI.

Addresses: #163 

## Testing

### Setup

1. Create an IBM Cloud account [here](https://cloud.ibm.com/login).
1. Build and test the IBM Cloud plugin locally according to [these instructions](https://developer.1password.com/docs/cli/shell-plugins/contribute/), i.e. `make ibmcloud/build`

### Importer

1. Go to https://cloud.ibm.com/iam/apikeys, create a new API key, and copy/download it.
1. Initialize the IBM Cloud plugin and import credentials by entering the API key manually in the terminal. The credentials should be saved in 1Password successfully.

### Provisioner

1. After initializing the IBM Cloud plugin and having your credential saved in 1Password, run `ibmcloud login`. You should be automatically authenticated with the API key stored from environment variables.
1. Try running an `ibmcloud` command with each of the following arguments (descriptions can be found [here](https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli#ibmcloud_login)):
```
-u
-p
--apikey
--cr-token
--profile
--sso
--no-account
```
You should not be prompted to authenticate through the 1Password CLI.

### Additional Information
