### PR TITLE
Add plugin for Nimble package manager

### DIFF
--- a/plugins/nimble/nimble.go
+++ b/plugins/nimble/nimble.go
@@ -1,0 +1,27 @@
+package nimble
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func nimCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "nimble",
+		Runs:    []string{"nimble"},
+		DocsURL: sdk.URL("https://github.com/nim-lang/nimble"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.IfAny(
+				needsauth.ForCommand("publish"),
+			),
+			needsauth.NotForHelp(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/nimble/personal_access_token.go
+++ b/plugins/nimble/personal_access_token.go
@@ -1,0 +1,52 @@
+package nimble
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAccessToken,
+		DocsURL:       sdk.URL("https://github.com/nim-lang/nimble"),
+		ManagementURL: sdk.URL("https://nimble.directory/about.html"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to GitHub.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 40,
+					Prefix: "ghp_",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			TryNimbleConfigFile(),
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"NIMBLE_GITHUB_API_TOKEN": fieldname.Token,
+}
+
+func TryNimbleConfigFile() sdk.Importer {
+	// TODO: Try importing from ~/.nimble/github_api_token file
+	return importer.NoOp()
+}
+
+type Config struct {
+	Token string `ini:"token"`
+}

--- a/plugins/nimble/personal_access_token_test.go
+++ b/plugins/nimble/personal_access_token_test.go
@@ -1,0 +1,41 @@
+package nimble
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "ghp_ahhfw82h48fh72nfn29fn291nwidhf8EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NIMBLE_GITHUB_API_TOKEN": "ghp_ahhfw82h48fh72nfn29fn291nwidhf8EXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"NIMBLE_GITHUB_API_TOKEN": "ghp_ahhfw82h48fh72nfn29fn291nwidhf8EXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "ghp_ahhfw82h48fh72nfn29fn291nwidhf8EXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/nimble/plugin.go
+++ b/plugins/nimble/plugin.go
@@ -1,0 +1,22 @@
+package nimble
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "nimble",
+		Platform: schema.PlatformInfo{
+			Name:     "Nimble",
+			Homepage: sdk.URL("https://nimble.directory/"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			nimCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
This plugin adds support for https://nimble.directory, the package manager for https://nim-lang.org

## Type of change
- [x] Created a new plugin

## How To Test
  1. Install [Nim](https://nim-lang.org/), this will also install `nimble`
  2. Install this plugin using [these instructions](https://developer.1password.com/docs/cli/shell-plugins/contribute/#step-5-build-and-test-your-plugin-locally) with `make nimble/build` & `op plugin init nimble`. This may prompt for your PAT, explained in step 4
  3. Run `nimble init` to create a new Nim package ([additional docs here](https://github.com/nim-lang/packages/))
  4. When executing `nimble publish`, 1Password will prompt for your GitHub Personal Access Token. This will need `public_repo` permissions.

## Changelog
Authenticate the publishing Nim (Nimble) packages using Touch ID and other unlock options with 1Password Shell Plugins.