### PR TITLE
Correct ngrok credential lengths

### DIFF
--- a/plugins/ngrok/credentials.go
+++ b/plugins/ngrok/credentials.go
@@ -22,7 +22,7 @@ func Credentials() schema.CredentialType {
 				Optional:            false,
 				Secret:              true,
 				Composition: &schema.ValueComposition{
-					Length: 43,
+					Length: 49,
 					Charset: schema.Charset{
 						Uppercase: true,
 						Lowercase: true,
@@ -36,7 +36,7 @@ func Credentials() schema.CredentialType {
 				Optional:            true,
 				Secret:              true,
 				Composition: &schema.ValueComposition{
-					Length: 48,
+					Length: 49,
 					Charset: schema.Charset{
 						Uppercase: true,
 						Lowercase: true,

--- a/plugins/ngrok/credentials_test.go
+++ b/plugins/ngrok/credentials_test.go
@@ -13,8 +13,8 @@ func TestCredentialsProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, Credentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"temp file": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-				fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+				fieldname.Authtoken: "cxG2Im21Yzkh8VnvFQaetlPHcQ9ZDUUk1IzzyHhcGcEXAMPLE",
+				fieldname.APIKey:    "NQdxymVXmWC15916Mmy1vYkpzzNG6a84Bo4mYKuDahEXAMPLE",
 			},
 			CommandLine: []string{"ngrok"},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -33,14 +33,14 @@ func TestCredentialsImporter(t *testing.T) {
 	plugintest.TestImporter(t, Credentials().Importer, map[string]plugintest.ImportCase{
 		"environment": {
 			Environment: map[string]string{
-				"NGROK_AUTHTOKEN": "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-				"NGROK_API_KEY":   "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+				"NGROK_AUTHTOKEN": "cxG2Im21Yzkh8VnvFQaetlPHcQ9ZDUUk1IzzyHhcGcEXAMPLE",
+				"NGROK_API_KEY":   "NQdxymVXmWC15916Mmy1vYkpzzNG6a84Bo4mYKuDahEXAMPLE",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						fieldname.Authtoken: "cxG2Im21Yzkh8VnvFQaetlPHcQ9ZDUUk1IzzyHhcGcEXAMPLE",
+						fieldname.APIKey:    "NQdxymVXmWC15916Mmy1vYkpzzNG6a84Bo4mYKuDahEXAMPLE",
 					},
 				},
 			},
@@ -53,8 +53,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						fieldname.Authtoken: "cxG2Im21Yzkh8VnvFQaetlPHcQ9ZDUUk1IzzyHhcGcEXAMPLE",
+						fieldname.APIKey:    "NQdxymVXmWC15916Mmy1vYkpzzNG6a84Bo4mYKuDahEXAMPLE",
 					},
 				},
 			},
@@ -67,8 +67,8 @@ func TestCredentialsImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Authtoken: "uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE",
-						fieldname.APIKey:    "L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE",
+						fieldname.Authtoken: "cxG2Im21Yzkh8VnvFQaetlPHcQ9ZDUUk1IzzyHhcGcEXAMPLE",
+						fieldname.APIKey:    "NQdxymVXmWC15916Mmy1vYkpzzNG6a84Bo4mYKuDahEXAMPLE",
 					},
 				},
 			},

--- a/plugins/ngrok/test-fixtures/config.yml
+++ b/plugins/ngrok/test-fixtures/config.yml
@@ -1,3 +1,3 @@
-api_key: L4STpMP3K8FNaQjBo5EAsXA2SThzq0J7BKD3jUZgtEXAMPLE
-authtoken: uSuQ7LUOJLs4xRbIySZ15F4v5KxfTnMknMdFEXAMPLE
+api_key: NQdxymVXmWC15916Mmy1vYkpzzNG6a84Bo4mYKuDahEXAMPLE
+authtoken: cxG2Im21Yzkh8VnvFQaetlPHcQ9ZDUUk1IzzyHhcGcEXAMPLE
 version: "2"


### PR DESCRIPTION
Resolves: #249 

The lengths of the ngrok credentials specified in ngrok/credentials.go seem to be incorrect. The correct lengths should be:

- Authtoken: 49
- API key: 49

You can create the secrets using these links:

- https://dashboard.ngrok.com/get-started/your-authtoken
- https://dashboard.ngrok.com/api

The incorrect length values don't seem to affect any functionality at the moment, but it's important to record the correct values for future features, e.g. any case where validating extracted credentials is needed.