### PR TITLE
fix(ngrok): updating formatting for Authtoken description

### DIFF
--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -19,7 +19,7 @@ func Credentials() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.AuthToken,
-				MarkdownDescription: "Auth Token used to authenticate to ngrok.",
+				MarkdownDescription: "Authtoken used to authenticate to ngrok.",
 				Optional:            false,
 				Secret:              true,
 				Composition: &schema.ValueComposition{


### PR DESCRIPTION
noticed the word authtoken was not formatted correctly when installing the plugin.