### PR TITLE
fix(tea): use `os.UserConfigDir` to find config

### DIFF
--- a/plugins/gitea/personal_access_token_test.go
+++ b/plugins/gitea/personal_access_token_test.go
@@ -18,7 +18,7 @@ func TestPersonalAccessTokenProvisioner(t *testing.T) {
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Files: map[string]sdk.OutputFile{
-					"~/.config/tea/config.yml": {
+					ConfigPath(): {
 						Contents: []byte(plugintest.LoadFixture(t, "config.yml")),
 					},
 				},
@@ -32,7 +32,7 @@ func TestPersonalAccessTokenImporter(t *testing.T) {
 
 		"config file": {
 			Files: map[string]string{
-				"~/.config/tea/config.yml": plugintest.LoadFixture(t, "import_config.yml"),
+				ConfigPath(): plugintest.LoadFixture(t, "import_config.yml"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{


### PR DESCRIPTION
On macOS, `tea` writes its configuration to
`~/Library/Application Support/tea` and not `~/.config/tea`. This breaks the tea plugin. Go provides `os.UserConfigDir` to abstract the location of the config directory, so use that to fix macOS while not breaking Linux. In case `os.UserConfigDir` fails, fall back to `~/.config/tea` (this shouldn't happen unless something weird is going on, like the user's $HOME is not set.)