### PR TITLE
Add support for Gitea (tea)

### DIFF
--- a/plugins/gitea/personal_access_token.go
+++ b/plugins/gitea/personal_access_token.go
@@ -1,0 +1,120 @@
+package gitea
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+	"gopkg.in/yaml.v2"
+)
+
+var configPath string = "~/.config/tea/config.yml"
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAccessToken,
+		DocsURL:       sdk.URL("https://gitea.com/user/settings/applications"),
+		ManagementURL: nil,
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Gitea.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 40,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.HostAddress,
+				MarkdownDescription: "The Gitea host to connect to, should start with https://",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Uppercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+					Prefix: "https://",
+				},
+			},
+			{
+				Name:                fieldname.User,
+				MarkdownDescription: "Your Gitea username",
+				Secret:              false,
+			},
+		},
+		DefaultProvisioner: provision.TempFile(giteaConfig, provision.AtFixedPath(configPath)),
+		Importer: importer.TryAll(
+			TryGiteaConfigFile(),
+		)}
+}
+
+func giteaConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		Logins: []Login{
+			{
+				Name:    in.ItemFields[fieldname.HostAddress],
+				URL:     in.ItemFields[fieldname.HostAddress],
+				Token:   in.ItemFields[fieldname.Token],
+				Default: true,
+				User:    in.ItemFields[fieldname.User],
+			},
+		},
+	}
+	contents, err := yaml.Marshal(&config)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(contents), nil
+}
+
+func TryGiteaConfigFile() sdk.Importer {
+	return importer.TryFile(configPath, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToYAML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for _, login := range config.Logins {
+			out.AddCandidate(sdk.ImportCandidate{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token:       login.Token,
+					fieldname.HostAddress: login.URL,
+					fieldname.User:        login.User,
+				},
+				NameHint: importer.SanitizeNameHint(login.Name),
+			})
+		}
+	})
+}
+
+type Login struct {
+	Name              string `yaml:"name"`
+	URL               string `yaml:"url"`
+	Token             string `yaml:"token"`
+	Default           bool   `yaml:"default"`
+	SSHHost           string `yaml:"ssh_host"`
+	SSHKey            string `yaml:"ssh_key"`
+	Insecure          bool   `yaml:"insecure"`
+	SSHCertPrincipal  string `yaml:"ssh_certificate_principal"`
+	SSHAgent          bool   `yaml:"ssh_agent"`
+	SSHKeyFingerprint string `yaml:"ssh_key_agent_pub"`
+	SSHPassphrase     string `yaml:"-"`
+	VersionCheck      bool   `yaml:"version_check"`
+	User              string `yaml:"user"`
+	Created           int64  `yaml:"created"`
+}
+
+type Config struct {
+	Logins []Login `yaml:"logins"`
+}

--- a/plugins/gitea/personal_access_token_test.go
+++ b/plugins/gitea/personal_access_token_test.go
@@ -1,0 +1,57 @@
+package gitea
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token:       "oyyfsny27bgphldmhvffxhhlmqvdkzjrfslrsj9f",
+				fieldname.HostAddress: "https://git.example.com",
+				fieldname.User:        "example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					"~/.config/tea/config.yml": {
+						Contents: []byte(plugintest.LoadFixture(t, "config.yml")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+
+		"config file": {
+			Files: map[string]string{
+				"~/.config/tea/config.yml": plugintest.LoadFixture(t, "import_config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:       "oyyfsny27bgphldmhvffxhhlmqvdkzjrfslrsj9f",
+						fieldname.HostAddress: "https://git.example.com",
+						fieldname.User:        "example",
+					},
+					NameHint: "git.example.com",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:       "enjkarzu2ca5ffcnvzaczxncuczeoq9utlpqqrzs",
+						fieldname.HostAddress: "https://gitea.com",
+						fieldname.User:        "example@example.com",
+					},
+					NameHint: "gitea.com",
+				},
+			},
+		},
+	})
+}

--- a/plugins/gitea/plugin.go
+++ b/plugins/gitea/plugin.go
@@ -1,0 +1,22 @@
+package gitea
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "gitea",
+		Platform: schema.PlatformInfo{
+			Name:     "Gitea",
+			Homepage: sdk.URL("https://gitea.com/"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			giteaCLI(),
+		},
+	}
+}

--- a/plugins/gitea/tea.go
+++ b/plugins/gitea/tea.go
@@ -1,0 +1,26 @@
+package gitea
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func giteaCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Gitea CLI",
+		Runs:    []string{"tea"},
+		DocsURL: sdk.URL("https://gitea.com/gitea/tea/src/branch/main/README.md"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("h"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/gitea/test-fixtures/config.yml
+++ b/plugins/gitea/test-fixtures/config.yml
@@ -1,0 +1,14 @@
+logins:
+- name: https://git.example.com
+  url: https://git.example.com
+  token: oyyfsny27bgphldmhvffxhhlmqvdkzjrfslrsj9f
+  default: true
+  ssh_host: ""
+  ssh_key: ""
+  insecure: false
+  ssh_certificate_principal: ""
+  ssh_agent: false
+  ssh_key_agent_pub: ""
+  version_check: false
+  user: example
+  created: 0

--- a/plugins/gitea/test-fixtures/import_config.yml
+++ b/plugins/gitea/test-fixtures/import_config.yml
@@ -1,0 +1,23 @@
+logins:
+- name: git.example.com
+  url: https://git.example.com
+  token: oyyfsny27bgphldmhvffxhhlmqvdkzjrfslrsj9f
+  default: false
+  ssh_host: git.example.com
+  ssh_key: ~/.ssh/id_ed25519
+  insecure: false
+  user: example
+  created: 1479340800000
+- name: gitea.com
+  url: https://gitea.com
+  token: enjkarzu2ca5ffcnvzaczxncuczeoq9utlpqqrzs
+  default: false
+  ssh_host: git.example.com
+  ssh_key: ~/.ssh/id_ed25519
+  insecure: true
+  user: example@example.com
+  created: 1479340800000
+preferences:
+  editor: false
+  flag_defaults:
+    remote: ""


### PR DESCRIPTION
Plugin for Gitea CLI (aka tea)

Addresses #204 

## Testing

### Prerequisites
- Sign up for [Gitea](https://gitea.com) (This step can be skipped if you're already hosting your own Gitea instance)
- Install [tea](https://gitea.com/gitea/tea)
- Build the plugin locally: `make gitea/build`

### Setup
- Create an application access token either at (Gitea.com)[https://gitea.com/user/settings/applications] or on your own instance (User Settings → Applications)
- Initialise the Tea plugin or use `tea login add` to sign in with a username & password which will then be imported.

## Provisioner
Tea stores a config file in ~/.config/tea/config.yml with the token, user, & url amongst other preferences.

## Issues
Tea reads the credentials from a set location which creates a couple of issues:
- If the config file already exists the plugin will fail. Removing this file once the plugin is configured is a good idea anyway.
- Skimming through the source it reads the file from $XDG_CONFIG_HOME if this is set to a location other than ~/.config the plugin will not work.
- After running `op plugin init tea` the alias is not setup and I'm not sure why.

## Notes
As far as I can tell there is no way to pass credentials through ENV or to pass the location of the config though ENV/flags either. 
Flags can be used to set the token, user, & url along with a blank password (--password " ") however the credentials are then stored in the config.yml.