### PR TITLE
Don't write a new aws config file when importing

### DIFF
--- a/plugins/aws/importers.go
+++ b/plugins/aws/importers.go
@@ -133,24 +133,16 @@ func TryAWSVaultBackends() sdk.Importer {
 			// Use the CredentialKeyring struct from aws-vault to retrieve vaulting backend credentials
 			credentialKeyring := &vault.CredentialKeyring{Keyring: keyring}
 
-			// Load the AWS config file (default location at ~/.aws/config)
-			awsConfigFile, err := GetAWSConfigFile()
+			profilesInfo, err := GetProfilesInfo()
 			if err != nil {
 				attempt.AddError(err)
 				return
 			}
-			configLoader := &vault.ConfigLoader{File: awsConfigFile}
-
-			// Get the region specified for the "default" profile
-			var defaultRegion string
-			if defaultSection, ok := awsConfigFile.ProfileSection("default"); ok {
-				defaultRegion = defaultSection.Region
-			}
 
 			// Iterate through the profiles in the AWS config file and
 			// import any matching credentials stored in the vaulting backend
-			for _, profileName := range awsConfigFile.ProfileNames() {
-				profileFound, err := credentialKeyring.Has(profileName)
+			for _, profile := range profilesInfo {
+				profileFound, err := credentialKeyring.Has(profile.Name)
 				if err != nil {
 					attempt.AddError(err)
 					continue
@@ -159,13 +151,7 @@ func TryAWSVaultBackends() sdk.Importer {
 					continue
 				}
 
-				creds, err := credentialKeyring.Get(profileName)
-				if err != nil {
-					attempt.AddError(err)
-					continue
-				}
-
-				profileConfig, err := configLoader.LoadFromProfile(profileName)
+				creds, err := credentialKeyring.Get(profile.Name)
 				if err != nil {
 					attempt.AddError(err)
 					continue
@@ -174,20 +160,13 @@ func TryAWSVaultBackends() sdk.Importer {
 				fields := make(map[sdk.FieldName]string)
 				fields[fieldname.AccessKeyID] = creds.AccessKeyID
 				fields[fieldname.SecretAccessKey] = creds.SecretAccessKey
-
-				// If a region is specified for the AWS profile, use it.
-				// Otherwise, use the "default" profile region if it's specified
-				if profileConfig.Region != "" {
-					fields[fieldname.DefaultRegion] = profileConfig.Region
-				} else if defaultRegion != "" {
-					fields[fieldname.DefaultRegion] = defaultRegion
-				}
-
+				fields[fieldname.MFASerial] = profile.MfaSerial
+				fields[fieldname.Region] = profile.Region
 				// Only add candidates with required credential fields
 				if fields[fieldname.AccessKeyID] != "" && fields[fieldname.SecretAccessKey] != "" {
 					attempt.AddCandidate(sdk.ImportCandidate{
 						Fields:   fields,
-						NameHint: importer.SanitizeNameHint(profileName),
+						NameHint: importer.SanitizeNameHint(profile.Name),
 					})
 				}
 			}
@@ -195,7 +174,13 @@ func TryAWSVaultBackends() sdk.Importer {
 	}
 }
 
-func GetAWSConfigFile() (*vault.ConfigFile, error) {
+type ProfileInfoToImport struct {
+	Name      string
+	MfaSerial string
+	Region    string
+}
+
+func GetProfilesInfo() ([]ProfileInfoToImport, error) {
 	file := os.Getenv("AWS_CONFIG_FILE")
 	if file == "" {
 		home, err := os.UserHomeDir()
@@ -203,10 +188,6 @@ func GetAWSConfigFile() (*vault.ConfigFile, error) {
 			return nil, err
 		}
 		file = filepath.Join(home, "/.aws/config")
-	}
-
-	config := &vault.ConfigFile{
-		Path: file,
 	}
 
 	f, err := ini.LoadSources(ini.LoadOptions{
@@ -218,31 +199,47 @@ func GetAWSConfigFile() (*vault.ConfigFile, error) {
 		return nil, err
 	}
 
+	const (
+		configFileRegionKey    = "region"
+		profileNamePrefix      = "profile "
+		configFileMfaSerialKey = "mfa_serial"
+	)
+
+	// Get the region specified for the "default" profile
+	var defaultRegion string
+	if defaultSection, err := f.GetSection(defaultProfileName); err != nil && defaultSection.HasKey(configFileRegionKey) {
+		key, err := defaultSection.GetKey(configFileRegionKey)
+		if err != nil {
+			return nil, err
+		}
+		defaultRegion = key.String()
+	}
+
+	var profiles []ProfileInfoToImport
 	for _, section := range f.Sections() {
 		var region, mfaSerial string
-		if section.HasKey("mfa_serial") {
-			key, err := section.GetKey("mfa_serial")
+		if section.HasKey(configFileMfaSerialKey) {
+			key, err := section.GetKey(configFileMfaSerialKey)
 			if err != nil {
 				return nil, err
 			}
 			mfaSerial = key.String()
 		}
-		if section.HasKey("region") {
-			key, err := section.GetKey("region")
+		if section.HasKey(configFileRegionKey) {
+			key, err := section.GetKey(configFileRegionKey)
 			if err != nil {
 				return nil, err
 			}
 			region = key.String()
+		} else {
+			region = defaultRegion
 		}
-		err = config.Add(vault.ProfileSection{
-			Name:      section.Name(),
+		profiles = append(profiles, ProfileInfoToImport{
+			Name:      strings.TrimPrefix(section.Name(), profileNamePrefix),
 			MfaSerial: mfaSerial,
 			Region:    region,
 		})
-		if err != nil {
-			return nil, err
-		}
 	}
 
-	return config, nil
+	return profiles, nil
 }


### PR DESCRIPTION

## Overview
<!--  
Provide a high-level description of this change.   
-->
It seems the aws-vault importer is creating the `.aws/config` file if it doesn't exist. We should make sure that importers only read.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience


## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
`op plugin init aws` and import credentials


## Changelog

AWS Shell Plugin importer never creates a `.aws/config` file if one does not exist already.
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


