### PR TITLE
Draft: Add capability to set a default credential when there are multiple

### DIFF
--- a/plugins/ngrok/api_credentials.go
+++ b/plugins/ngrok/api_credentials.go
@@ -1,0 +1,86 @@
+package ngrok
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+	"gopkg.in/yaml.v3"
+)
+
+func APICredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.APIKey,
+		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to ngrok API.",
+				Optional:            true,
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 48,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(ngrokApiConfig, provision.Filename("config.yml"), provision.AddArgs("--config", "{{ .Path }}")),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultApiEnvVarMapping),
+			importer.MacOnly(
+				TryngrokAPIConfigFile("~/Library/Application Support/ngrok/ngrok.yml"),
+			),
+			importer.LinuxOnly(
+				TryngrokAPIConfigFile("~/.config/ngrok/ngrok.yml"),
+			),
+		)}
+}
+
+func ngrokApiConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := APIConfig{
+		APIKey:  in.ItemFields[fieldname.APIKey],
+		Version: "2", // required field for ngrok CLI to work when file-based configuration is used; automatically configured by the CLI program and is not configurable by the user
+	}
+	contents, err := yaml.Marshal(&config)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(contents), nil
+}
+
+var defaultApiEnvVarMapping = map[string]sdk.FieldName{
+	"NGROK_API_KEY": fieldname.APIKey,
+}
+
+func TryngrokAPIConfigFile(path string) sdk.Importer {
+	return importer.TryFile(path, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config APIConfig
+		if err := contents.ToYAML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.APIKey == "" || config.Version == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.APIKey: config.APIKey,
+			},
+		})
+	})
+}
+
+type APIConfig struct {
+	APIKey  string `yaml:"api_key"`
+	Version string
+}

