### PR TITLE
Add ManagementURL for Sourcegraph plugin

### DIFF
--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -11,8 +11,9 @@ import (
 
 func AccessToken() schema.CredentialType {
 	return schema.CredentialType{
-		Name:    credname.AccessToken,
-		DocsURL: sdk.URL("https://docs.sourcegraph.com/cli"),
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://docs.sourcegraph.com/cli"),
+		ManagementURL: sdk.URL("https://sourcegraph.com/user/settings/tokens"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Endpoint,


### PR DESCRIPTION
In the dashboard the management URL is dynamic; It contains the username: https://sourcegraph.com/users/<username>/settings/token

That's probably why it wasn't included in the first iteration of this plugin.

I just found that https://sourcegraph.com/user/settings/tokens redirects to the management URL for the currently logged in user. Sourcegraph also uses this in the 'src login' command, so it should be safe to use that here as well.