### PR TITLE
chore(docs): add `<p>` tag to force line break

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ No more plaintext credentials in your home directory. Automatically authenticate
   <img alt="Picture changing depending on light mode." src="https://user-images.githubusercontent.com/45081667/226969008-0a3f7537-7942-442f-9170-18b008a6574c.png">
 
 </picture>
-See all...
+<p>See all...</p>
 </a>
 </p>
 


### PR DESCRIPTION
If you go to the wide view of README.md https://github.com/1Password/shell-plugins/blob/main/README.md

The "Show all..." text is inline next to the image instead of below it. Surrounding with `<p>` fixes that.