### PR TITLE
update(ngrok): switch to envvars provisioner for ngrok 3.2.1 and higher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/golang/protobuf v1.3.4 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
+	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/golang/protobuf v1.3.4 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
-	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
@@ -52,6 +51,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
+	golang.org/x/mod v0.9.0
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQ
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-plugin v1.4.6 h1:MDV3UrKQBM3du3G7MApDGvOsMYy3JQJ4exhSoKBAeVA=
 github.com/hashicorp/go-plugin v1.4.6/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQ
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-plugin v1.4.6 h1:MDV3UrKQBM3du3G7MApDGvOsMYy3JQJ4exhSoKBAeVA=
 github.com/hashicorp/go-plugin v1.4.6/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
@@ -138,6 +136,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -45,7 +45,7 @@ func Credentials() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: newNgrokProvisioner(),
+		DefaultProvisioner: ngrokProvisioner(),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
 			importer.MacOnly(

--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -45,7 +45,7 @@ func Credentials() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: ngrokProvisioner(),
+		DefaultProvisioner: ngrokEnvVarProvisioner{},
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
 			importer.MacOnly(

--- a/plugins/ngrok/credentials_test.go
+++ b/plugins/ngrok/credentials_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCredentialsProvisioner(t *testing.T) {
-	plugintest.TestProvisioner(t, Credentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+	plugintest.TestProvisioner(t, ngrokProvisioner(), map[string]plugintest.ProvisionCase{
 		"temp file": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",

--- a/plugins/ngrok/env_var_provisioner.go
+++ b/plugins/ngrok/env_var_provisioner.go
@@ -13,7 +13,7 @@ type ngrokEnvVarProvisioner struct {
 }
 
 func (p ngrokEnvVarProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
-	currentVersion, requiredVersion, err := getNgrokVersion()
+	currentVersion, err := getNgrokVersion()
 	if err != nil {
 		out.AddError(err)
 		return
@@ -24,8 +24,8 @@ func (p ngrokEnvVarProvisioner) Provision(ctx context.Context, in sdk.ProvisionI
 	//
 	// semver.Compare resulting in 0 means 3.2.1 is in use
 	// semver.Compare resulting in +1 means >3.2.1 is in use
-	if semver.Compare(currentVersion, requiredVersion) == -1 {
-		out.AddError(fmt.Errorf("ngrok version %s is not supported. Please upgrade to version %s or higher", currentVersion, requiredVersion))
+	if semver.Compare(currentVersion, envVarAuthVersion) == -1 {
+		out.AddError(fmt.Errorf("ngrok version %s is not supported. Please upgrade to version %s or higher", currentVersion, envVarAuthVersion))
 		return
 	}
 

--- a/plugins/ngrok/env_var_provisioner.go
+++ b/plugins/ngrok/env_var_provisioner.go
@@ -1,0 +1,42 @@
+package ngrok
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+	"golang.org/x/mod/semver"
+)
+
+type ngrokEnvVarProvisioner struct {
+}
+
+func (p ngrokEnvVarProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	currentVersion, requiredVersion, err := getNgrokVersion()
+	if err != nil {
+		out.AddError(err)
+		return
+	}
+
+	// If the current ngrok CLI version is 3.2.1 or higher,
+	// use environment variables to provision the Shell Plugin credentials
+	//
+	// semver.Compare resulting in 0 means 3.2.1 is in use
+	// semver.Compare resulting in +1 means >3.2.1 is in use
+	if semver.Compare(currentVersion, requiredVersion) == -1 {
+		out.AddError(fmt.Errorf("ngrok version %s is not supported. Please upgrade to version %s or higher", currentVersion, requiredVersion))
+		return
+	}
+
+	out.AddEnvVar("NGROK_AUTHTOKEN", in.ItemFields[fieldname.Authtoken])
+	out.AddEnvVar("NGROK_API_KEY", in.ItemFields[fieldname.APIKey])
+}
+
+func (p ngrokEnvVarProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Nothing to do here: environment variables get wiped automatically when the process exits.
+}
+
+func (p ngrokEnvVarProvisioner) Description() string {
+	return "Provision ngrok credentials as environment variables NGROK_AUTH_TOKEN and NGROK_API_KEY"
+}

--- a/plugins/ngrok/ngrok.go
+++ b/plugins/ngrok/ngrok.go
@@ -23,7 +23,8 @@ func ngrokCLI() schema.Executable {
 		),
 		Uses: []schema.CredentialUsage{
 			{
-				Name: credname.Credentials,
+				Name:        credname.Credentials,
+				Provisioner: ngrokProvisioner(),
 			},
 		},
 	}

--- a/plugins/ngrok/provisioner.go
+++ b/plugins/ngrok/provisioner.go
@@ -41,9 +41,8 @@ func ngrokProvisioner() sdk.Provisioner {
 	//
 	// semver.Compare resulting in 0 means 3.2.1 is in use
 	// semver.Compare resulting in +1 means >3.2.1 is in use
-	if semver.Compare(currentVersion, envVarAuthVersion) == 0 || semver.Compare(currentVersion, envVarAuthVersion) == +1 {
-		newNgrokEnvVarProvisioner := ngrokEnvVarProvisioner{}
-		newNgrokEnvVarProvisioner.Provision(context.Background(), sdk.ProvisionInput{}, &sdk.ProvisionOutput{})
+	if semver.Compare(currentVersion, envVarAuthVersion) >= 0 {
+		return ngrokEnvVarProvisioner{}
 	}
 
 	// Otherwise use config file to provision credentials

--- a/plugins/ngrok/provisioner.go
+++ b/plugins/ngrok/provisioner.go
@@ -28,7 +28,7 @@ const (
 type fileProvisioner struct {
 }
 
-func newNgrokProvisioner() sdk.Provisioner {
+func ngrokProvisioner() sdk.Provisioner {
 	cmd := exec.Command("ngrok", "--version")
 	versionByte, err := cmd.Output()
 	if err != nil {

--- a/plugins/ngrok/provisioner.go
+++ b/plugins/ngrok/provisioner.go
@@ -3,7 +3,6 @@ package ngrok
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,7 +31,7 @@ func ngrokProvisioner() sdk.Provisioner {
 	cmd := exec.Command("ngrok", "--version")
 	ngrokVersion, err := cmd.Output()
 	if err != nil {
-		log.Fatalf(err.Error())
+		return fileProvisioner{}
 	}
 
 	// Example: "ngrok version 3.1.1\n" to "3.1.1\n"


### PR DESCRIPTION
Fixes https://github.com/1Password/shell-plugins/issues/216 and fixes https://github.com/1Password/shell-plugins/issues/274

## Description

This PR updates the ngrok Shell Plugin to use environment variables to provision credentials when the ngrok CLI is 3.2.1 or higher. We'd retain the config file-based provisioner for older versions.

## Testing instructions

- Make sure there isn't a ngrok config file on your computer at [the path depending on your OS](https://ngrok.com/docs/ngrok-agent/config/#default-locations). (This is important because as of https://github.com/1Password/shell-plugins/pull/194, we detect such configuration files and merge with 1Password-generated configuration file)
- Check ngrok version by running `ngrok --version`. If it's 3.2.1 or higher, any `ngrok api` command (example `ngrok api tunnels list`) should succeed. During this run, the credentials are provisioned using the NGROK_AUTH_TOKEN and NGROK_API_KEY environment variables. (Note that [only NGROK_API_KEY is new as of 3.2.1](https://ngrok.com/docs/ngrok-agent/changelog/#ngrok-agent-321---2023-03-13), NGROK_AUTH_TOKEN was already supported in previous versions)
- If the version is 3.1.1 or older, `ngrok api tunnels list` should still succeed, but this time the provisioning happens with configuration files.

## Another way to test

- Checkout this branch and switch to it.
- In the file `plugins/ngrok/provisioner.go`, change `return fileProvisioner{}` to `return provision.EnvVars(defaultEnvVarMapping)` (line 64)
- With ngrok 3.1.1, run `ngrok api tunnels list`. It should fail with `ERROR:  API key is missing; either use '--api-key' flag or set it as 'api_key' in the configuration file` because at this point the provisioning happens with the env vars NGROK_AUTH_TOKEN and NGROK_API_KEY of which NGROK_API_KEY is not supported on 3.1.1

## Download ngrok 3.1.1

To download ngrok 3.1.1, download the binary from one of these two links depending on your system architecture:

https://github.com/ngrok/homebrew-ngrok/blob/668bb053898e0f767916083f3fdeaf4a0f6eac84/Casks/ngrok.rb#L4-L10

And then run `sudo unzip ~/Downloads/ngrok-v3-3.1.1-darwin-arm64.zip -d /usr/local/bin`

Ensure you are running the ngrok binary that you downloaded now by running `which ngrok`. You don't want to be testing with another binary, say Homebrew's version if you had it installed previously. `which ngrok` should read `/usr/local/bin/ngrok`

