### PR TITLE
Add correct credential name to Treasure Data executable

### DIFF
--- a/plugins/treasuredata/td.go
+++ b/plugins/treasuredata/td.go
@@ -20,7 +20,7 @@ func TreasureDataCLI() schema.Executable {
 		),
 		Uses: []schema.CredentialUsage{
 			{
-				Name: credname.AccessKey,
+				Name: credname.APIKey,
 			},
 		},
 	}


### PR DESCRIPTION
While the credential name within the Treasure Data plugin is `API Key`, the executable references `Access Key`. 

This MR fixes this issue.