### PR TITLE
Search alternative config directories when building a plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-plugins_dir := ~/.op/plugins/local
+config_dir := $(shell go run cmd/contrib/scripts/main.go)
+plugins_dir := ${config_dir}/plugins/local
 
 .PHONY: new-plugin registry %/example-secrets %/validate %/build test
 
@@ -27,8 +28,8 @@ validate: registry
 $(plugins_dir):
 	mkdir -p $(plugins_dir)
 	chmod 700 $(plugins_dir)
-	chmod 700 ~/.op
-	chmod 700 ~/.op/plugins
+	chmod 700 ${config_dir}
+	chmod 700 ${config_dir}/plugins
 
 %/build: $(plugins_dir) registry beta-notice
 	$(eval plugin := $(firstword $(subst /, ,$@)))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-config_dir := $(shell go run cmd/contrib/scripts/main.go)
+config_dir := $(shell go run cmd/contrib/scripts/config_dir_getter.go)
 plugins_dir := ${config_dir}/plugins/local
 
 .PHONY: new-plugin registry %/example-secrets %/validate %/build test

--- a/cmd/contrib/scripts/config_dir_getter.go
+++ b/cmd/contrib/scripts/config_dir_getter.go
@@ -10,16 +10,18 @@ import (
 
 // Retrieve the config directory to read or write to
 func main() {
-	opConfigDir, _ := os.LookupEnv("OP_CONFIG_DIR")
-	xdgConfigHome, _ := os.LookupEnv("XDG_CONFIG_HOME")
-	home, _ := homedir.Dir()
-
 	// This logic is based on the order of precedence outlined in the CLI documentation:
 	// https://developer.1password.com/docs/cli/config-directories
-	configDirPaths := []string{}
-	if opConfigDir != "" {
-		configDirPaths = append(configDirPaths, opConfigDir)
+
+	// If OP_CONFIG_DIR is set, use it immediately
+	if opConfigDir, _ := os.LookupEnv("OP_CONFIG_DIR"); opConfigDir != "" {
+		fmt.Print(opConfigDir)
+		return
 	}
+
+	xdgConfigHome, _ := os.LookupEnv("XDG_CONFIG_HOME")
+	home, _ := homedir.Dir()
+	configDirPaths := []string{}
 	if home != "" {
 		// Legacy home
 		configDirPaths = append(configDirPaths, filepath.Join(home, ".op"))
@@ -45,8 +47,8 @@ func main() {
 		}
 	}
 
-	// If we reach this point then none of those directories exist (op is executed
-	// for the first time). Default to the last entry in the list.
+	// None of those directories exist and OP_CONFIG_DIR is not set
+	// Default to the last entry in the list
 	if len(configDirPaths) > 0 {
 		fmt.Print(configDirPaths[len(configDirPaths)-1])
 	}

--- a/cmd/contrib/scripts/config_dir_getter.go
+++ b/cmd/contrib/scripts/config_dir_getter.go
@@ -16,8 +16,6 @@ func main() {
 
 	// This logic is based on the order of precedence outlined in the CLI documentation:
 	// https://developer.1password.com/docs/cli/config-directories
-	// Note: At the moment, if the --config flag is being used to specify the config
-	// directory then this script does not search in that location
 	configDirPaths := []string{}
 	if opConfigDir != "" {
 		configDirPaths = append(configDirPaths, opConfigDir)

--- a/cmd/contrib/scripts/main.go
+++ b/cmd/contrib/scripts/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// Retrieve the config directory to read or write to
+func main() {
+	opConfigDir, _ := os.LookupEnv("OP_CONFIG_DIR")
+	xdgConfigHome, _ := os.LookupEnv("XDG_CONFIG_HOME")
+	home, _ := homedir.Dir()
+
+	// This logic is based on the following order of precedence
+	// (for more context, refer to the documentation: https://developer.1password.com/docs/cli/config-directories):
+	// ${OP_CONFIG_DIR}
+	// ${HOME}/.op (legacy)
+	// ${XDG_CONFIG_HOME}/.op (legacy)
+	// ${HOME}/.config/op
+	// ${XDG_CONFIG_HOME}/op
+	// Note: At the moment, if the --config flag is used to specify the config directory
+	// then this script does not search in that location
+	configDirPaths := []string{}
+	if opConfigDir != "" {
+		configDirPaths = append(configDirPaths, opConfigDir)
+	}
+	if home != "" {
+		// Legacy home
+		configDirPaths = append(configDirPaths, filepath.Join(home, ".op"))
+	}
+	if xdgConfigHome != "" {
+		// Legacy xdg
+		configDirPaths = append(configDirPaths, filepath.Join(xdgConfigHome, ".op"))
+	}
+	if home != "" {
+		// New home
+		configDirPaths = append(configDirPaths, filepath.Join(home, ".config", "op"))
+	}
+	if xdgConfigHome != "" {
+		// New xdg
+		configDirPaths = append(configDirPaths, filepath.Join(xdgConfigHome, "op"))
+	}
+
+	for _, configDir := range configDirPaths {
+		fileInfo, err := os.Stat(configDir)
+		if err == nil && fileInfo.IsDir() {
+			fmt.Print(configDir)
+			return
+		}
+	}
+
+	// If we reach this point then none of those directories exist (op is executed
+	// for the first time). Default to the last entry in the list.
+	if len(configDirPaths) > 0 {
+		fmt.Print(configDirPaths[len(configDirPaths)-1])
+	}
+}

--- a/cmd/contrib/scripts/main.go
+++ b/cmd/contrib/scripts/main.go
@@ -21,7 +21,7 @@ func main() {
 	// ${XDG_CONFIG_HOME}/.op (legacy)
 	// ${HOME}/.config/op
 	// ${XDG_CONFIG_HOME}/op
-	// Note: At the moment, if the --config flag is used to specify the config directory
+	// Note: At the moment, if the --config flag is being used to specify the config directory
 	// then this script does not search in that location
 	configDirPaths := []string{}
 	if opConfigDir != "" {

--- a/cmd/contrib/scripts/main.go
+++ b/cmd/contrib/scripts/main.go
@@ -14,15 +14,10 @@ func main() {
 	xdgConfigHome, _ := os.LookupEnv("XDG_CONFIG_HOME")
 	home, _ := homedir.Dir()
 
-	// This logic is based on the following order of precedence
-	// (for more context, refer to the documentation: https://developer.1password.com/docs/cli/config-directories):
-	// ${OP_CONFIG_DIR}
-	// ${HOME}/.op (legacy)
-	// ${XDG_CONFIG_HOME}/.op (legacy)
-	// ${HOME}/.config/op
-	// ${XDG_CONFIG_HOME}/op
-	// Note: At the moment, if the --config flag is being used to specify the config directory
-	// then this script does not search in that location
+	// This logic is based on the order of precedence outlined in the CLI documentation:
+	// https://developer.1password.com/docs/cli/config-directories
+	// Note: At the moment, if the --config flag is being used to specify the config
+	// directory then this script does not search in that location
 	configDirPaths := []string{}
 	if opConfigDir != "" {
 		configDirPaths = append(configDirPaths, opConfigDir)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=


### PR DESCRIPTION
## Summary

Currently, the config directory for shell plugins is hard-coded as `~/.op`. Whenever a user builds a plugin (e.g. `make aws/build`), the plugin executable gets stored at `~/.op/plugins/local`. However, depending on the user's environment, `~/.op` will not always necessarily be the config directory that's used by the CLI. The [CLI documentation](https://developer.1password.com/docs/cli/config-directories/) lists the order of precedence for possible configuration directory locations. We should search for an existing config directory based on that order of precedence and use it if it exists, for the sake of consistency and to avoid situations where multiple config directories get created for users of the CLI that also build their own shell plugins, which could result in issues like this https://www.reddit.com/r/1Password/comments/11jgm6j/error_from_1pw_cli_while_inspecting_gh/.

## How to Test

1. Check the values for the `OP_CONFIG_DIR`, `HOME`, and `XDG_CONFIG_HOME` env variables on your system. 
2. Build a shell plugin, e.g. `make aws/build`. Based on the env var values you found previously, the plugin executable should have been stored in the correct location based on the order of precedence.

## Additional Notes

For general `op` commands when using the CLI, users could specify a custom config directory using the `--config` flag, which takes the highest priority. However, since building for the shell plugins is done using a Makefile, I couldn't think of a good way that a custom config location could be specified in the build flow. Even with this gap, this PR should cover the majority of use cases since I don't anticipate many users rely on the `--config` flag. However, if this is too big of an assumption please let me know.