### PR TITLE
Add IDs to credentials based on their name

### DIFF
--- a/plugins/registry_test.go
+++ b/plugins/registry_test.go
@@ -1,10 +1,10 @@
 package plugins
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidatePlugins(t *testing.T) {

--- a/plugins/registry_test.go
+++ b/plugins/registry_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/1Password/shell-plugins/sdk/schema"
@@ -16,4 +17,13 @@ func TestValidatePlugins(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestAllPluginsHaveUniqueNames(t *testing.T) {
+	var pluginNames []string
+	for _, p := range registry {
+		pluginNames = append(pluginNames, p.Name)
+	}
+
+	assert.True(t, schema.IsStringSliceASet(pluginNames))
 }

--- a/sdk/names.go
+++ b/sdk/names.go
@@ -25,6 +25,8 @@ func (n CredentialName) ID() CredentialTypeID {
 func credentialNameToSnakeCase(name CredentialName) string {
 	str := name.String()
 	str = strings.ReplaceAll(str, " ", "_")
+	str = strings.ReplaceAll(str, "-", "_")
+	str = strings.ReplaceAll(str, "/", "_")
 	return strings.ToLower(str)
 }
 

--- a/sdk/names.go
+++ b/sdk/names.go
@@ -1,6 +1,9 @@
 package sdk
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // FieldName represents a name of credential field. It should be title-cased.
 // Examples: "Password", "Token", "API Key".
@@ -23,10 +26,19 @@ func (n CredentialName) ID() CredentialTypeID {
 }
 
 func credentialNameToSnakeCase(name CredentialName) string {
+	const underscore = "_"
+
 	str := name.String()
-	str = strings.ReplaceAll(str, " ", "_")
-	str = strings.ReplaceAll(str, "-", "_")
-	str = strings.ReplaceAll(str, "/", "_")
+
+	charsToReplace := regexp.MustCompile(`[-/,. ]`)
+	str = charsToReplace.ReplaceAllLiteralString(str, underscore)
+
+	multipleUnderscores := regexp.MustCompile(`_+`)
+	str = multipleUnderscores.ReplaceAllString(str, underscore)
+
+	str = strings.TrimPrefix(str, "_")
+	str = strings.TrimSuffix(str, "_")
+
 	return strings.ToLower(str)
 }
 

--- a/sdk/names.go
+++ b/sdk/names.go
@@ -1,5 +1,7 @@
 package sdk
 
+import "strings"
+
 // FieldName represents a name of credential field. It should be title-cased.
 // Examples: "Password", "Token", "API Key".
 type FieldName string
@@ -14,4 +16,14 @@ type CredentialName string
 
 func (n CredentialName) String() string {
 	return string(n)
+}
+
+func (n CredentialName) ID() string {
+	return credentialNameToSnakeCase(n)
+}
+
+func credentialNameToSnakeCase(name CredentialName) string {
+	str := name.String()
+	str = strings.ReplaceAll(str, " ", "_")
+	return strings.ToLower(str)
 }

--- a/sdk/names.go
+++ b/sdk/names.go
@@ -18,12 +18,18 @@ func (n CredentialName) String() string {
 	return string(n)
 }
 
-func (n CredentialName) ID() string {
-	return credentialNameToSnakeCase(n)
+func (n CredentialName) ID() CredentialTypeID {
+	return CredentialTypeID(credentialNameToSnakeCase(n))
 }
 
 func credentialNameToSnakeCase(name CredentialName) string {
 	str := name.String()
 	str = strings.ReplaceAll(str, " ", "_")
 	return strings.ToLower(str)
+}
+
+type CredentialTypeID string
+
+func (i CredentialTypeID) String() string {
+	return string(i)
 }

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -208,13 +208,3 @@ func (c CredentialType) hasNoDuplicateFieldNames() bool {
 	}
 	return true
 }
-
-func (c CredentialType) ID() CredentialTypeID {
-	return CredentialTypeID(c.Name.ID())
-}
-
-type CredentialTypeID string
-
-func (i CredentialTypeID) String() string {
-	return string(i)
-}

--- a/sdk/schema/credential_type.go
+++ b/sdk/schema/credential_type.go
@@ -208,3 +208,13 @@ func (c CredentialType) hasNoDuplicateFieldNames() bool {
 	}
 	return true
 }
+
+func (c CredentialType) ID() CredentialTypeID {
+	return CredentialTypeID(c.Name.ID())
+}
+
+type CredentialTypeID string
+
+func (i CredentialTypeID) String() string {
+	return string(i)
+}

--- a/sdk/schema/credname/names_test.go
+++ b/sdk/schema/credname/names_test.go
@@ -1,9 +1,10 @@
 package credname
 
 import (
+	"testing"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGettingCredentialIDsFromNames(t *testing.T) {

--- a/sdk/schema/credname/names_test.go
+++ b/sdk/schema/credname/names_test.go
@@ -1,0 +1,53 @@
+package credname
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGettingCredentialIDsFromNames(t *testing.T) {
+	names := []sdk.CredentialName{
+		APIClientCredentials,
+		APIKey,
+		APIToken,
+		AccessKey,
+		AccessToken,
+		AppPassword,
+		AppToken,
+		AuthToken,
+		CLIToken,
+		Credential,
+		Credentials,
+		DatabaseCredentials,
+		LoginDetails,
+		PersonalAPIToken,
+		PersonalAccessToken,
+		RegistryCredentials,
+		SecretKey,
+	}
+
+	expectedIDs := []string{
+		"api_client_credentials",
+		"api_key",
+		"api_token",
+		"access_key",
+		"access_token",
+		"app_password",
+		"app_token",
+		"auth_token",
+		"cli_token",
+		"credential",
+		"credentials",
+		"database_credentials",
+		"login_details",
+		"personal_api_token",
+		"personal_access_token",
+		"registry_credentials",
+		"secret_key",
+	}
+
+	for i, name := range names {
+		assert.Equal(t, expectedIDs[i], name.ID())
+	}
+}

--- a/sdk/schema/credname/names_test.go
+++ b/sdk/schema/credname/names_test.go
@@ -31,7 +31,9 @@ func TestGettingCredentialIDsFromNames(t *testing.T) {
 		sdk.CredentialName("Public/Private Key-Pair"),
 		sdk.CredentialName("Public/Private Key Pair"),
 		sdk.CredentialName("KeyPair"),
-		sdk.CredentialName("some-test/name-which is/NOT-a_real_life scENARIo"),
+		sdk.CredentialName("___some-test/name "),
+		sdk.CredentialName("this -is/NOT-a, real. _- /  life---- scENARIo..."),
+		sdk.CredentialName("___some,.other test/name-which -is/NOT-a, real. , - ./ - life_scENARIo..."),
 	}
 
 	expectedIDs := []string{
@@ -57,7 +59,9 @@ func TestGettingCredentialIDsFromNames(t *testing.T) {
 		"public_private_key_pair",
 		"public_private_key_pair",
 		"keypair",
-		"some_test_name_which_is_not_a_real_life_scenario",
+		"some_test_name",
+		"this_is_not_a_real_life_scenario",
+		"some_other_test_name_which_is_not_a_real_life_scenario",
 	}
 
 	for i, name := range names {

--- a/sdk/schema/credname/names_test.go
+++ b/sdk/schema/credname/names_test.go
@@ -49,6 +49,6 @@ func TestGettingCredentialIDsFromNames(t *testing.T) {
 	}
 
 	for i, name := range names {
-		assert.Equal(t, expectedIDs[i], name.ID())
+		assert.Equal(t, expectedIDs[i], name.ID().String())
 	}
 }

--- a/sdk/schema/credname/names_test.go
+++ b/sdk/schema/credname/names_test.go
@@ -26,6 +26,12 @@ func TestGettingCredentialIDsFromNames(t *testing.T) {
 		PersonalAccessToken,
 		RegistryCredentials,
 		SecretKey,
+		sdk.CredentialName(""),
+		sdk.CredentialName("Database-specific Credentials"),
+		sdk.CredentialName("Public/Private Key-Pair"),
+		sdk.CredentialName("Public/Private Key Pair"),
+		sdk.CredentialName("KeyPair"),
+		sdk.CredentialName("some-test/name-which is/NOT-a_real_life scENARIo"),
 	}
 
 	expectedIDs := []string{
@@ -46,6 +52,12 @@ func TestGettingCredentialIDsFromNames(t *testing.T) {
 		"personal_access_token",
 		"registry_credentials",
 		"secret_key",
+		"",
+		"database_specific_credentials",
+		"public_private_key_pair",
+		"public_private_key_pair",
+		"keypair",
+		"some_test_name_which_is_not_a_real_life_scenario",
 	}
 
 	for i, name := range names {

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -86,7 +86,7 @@ func (p Plugin) Validate() (bool, ValidationReport) {
 
 	report.AddCheck(ValidationCheck{
 		Description: "Credentials are uniquely identifiable inside a plugin",
-		Assertion:   CredentialsAreUniquelyIdentifiableInsideAPlugin(p),
+		Assertion:   NoDuplicateCredentials(p),
 		Severity:    ValidationSeverityError,
 	})
 

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -84,6 +84,12 @@ func (p Plugin) Validate() (bool, ValidationReport) {
 		Severity:    ValidationSeverityError,
 	})
 
+	report.AddCheck(ValidationCheck{
+		Description: "Credentials are uniquely identifiable inside a plugin",
+		Assertion:   CredentialsAreUniquelyIdentifiableInsideAPlugin(p),
+		Severity:    ValidationSeverityError,
+	})
+
 	return report.IsValid(), report
 }
 

--- a/sdk/schema/validation.go
+++ b/sdk/schema/validation.go
@@ -112,3 +112,27 @@ func CredentialReferencesInCredentialList(plugin Plugin) bool {
 	}
 	return true
 }
+
+func CredentialsAreUniquelyIdentifiableInsideAPlugin(plugin Plugin) bool {
+	var ids []string
+	for _, credential := range plugin.Credentials {
+		ids = append(ids, credential.ID().String())
+	}
+
+	return IsStringSliceASet(ids)
+}
+
+func IsStringSliceASet(slice []string) bool {
+	for i, s := range slice {
+		if i == len(s)-1 {
+			break
+		}
+		for _, ss := range slice[i+1:] {
+			if ss == s {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/sdk/schema/validation.go
+++ b/sdk/schema/validation.go
@@ -116,7 +116,7 @@ func CredentialReferencesInCredentialList(plugin Plugin) bool {
 func CredentialsAreUniquelyIdentifiableInsideAPlugin(plugin Plugin) bool {
 	var ids []string
 	for _, credential := range plugin.Credentials {
-		ids = append(ids, credential.ID().String())
+		ids = append(ids, credential.Name.ID().String())
 	}
 
 	return IsStringSliceASet(ids)

--- a/sdk/schema/validation.go
+++ b/sdk/schema/validation.go
@@ -124,7 +124,7 @@ func CredentialsAreUniquelyIdentifiableInsideAPlugin(plugin Plugin) bool {
 
 func IsStringSliceASet(slice []string) bool {
 	for i, s := range slice {
-		if i == len(s)-1 {
+		if i == len(slice)-1 {
 			break
 		}
 		for _, ss := range slice[i+1:] {

--- a/sdk/schema/validation.go
+++ b/sdk/schema/validation.go
@@ -113,7 +113,7 @@ func CredentialReferencesInCredentialList(plugin Plugin) bool {
 	return true
 }
 
-func CredentialsAreUniquelyIdentifiableInsideAPlugin(plugin Plugin) bool {
+func NoDuplicateCredentials(plugin Plugin) bool {
 	var ids []string
 	for _, credential := range plugin.Credentials {
 		ids = append(ids, credential.Name.ID().String())

--- a/sdk/schema/validation_test.go
+++ b/sdk/schema/validation_test.go
@@ -135,3 +135,33 @@ func TestPluginValidateEachReportFieldHasError(t *testing.T) {
 
 	assert.False(t, c.Assertion, fmt.Sprintf("\"%s\" validation is erroneous", c.Description))
 }
+
+func TestIsStringSliceASet(t *testing.T) {
+	testCases := []struct {
+		slice     []string
+		assertion bool
+	}{
+		{
+			slice:     []string{"a", "b", "c", "b", "d"},
+			assertion: false,
+		}, {
+			slice:     []string{"a", "a", "a", "a", "a"},
+			assertion: false,
+		}, {
+			slice:     []string{"a", "a", "c", "d", "e"},
+			assertion: false,
+		}, {
+			slice:     []string{"a", "b", "c", "d", "d"},
+			assertion: false,
+		}, {
+			slice:     []string{"a", "b", "c", "d", "e"},
+			assertion: true,
+		}, {
+			slice:     []string{"a", "b", "b", "b", "d"},
+			assertion: false,
+		},
+	}
+	for _, tc := range testCases {
+		assert.Equal(t, tc.assertion, IsStringSliceASet(tc.slice))
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

We need a way to identify credentials in a stable long-term manner. The credential names could be subject to change at a certain point in the future, so we are introducing an additional layer meant for unique identification that is not vulnerable to sdk changes.

Also we need to enforce that plugins are uniquely identified by their name, and credentials inside each plugin definition are uniquely identifiable by their ID.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #257 

Relates other some internal issues.



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Credentials now have an ID they can be identified after.

Plugins can be uniquely identified by their name, and credentials inside a plugin definition can be uniquely identified by their ID