--- a/plugins/ngrok/auth_credentials.go
+++ b/plugins/ngrok/auth_credentials.go
@@ -18,9 +18,9 @@ func AuthCredentials() schema.CredentialType {
 		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
 		Fields: []schema.CredentialField{
 			{
-				Name:                fieldname.Authtoken,
+				Name:                fieldname.AuthToken,
 				AlternativeNames:    []string{"Auth Token"},
-				MarkdownDescription: "Authtoken used to authenticate to ngrok.",
+				MarkdownDescription: "AuthToken used to authenticate to ngrok.",
 				Optional:            false,
 				Secret:              true,
 				Composition: &schema.ValueComposition{

--- a/plugins/ngrok/auth_credentials.go
+++ b/plugins/ngrok/auth_credentials.go
@@ -18,9 +18,9 @@ func AuthCredentials() schema.CredentialType {
 		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
 		Fields: []schema.CredentialField{
 			{
-				Name:                fieldname.AuthToken,
+				Name:                fieldname.Authtoken,
 				AlternativeNames:    []string{"Auth Token"},
-				MarkdownDescription: "AuthToken used to authenticate to ngrok.",
+				MarkdownDescription: "Authtoken used to authenticate to ngrok.",
 				Optional:            false,
 				Secret:              true,
 				Composition: &schema.ValueComposition{
@@ -48,7 +48,7 @@ func AuthCredentials() schema.CredentialType {
 
 func ngrokConfig(in sdk.ProvisionInput) ([]byte, error) {
 	config := Config{
-		AuthToken: in.ItemFields[fieldname.AuthToken],
+		AuthToken: in.ItemFields[fieldname.Authtoken],
 		Version:   "2", // required field for ngrok CLI to work when file-based configuration is used; automatically configured by the CLI program and is not configurable by the user
 	}
 	contents, err := yaml.Marshal(&config)
@@ -59,7 +59,7 @@ func ngrokConfig(in sdk.ProvisionInput) ([]byte, error) {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"NGROK_AUTHTOKEN": fieldname.AuthToken,
+	"NGROK_AUTHTOKEN": fieldname.Authtoken,
 }
 
 func TryngrokConfigFile(path string) sdk.Importer {
@@ -76,7 +76,7 @@ func TryngrokConfigFile(path string) sdk.Importer {
 
 		out.AddCandidate(sdk.ImportCandidate{
 			Fields: map[sdk.FieldName]string{
-				fieldname.AuthToken: config.AuthToken,
+				fieldname.Authtoken: config.AuthToken,
 			},
 		})
 	})

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -31,6 +31,25 @@ func Credentials() schema.CredentialType {
 					},
 				},
 			},
+		},
+		DefaultCredential:  true,
+		DefaultProvisioner: provision.TempFile(ngrokConfig, provision.Filename("config.yml"), provision.AddArgs("--config", "{{ .Path }}")),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			importer.MacOnly(
+				TryngrokConfigFile("~/Library/Application Support/ngrok/ngrok.yml"),
+			),
+			importer.LinuxOnly(
+				TryngrokConfigFile("~/.config/ngrok/ngrok.yml"),
+			),
+		)}
+}
+
+func CredentialsAPI() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.Credentials,
+		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
+		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,
 				MarkdownDescription: "API Key used to authenticate to ngrok API.",

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -14,7 +14,7 @@ import (
 
 func Credentials() schema.CredentialType {
 	return schema.CredentialType{
-		Name:    credname.Credentials,
+		Name:    credname.AuthToken,
 		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
 		Fields: []schema.CredentialField{
 			{
@@ -47,7 +47,7 @@ func Credentials() schema.CredentialType {
 
 func CredentialsAPI() schema.CredentialType {
 	return schema.CredentialType{
-		Name:    credname.Credentials,
+		Name:    credname.APIKey,
 		DocsURL: sdk.URL("https://ngrok.com/docs/ngrok-agent/config"),
 		Fields: []schema.CredentialField{
 			{

--- a/plugins/ngrok/credentials_test.go
+++ b/plugins/ngrok/credentials_test.go
@@ -9,11 +9,10 @@ import (
 )
 
 func TestCredentialsProvisioner(t *testing.T) {
-	plugintest.TestProvisioner(t, Credentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+	plugintest.TestProvisioner(t, AuthCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"temp file": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-				fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 			},
 			CommandLine: []string{"ngrok"},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -29,17 +28,15 @@ func TestCredentialsProvisioner(t *testing.T) {
 }
 
 func TestCredentialsImporter(t *testing.T) {
-	plugintest.TestImporter(t, Credentials().Importer, map[string]plugintest.ImportCase{
+	plugintest.TestImporter(t, AuthCredentials().Importer, map[string]plugintest.ImportCase{
 		"environment": {
 			Environment: map[string]string{
 				"NGROK_AUTHTOKEN": "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-				"NGROK_API_KEY":   "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
 						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},
@@ -53,7 +50,6 @@ func TestCredentialsImporter(t *testing.T) {
 				{
 					Fields: map[sdk.FieldName]string{
 						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},
@@ -67,7 +63,6 @@ func TestCredentialsImporter(t *testing.T) {
 				{
 					Fields: map[sdk.FieldName]string{
 						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
 					},
 				},
 			},

--- a/plugins/ngrok/credentials_test.go
+++ b/plugins/ngrok/credentials_test.go
@@ -12,7 +12,7 @@ func TestCredentialsProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, AuthCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"temp file": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+				fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
 			},
 			CommandLine: []string{"ngrok"},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -36,7 +36,7 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
 					},
 				},
 			},
@@ -49,7 +49,7 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
 					},
 				},
 			},
@@ -62,7 +62,7 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.AuthToken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
+						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
 					},
 				},
 			},

--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -8,10 +8,6 @@ import (
 )
 
 func ngrokCLI() schema.Executable {
-
-	var cmds []string
-	cmds = append(cmds, "api")
-
 	return schema.Executable{
 		Name:    "ngrok CLI",
 		Runs:    []string{"ngrok"},
@@ -26,12 +22,11 @@ func ngrokCLI() schema.Executable {
 
 		Uses: []schema.CredentialUsage{
 			{
-				Name:    credname.AuthToken,
-				Default: true,
+				Name: credname.AuthToken,
 			},
 			{
-				Name:     credname.APIKey,
-				Commands: cmds,
+				Name:      credname.APIKey,
+				NeedsAuth: needsauth.ForCommand("api"),
 			},
 		},
 	}

--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -8,6 +8,10 @@ import (
 )
 
 func ngrokCLI() schema.Executable {
+
+	var cmds []string
+	cmds = append(cmds, "api")
+
 	return schema.Executable{
 		Name:    "ngrok CLI",
 		Runs:    []string{"ngrok"},
@@ -19,9 +23,15 @@ func ngrokCLI() schema.Executable {
 			needsauth.NotForExactArgs("config"),
 			needsauth.NotForExactArgs("update"),
 		),
+
 		Uses: []schema.CredentialUsage{
 			{
-				Name: credname.Credentials,
+				Name:    credname.AuthToken,
+				Default: true,
+			},
+			{
+				Name:     credname.APIKey,
+				Commands: cmds,
 			},
 		},
 	}

--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -19,7 +19,7 @@ func ngrokCLI() schema.Executable {
 			needsauth.NotForExactArgs("config"),
 			needsauth.NotForExactArgs("update"),
 		),
-		AuthPrompt: "ngrok uses an Authtoken for most commands, and the api command requires an API Token to be configured.",
+		AuthPrompt: "ngrok uses an Authtoken for most commands, and an API token for `ngrok api` commands.",
 
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -19,6 +19,7 @@ func ngrokCLI() schema.Executable {
 			needsauth.NotForExactArgs("config"),
 			needsauth.NotForExactArgs("update"),
 		),
+		AuthPrompt: "ngrok uses an Authtoken for most commands, and the api command requires an API Token to be configured.",
 
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/ngrok/plugin.go
+++ b/plugins/ngrok/plugin.go
@@ -13,8 +13,8 @@ func New() schema.Plugin {
 			Homepage: sdk.URL("https://ngrok.com"),
 		},
 		Credentials: []schema.CredentialType{
-			Credentials(),
-			CredentialsAPI(),
+			AuthCredentials(),
+			APICredentials(),
 		},
 		Executables: []schema.Executable{
 			ngrokCLI(),

--- a/plugins/ngrok/plugin.go
+++ b/plugins/ngrok/plugin.go
@@ -14,6 +14,7 @@ func New() schema.Plugin {
 		},
 		Credentials: []schema.CredentialType{
 			Credentials(),
+			CredentialsAPI(),
 		},
 		Executables: []schema.Executable{
 			ngrokCLI(),

--- a/plugins/ngrok/test-fixtures/config.yml
+++ b/plugins/ngrok/test-fixtures/config.yml
@@ -1,3 +1,2 @@
 authtoken: uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE
-api_key: L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE
 version: "2"

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -24,6 +24,9 @@ type CredentialType struct {
 	// (Optional) A function to scan the system for occurences of this credential type.
 	Importer sdk.Importer
 
+	// (Optional) Whether this is the type of credential to default to
+	DefaultCredential bool
+
 	// The default provisioner to use for this credential if the executable doesn't override it.
 	DefaultProvisioner sdk.Provisioner
 }

--- a/sdk/schema/executable.go
+++ b/sdk/schema/executable.go
@@ -23,6 +23,9 @@ type Executable struct {
 
 	// (Optional) Whether the exectuable needs authentication for certain args.
 	NeedsAuth sdk.NeedsAuthentication
+
+	// (Optional) words to prompt about a credential
+	AuthPrompt string
 }
 
 type CredentialUsage struct {

--- a/sdk/schema/executable.go
+++ b/sdk/schema/executable.go
@@ -37,6 +37,12 @@ type CredentialUsage struct {
 	// set in the credential schema, so should only be used if this executable requires a custom configuration, that deviates
 	// from the way the credential is usually provisioned.
 	Provisioner sdk.Provisioner
+
+	// add a field for command used with the credential
+	Commands []string
+
+	// whether this is the default credential
+	Default bool
 }
 
 func (e Executable) Validate() (bool, ValidationReport) {

--- a/sdk/schema/executable.go
+++ b/sdk/schema/executable.go
@@ -24,7 +24,7 @@ type Executable struct {
 	// (Optional) Whether the exectuable needs authentication for certain args.
 	NeedsAuth sdk.NeedsAuthentication
 
-	// (Optional) words to prompt about a credential
+	// (Optional) Prompt to explain what credentials are for when there are multiple.
 	AuthPrompt string
 }
 
@@ -41,7 +41,7 @@ type CredentialUsage struct {
 	// from the way the credential is usually provisioned.
 	Provisioner sdk.Provisioner
 
-	// (Optional) Whether the credential is specific to a specific argument
+	// (Optional) Whether the credential is needed for authentication with a specific argument
 	NeedsAuth sdk.NeedsAuthentication
 }
 

--- a/sdk/schema/executable.go
+++ b/sdk/schema/executable.go
@@ -38,11 +38,8 @@ type CredentialUsage struct {
 	// from the way the credential is usually provisioned.
 	Provisioner sdk.Provisioner
 
-	// add a field for command used with the credential
-	Commands []string
-
-	// whether this is the default credential
-	Default bool
+	// (Optional) Whether the credential is specific to a specific argument
+	NeedsAuth sdk.NeedsAuthentication
 }
 
 func (e Executable) Validate() (bool, ValidationReport) {

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -83,12 +83,6 @@ func (p Plugin) Validate() (bool, ValidationReport) {
 	})
 
 	report.AddCheck(ValidationCheck{
-		Description: "Has no more than one credential type defined. Plugins with multiple credential types are not supported yet",
-		Assertion:   len(p.Credentials) == 1,
-		Severity:    ValidationSeverityError,
-	})
-
-	report.AddCheck(ValidationCheck{
 		Description: "Has no more than one executable defined. Plugins with multiple executables are not supported yet",
 		Assertion:   len(p.Executables) == 1,
 		Severity:    ValidationSeverityError,

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -21,16 +21,6 @@ type Plugin struct {
 	Executables []Executable
 }
 
-// Return the default credential for a plugin, or the first one in the list if it isn't set
-func (p Plugin) DefaultCredentialType() CredentialType {
-	for _, q := range p.Credentials {
-		if q.DefaultCredential {
-			return q
-		}
-	}
-	return p.Credentials[0]
-}
-
 // PlatformInfo provides information on the platform of the shell plugin.
 type PlatformInfo struct {
 	// The display name of the platform, e.g. "AWS" or "GitHub".

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -21,6 +21,16 @@ type Plugin struct {
 	Executables []Executable
 }
 
+// Return the default credential for a plugin, or the first one in the list if it isn't set
+func (p Plugin) DefaultCredentialType() CredentialType {
+	for _, q := range p.Credentials {
+		if q.DefaultCredential {
+			return q
+		}
+	}
+	return p.Credentials[0]
+}
+
 // PlatformInfo provides information on the platform of the shell plugin.
 type PlatformInfo struct {
 	// The display name of the platform, e.g. "AWS" or "GitHub".


### PR DESCRIPTION
also map to a command

Using ngrok as an axample, add functionality to have multiple credential types, such as auth token and api token. This means also adding the ability to set a credential type as the default, and mapping commands to a credential type. There will be op changes to match to these.