### PR TITLE
Check that all executable credentials are defined in the plugin

### DIFF
--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -84,6 +84,12 @@ func (p Plugin) Validate() (bool, ValidationReport) {
 		Severity:    ValidationSeverityError,
 	})
 
+	report.AddCheck(ValidationCheck{
+		Description: "All the executables within the plugin using credentials included in the plugin definition",
+		Assertion:   CredentialReferencesInCredentialList(p),
+		Severity:    ValidationSeverityError,
+	})
+
 	return report.IsValid(), report
 }
 

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -85,7 +85,7 @@ func (p Plugin) Validate() (bool, ValidationReport) {
 	})
 
 	report.AddCheck(ValidationCheck{
-		Description: "All the executables within the plugin using credentials included in the plugin definition",
+		Description: "Credentials referenced in executables are included in the same plugin definition",
 		Assertion:   CredentialReferencesInCredentialList(p),
 		Severity:    ValidationSeverityError,
 	})

--- a/sdk/schema/validation.go
+++ b/sdk/schema/validation.go
@@ -94,3 +94,21 @@ func ContainsLowercaseLettersOrDigits(str string) bool {
 	}
 	return matched
 }
+
+func CredentialReferencesInCredentialList(plugin Plugin) bool {
+	for _, executable := range plugin.Executables {
+		for _, execCredential := range executable.Uses {
+			found := false
+			for _, credential := range plugin.Credentials {
+				if execCredential.Name == credential.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
https://github.com/1Password/shell-plugins/pull/225 showed that currently, errors where undefined credentials can be referenced within the executable can happen.

This adds a validation check that will take place automatically, in the CI pipeline.