### PR TITLE
new(clilol): New clilol plugin that connects to the omg.lol platform

### DIFF
--- a/plugins/clilol/api_key.go
+++ b/plugins/clilol/api_key.go
@@ -1,0 +1,66 @@
+package clilol
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		ManagementURL: sdk.URL("https://home.omg.lol/account#api-key"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Address,
+				MarkdownDescription: "Your omg.lol address.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Length: 63,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Uppercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Email,
+				MarkdownDescription: "Your omg.lol account email address.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Uppercase: true,
+						Digits:    true,
+						Specific:  []rune{'@', '.'},
+					},
+				},
+			},
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to omg.lol.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 32,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"CLILOL_ADDRESS": fieldname.Address,
+	"CLILOL_EMAIL":   fieldname.Email,
+	"CLILOL_APIKEY":  fieldname.APIKey,
+}

--- a/plugins/clilol/api_key_test.go
+++ b/plugins/clilol/api_key_test.go
@@ -1,0 +1,49 @@
+package clilol
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Address: "SyzkKWR6Pb4zspdKyji0ZFqSqw2v832uOUkaverJzsmwL5kqImIhD4XREXAMPLE",
+				fieldname.Email:   "example@example.com",
+				fieldname.APIKey:  "tnoe59h3w6jiv4tp0x9o72szmexample",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"CLILOL_ADDRESS": "SyzkKWR6Pb4zspdKyji0ZFqSqw2v832uOUkaverJzsmwL5kqImIhD4XREXAMPLE",
+					"CLILOL_EMAIL":   "example@example.com",
+					"CLILOL_APIKEY":  "tnoe59h3w6jiv4tp0x9o72szmexample",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"CLILOL_ADDRESS": "SyzkKWR6Pb4zspdKyji0ZFqSqw2v832uOUkaverJzsmwL5kqImIhD4XREXAMPLE",
+				"CLILOL_EMAIL":   "example@example.com",
+				"CLILOL_APIKEY":  "tnoe59h3w6jiv4tp0x9o72szmexample",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Address: "SyzkKWR6Pb4zspdKyji0ZFqSqw2v832uOUkaverJzsmwL5kqImIhD4XREXAMPLE",
+						fieldname.Email:   "example@example.com",
+						fieldname.APIKey:  "tnoe59h3w6jiv4tp0x9o72szmexample",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/clilol/clilol.go
+++ b/plugins/clilol/clilol.go
@@ -1,0 +1,25 @@
+package clilol
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func omglolCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "clilol",
+		Runs:    []string{"clilol"},
+		DocsURL: sdk.URL("https://mcornick.com/clilol/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/clilol/plugin.go
+++ b/plugins/clilol/plugin.go
@@ -1,0 +1,22 @@
+package clilol
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "clilol",
+		Platform: schema.PlatformInfo{
+			Name:     "omg.lol",
+			Homepage: sdk.URL("https://omg.lol"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			omglolCLI(),
+		},
+	}
+}

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -24,6 +24,7 @@ const (
 	Credentials     = sdk.FieldName("Credentials")
 	Database        = sdk.FieldName("Database")
 	DefaultRegion   = sdk.FieldName("Default Region")
+	Email           = sdk.FieldName("Email")
 	Endpoint        = sdk.FieldName("Endpoint")
 	Host            = sdk.FieldName("Host")
 	HostAddress     = sdk.FieldName("Host Address")
@@ -69,6 +70,7 @@ func ListAll() []sdk.FieldName {
 		Credentials,
 		Database,
 		DefaultRegion,
+		Email,
 		Endpoint,
 		Host,
 		HostAddress,


### PR DESCRIPTION
[omg.lol](https://omg.lol/) is a platform run by an individual ([Adam](https://adam.omg.lol/)) and offers a variety of online services with [cool domains](https://home.omg.lol/info/service-domains). It's a bit popular among the 1Password staff as well!

[clilol](https://mcornick.com/clilol/) is a third-party-developed CLI program for the omg.lol platform: [announcement post](https://discourse.lol/t/announce-clilol-version-1-0-0-released/211).

This PR is an ongoing work. It supports environment-variable based importing and provisioning for now, but there are configuration files that we could import as well:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/18581859/226386004-5a8cf353-fcc9-486f-b7bb-f5bf1903ce92.png">

Marking PR as a draft until that's completed.