### PR TITLE
Make Sourcegraph endpoint optional

### DIFF
--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -18,6 +18,7 @@ func AccessToken() schema.CredentialType {
 				Name:                fieldname.Endpoint,
 				MarkdownDescription: "Base URL for your Sourcegraph instance.",
 				Secret:              false,
+				Optional:            true,
 				Composition: &schema.ValueComposition{
 					Charset: schema.Charset{
 						Lowercase: true,


### PR DESCRIPTION
The [Sourcegraph](https://docs.sourcegraph.com) plugin currently _requires_ the endpoint field, but I'm not sure that's necessary because Sourcegraph also has a main API. 

@arunsathiya Was there a reason for this, or can we make it optional?