### PR TITLE
Support for importing AWS vault credentials from encrypted files

### DIFF
--- a/plugins/aws/importers.go
+++ b/plugins/aws/importers.go
@@ -107,7 +107,9 @@ func fileKeyringPassphrasePrompt(prompt string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Println()
+
+	fmt.Print("\n\n")
+
 	return string(b), nil
 }
 


### PR DESCRIPTION
## Summary

Currently, if you store AWS credentials using AWS vault with an encrypted file as the backend, then try to import credentials into 1Password using the AWS vault importer, you get a long `invalid memory address or nil pointer dereference` error in the terminal and no import candidates are shown. We want to support importing credentials from encrypted files.

Also, while importing using a build of the AWS plugin that **isn't a local build**, several log messages display in the terminal. These messages are invoked in the AWS vault code - we want to silence these. Example:

```
2023/04/21 13:19:32 Loading config file /Users/williampark/.aws/config
2023/04/21 13:19:32 Parsing config file /Users/williampark/.aws/config
2023/04/21 13:19:32 Unrecognised ini file section: DEFAULT
```

## How to Test

1. Add a profile through aws-vault using an encrypted file as the backend: `aws-vault add file-profile --backend file`
2. Run `op plugin init aws` (don't use a local build) > `Import into 1Password...`

## Expected Behaviour

No unnecessary  log messages should be displayed.

You should get a prompt in the terminal: `Enter passphrase to unlock "~/.awsvault/keys/": `. After inputting the correct password, `Encrypted file (file-profile)` should be displayed as an import candidate. You should be able to import the credential into 1Password successfully.
