### PR TITLE
fix(ngrok): Do not require 1Password authentication for certain (sub)commands

### DIFF
--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -20,6 +20,7 @@ func ngrokCLI() schema.Executable {
 			needsauth.NotWhenContainsArgs("update"),     // skip 1Password authentication for "ngrok update" and "ngrok update --channel=beta"
 			needsauth.NotWhenContainsArgs("completion"), // skip 1Password authentication for "ngrok completion"
 			needsauth.NotWhenContainsArgs("credits"),    // skip 1Password authentication for "ngrok credits"
+			needsauth.NotWhenContainsArgs("service"),    // skip 1Password authentication for "ngrok service" subcommands because that setup involves defining/knowing in advance the config file path, which isn't something we can handle with 1Password Shell Plugins.
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -15,9 +15,9 @@ func ngrokCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
-			needsauth.NotWhenContainsArgs("--config"),
-			needsauth.NotForExactArgs("config"),
-			needsauth.NotForExactArgs("update"),
+			needsauth.NotWhenContainsArgs("--config"), // skip 1Password authentication when any command contains "--config" flag
+			needsauth.NotWhenContainsArgs("config"),   // skip 1Password authentication for "ngrok config" and its subcommands
+			needsauth.NotWhenContainsArgs("update"),   // skip 1Password authentication for "ngrok update" and "ngrok update --channel=beta"
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -15,9 +15,11 @@ func ngrokCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
-			needsauth.NotWhenContainsArgs("--config"), // skip 1Password authentication when any command contains "--config" flag
-			needsauth.NotWhenContainsArgs("config"),   // skip 1Password authentication for "ngrok config" and its subcommands
-			needsauth.NotWhenContainsArgs("update"),   // skip 1Password authentication for "ngrok update" and "ngrok update --channel=beta"
+			needsauth.NotWhenContainsArgs("--config"),   // skip 1Password authentication when any command contains "--config" flag
+			needsauth.NotWhenContainsArgs("config"),     // skip 1Password authentication for "ngrok config" and its subcommands
+			needsauth.NotWhenContainsArgs("update"),     // skip 1Password authentication for "ngrok update" and "ngrok update --channel=beta"
+			needsauth.NotWhenContainsArgs("completion"), // skip 1Password authentication for "ngrok completion"
+			needsauth.NotWhenContainsArgs("credits"),    // skip 1Password authentication for "ngrok credits"
 		),
 		Uses: []schema.CredentialUsage{
 			{


### PR DESCRIPTION
Fixes https://github.com/1Password/shell-plugins/issues/185

We currently require 1Password authentication for `ngrok config`'s and `ngrok update`'s subcommands, while it isn't necessary at all. Requiring authentication results in breakage for certain commands, as described here:

- https://github.com/1Password/shell-plugins/issues/185

This PR fixes that issue by not requiring 1Password authentication for `ngrok config`, `ngrok update` and their subcommands.