### PR TITLE
Add alternative field names

### DIFF
--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -2,8 +2,6 @@ package ngrok
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -21,7 +19,7 @@ func Credentials() schema.CredentialType {
 			{
 				Name:                fieldname.Authtoken,
 				AlternativeNames:    []string{"Auth Token"},
-				MarkdownDescription: fmt.Sprintf("%s used to authenticate to ngrok.", fieldname.Authtoken),
+				MarkdownDescription: "Authtoken used to authenticate to ngrok.",
 				Optional:            false,
 				Secret:              true,
 				Composition: &schema.ValueComposition{

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -13,17 +13,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const ngrokAuthToken = "Authtoken"
-
 func Credentials() schema.CredentialType {
 	return schema.CredentialType{
 		Name:    credname.Credentials,
 		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
 		Fields: []schema.CredentialField{
 			{
-				Name:                ngrokAuthToken,
-				AlternativeNames:    []string{fieldname.AuthToken.String()},
-				MarkdownDescription: fmt.Sprintf("%s used to authenticate to ngrok.", ngrokAuthToken),
+				Name:                fieldname.Authtoken,
+				AlternativeNames:    []string{"Auth Token"},
+				MarkdownDescription: fmt.Sprintf("%s used to authenticate to ngrok.", fieldname.Authtoken),
 				Optional:            false,
 				Secret:              true,
 				Composition: &schema.ValueComposition{
@@ -64,7 +62,7 @@ func Credentials() schema.CredentialType {
 
 func ngrokConfig(in sdk.ProvisionInput) ([]byte, error) {
 	config := Config{
-		AuthToken: in.ItemFields[ngrokAuthToken],
+		AuthToken: in.ItemFields[fieldname.Authtoken],
 		APIKey:    in.ItemFields[fieldname.APIKey],
 		Version:   "2", // required field for ngrok CLI to work when file-based configuration is used; automatically configured by the CLI program and is not configurable by the user
 	}
@@ -76,7 +74,7 @@ func ngrokConfig(in sdk.ProvisionInput) ([]byte, error) {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"NGROK_AUTHTOKEN": ngrokAuthToken,
+	"NGROK_AUTHTOKEN": fieldname.Authtoken,
 	"NGROK_API_KEY":   fieldname.APIKey,
 }
 
@@ -94,8 +92,8 @@ func TryngrokConfigFile(path string) sdk.Importer {
 
 		out.AddCandidate(sdk.ImportCandidate{
 			Fields: map[sdk.FieldName]string{
-				ngrokAuthToken:   config.AuthToken,
-				fieldname.APIKey: config.APIKey,
+				fieldname.Authtoken: config.AuthToken,
+				fieldname.APIKey:    config.APIKey,
 			},
 		})
 	})

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -18,7 +18,8 @@ func Credentials() schema.CredentialType {
 		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
 		Fields: []schema.CredentialField{
 			{
-				Name:                fieldname.AuthToken,
+				Name:                "Authtoken",
+				AlternativeNames:    []string{fieldname.AuthToken.String()},
 				MarkdownDescription: "Auth Token used to authenticate to ngrok.",
 				Optional:            false,
 				Secret:              true,

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -2,6 +2,7 @@ package ngrok
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
@@ -22,7 +23,7 @@ func Credentials() schema.CredentialType {
 			{
 				Name:                ngrokAuthToken,
 				AlternativeNames:    []string{fieldname.AuthToken.String()},
-				MarkdownDescription: "Auth Token used to authenticate to ngrok.",
+				MarkdownDescription: fmt.Sprintf("%s used to authenticate to ngrok.", ngrokAuthToken),
 				Optional:            false,
 				Secret:              true,
 				Composition: &schema.ValueComposition{

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -12,13 +12,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const ngrokAuthToken = "Authtoken"
+
 func Credentials() schema.CredentialType {
 	return schema.CredentialType{
 		Name:    credname.Credentials,
 		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
 		Fields: []schema.CredentialField{
 			{
-				Name:                "Authtoken",
+				Name:                ngrokAuthToken,
 				AlternativeNames:    []string{fieldname.AuthToken.String()},
 				MarkdownDescription: "Auth Token used to authenticate to ngrok.",
 				Optional:            false,
@@ -61,7 +63,7 @@ func Credentials() schema.CredentialType {
 
 func ngrokConfig(in sdk.ProvisionInput) ([]byte, error) {
 	config := Config{
-		AuthToken: in.ItemFields[fieldname.AuthToken],
+		AuthToken: in.ItemFields[ngrokAuthToken],
 		APIKey:    in.ItemFields[fieldname.APIKey],
 		Version:   "2", // required field for ngrok CLI to work when file-based configuration is used; automatically configured by the CLI program and is not configurable by the user
 	}
@@ -73,7 +75,7 @@ func ngrokConfig(in sdk.ProvisionInput) ([]byte, error) {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"NGROK_AUTHTOKEN": fieldname.AuthToken,
+	"NGROK_AUTHTOKEN": ngrokAuthToken,
 	"NGROK_API_KEY":   fieldname.APIKey,
 }
 
@@ -91,8 +93,8 @@ func TryngrokConfigFile(path string) sdk.Importer {
 
 		out.AddCandidate(sdk.ImportCandidate{
 			Fields: map[sdk.FieldName]string{
-				fieldname.AuthToken: config.AuthToken,
-				fieldname.APIKey:    config.APIKey,
+				ngrokAuthToken:   config.AuthToken,
+				fieldname.APIKey: config.APIKey,
 			},
 		})
 	})

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -2,6 +2,7 @@ package ngrok
 
 import (
 	"context"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"

--- a/plugins/ngrok/credentials_test.go
+++ b/plugins/ngrok/credentials_test.go
@@ -12,8 +12,8 @@ func TestCredentialsProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, Credentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"temp file": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-				fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+				ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+				fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 			},
 			CommandLine: []string{"ngrok"},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -38,8 +38,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},
@@ -52,8 +52,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},
@@ -66,8 +66,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},

--- a/plugins/ngrok/credentials_test.go
+++ b/plugins/ngrok/credentials_test.go
@@ -12,8 +12,8 @@ func TestCredentialsProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, Credentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"temp file": {
 			ItemFields: map[sdk.FieldName]string{
-				ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-				fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+				fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+				fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 			},
 			CommandLine: []string{"ngrok"},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -38,8 +38,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},
@@ -52,8 +52,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},
@@ -66,8 +66,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						ngrokAuthToken:   "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey: "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -144,9 +144,9 @@ func (c CredentialType) Validate() (bool, ValidationReport) {
 			hasSecretField = true
 		}
 
-		for _, name := range append(f.AlternativeNames, f.Name) {
-			if _, found := allFieldNames[name.String()]; !found {
-				allFieldNames[name.String()] = struct{}{}
+		for _, name := range append(f.AlternativeNames, f.Name.String()) {
+			if _, found := allFieldNames[name]; !found {
+				allFieldNames[name] = struct{}{}
 			} else {
 				hasNoDuplicateNamesAcrossFields = false
 				break

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -34,7 +34,7 @@ type CredentialField struct {
 	Name sdk.FieldName
 
 	// Other names this field can be recognized after. The order in which these names are specified matters towards which 1Password item field will be selected.
-	AlternativeNames []sdk.FieldName
+	AlternativeNames []string
 
 	// A description of the field.
 	MarkdownDescription string

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -33,7 +33,8 @@ type CredentialField struct {
 	// The name of the field, e.g. "Token", "Password", or "Username".
 	Name sdk.FieldName
 
-	// Other names this field can be recognized after. The order in which these names are specified matters towards which 1Password item field will be selected.
+	// Alternative names for this field. Can be used to deprecate field names without breaking existing setups.
+	// If there are values present for multiple entries, the first match will be chosen.
 	AlternativeNames []string
 
 	// A description of the field.

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -33,7 +33,7 @@ type CredentialField struct {
 	// The name of the field, e.g. "Token", "Password", or "Username".
 	Name sdk.FieldName
 
-	// Other names this field can be recognized after.
+	// Other names this field can be recognized after. The order in which these names are specified matters towards which 1Password item field will be selected.
 	AlternativeNames []sdk.FieldName
 
 	// A description of the field.

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -186,7 +186,7 @@ func (c CredentialType) Validate() (bool, ValidationReport) {
 	})
 
 	report.AddCheck(ValidationCheck{
-		Description: "Has no separate fields that could be identified by the same name",
+		Description: "Has no duplicate field names",
 		Assertion:   hasNoDuplicateNamesAcrossFields,
 		Severity:    ValidationSeverityError,
 	})

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -17,6 +17,7 @@ const (
 	AppSecret       = sdk.FieldName("App Secret")
 	AppToken        = sdk.FieldName("App Token")
 	AuthToken       = sdk.FieldName("Auth Token")
+	Authtoken       = sdk.FieldName("Authtoken")
 	Cert            = sdk.FieldName("Cert")
 	Certificate     = sdk.FieldName("Certificate")
 	Credential      = sdk.FieldName("Credential")

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -62,6 +62,7 @@ func ListAll() []sdk.FieldName {
 		AppSecret,
 		AppToken,
 		AuthToken,
+		Authtoken,
 		Cert,
 		Certificate,
 		Credential,


### PR DESCRIPTION
Related PR: https://github.com/1Password/shell-plugins/pull/186

Add ability to specify various names for a `CredentialField`, so that users aren't constrained to map a field to only one name.

The order in which these names are specified matters towards which 1Password item field will be selected. 
Example:

A `CredentialField` with `Name` set to `d` and `AternativeNames` set to `[]sdk.FieldName{"b", "a", "c"}` and an item with fields named `a`, `b` and `c` will result into a `ProvisionInput` with `ItemFields` containing the value of `b`. If the item were to be added with a field `d` then the value in `ItemFields` would become that of field `d` since the `Name` takes priority over `AlternativeNames`.

For this to work in all cases, a constraint for all fields should be that they do not share any alternative names. Otherwise a conflict will arise in `ItemFields`.
