### PR TITLE
fix(new-plugin): Set only the last word of the credential name as the field name, if it's larger than seven characters

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -191,24 +191,25 @@ func newPlugin() error {
 
 	// As a placeholder, assume the field name is the short version (max 7 chars) of the credential name, starting from the last word.
 	//
+	// When the last word of the credential name is greater than seven characters, the last word is used as the field name.
+	//
 	// For example:
 	// "Personal Access Token" => "Token"
 	// "Secret Key" => "Key"
 	// "API Key" => "API Key"
-	//
-	// When the last word of the credential name is greater than seven characters, the last word is used as the field name
-	var fieldNameSplit []string
+	// "GitHub API Key" => "API Key"
+	// "Credentials" => "Credentials"
 	lengthCutoff := 7
-	for i := range credNameSplit {
-		word := credNameSplit[len(credNameSplit)-1-i]
+	fieldNameSplit := []string{credNameSplit[len(credNameSplit)-1]}
+	for i := range credNameSplit[:len(credNameSplit)-1] {
+		// Skip credNameSplit's last word because it's already added to fieldNameSplit
 		if i == 0 {
-			fieldNameSplit = append([]string{word}, fieldNameSplit...)
 			continue
 		}
+		word := credNameSplit[len(credNameSplit)-1-i]
 		if len(strings.Join(append(fieldNameSplit, word), " ")) > lengthCutoff {
 			break
 		}
-
 		fieldNameSplit = append([]string{word}, fieldNameSplit...)
 	}
 	result.FieldName = strings.Join(fieldNameSplit, " ")

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -189,15 +189,22 @@ func newPlugin() error {
 		}
 	}
 
-	// As a placeholder, assume the field name is the short version (max 7 chars) of the credential name, starting
-	// from the last word. For example:
+	// As a placeholder, assume the field name is the short version (max 7 chars) of the credential name, starting from the last word.
+	//
+	// For example:
 	// "Personal Access Token" => "Token"
 	// "Secret Key" => "Key"
 	// "API Key" => "API Key"
+	//
+	// When the last word of the credential name is greater than seven characters, the last word is used as the field name
 	var fieldNameSplit []string
 	lengthCutoff := 7
 	for i := range credNameSplit {
 		word := credNameSplit[len(credNameSplit)-1-i]
+		if i == 0 {
+			fieldNameSplit = append([]string{word}, fieldNameSplit...)
+			continue
+		}
 		if len(strings.Join(append(fieldNameSplit, word), " ")) > lengthCutoff {
 			break
 		}

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -200,18 +200,7 @@ func newPlugin() error {
 	// "GitHub API Key" => "API Key"
 	// "Credentials" => "Credentials"
 	lengthCutoff := 7
-	fieldNameSplit := []string{credNameSplit[len(credNameSplit)-1]}
-	for i := range credNameSplit[:len(credNameSplit)-1] {
-		// Skip credNameSplit's last word because it's already added to fieldNameSplit
-		if i == 0 {
-			continue
-		}
-		word := credNameSplit[len(credNameSplit)-1-i]
-		if len(strings.Join(append(fieldNameSplit, word), " ")) > lengthCutoff {
-			break
-		}
-		fieldNameSplit = append([]string{word}, fieldNameSplit...)
-	}
+	fieldNameSplit := fieldNameSplitFromCredNameSplit(credNameSplit, lengthCutoff)
 	result.FieldName = strings.Join(fieldNameSplit, " ")
 	result.FieldNameUpperCamelCase = strings.Join(fieldNameSplit, "")
 	result.CredentialEnvVarName = strings.ToUpper(strings.Join(append([]string{result.Name}, fieldNameSplit...), "_"))
@@ -643,4 +632,29 @@ func generateRegistryJSON() error {
 		return err
 	}
 	return os.WriteFile(filepath.Join("plugins", "registry.json"), b, 0600)
+}
+
+// fieldNameSplitFromCredNameSplit takes in a credential name split array and returns a field name split array.
+//
+// As a placeholder, assume the field name is the short version (max 7 chars, including space between words) of the credential name, starting from the last word.
+//
+// When the last word of the credential name is greater than seven characters, the last word is used as the field name.
+//
+// For example:
+//
+//	"Personal Access Token" => "Token"
+//	"Secret Key" => "Key"
+//	"API Key" => "API Key"
+//	"GitHub API Key" => "API Key"
+//	"Credentials" => "Credentials"
+func fieldNameSplitFromCredNameSplit(credNameSplit []string, lengthCutoff int) []string {
+	fieldNameSplit := []string{credNameSplit[len(credNameSplit)-1]}
+	for i := len(credNameSplit) - 2; i >= 0; i-- {
+		word := credNameSplit[i]
+		if len(strings.Join(append(fieldNameSplit, word), " ")) > lengthCutoff {
+			break
+		}
+		fieldNameSplit = append([]string{word}, fieldNameSplit...)
+	}
+	return fieldNameSplit
 }

--- a/cmd/contrib/main_test.go
+++ b/cmd/contrib/main_test.go
@@ -34,7 +34,7 @@ type FieldNameSplitFromCredNameSplit struct {
 	CredNameSplit  []string
 }
 
-func TestValidateFieldNameSplitFromCredNameSplitReturnError(t *testing.T) {
+func TestValidateFieldNameSplitFromCredNameSplit(t *testing.T) {
 	lengthCutoff := 7
 	cases := []FieldNameSplitFromCredNameSplit{
 		{

--- a/cmd/contrib/main_test.go
+++ b/cmd/contrib/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,44 @@ func TestValidateCredentialNameReturnError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := validateCredentialName(any(tc))
 			assert.NotNil(t, err)
+		})
+	}
+}
+
+type FieldNameSplitFromCredNameSplit struct {
+	FieldNameSplit []string
+	CredNameSplit  []string
+}
+
+func TestValidateFieldNameSplitFromCredNameSplitReturnError(t *testing.T) {
+	lengthCutoff := 7
+	cases := []FieldNameSplitFromCredNameSplit{
+		{
+			CredNameSplit:  []string{"Personal", "Access", "Token"},
+			FieldNameSplit: []string{"Token"},
+		},
+		{
+			CredNameSplit:  []string{"Secret", "Key"},
+			FieldNameSplit: []string{"Key"},
+		},
+		{
+			CredNameSplit:  []string{"API", "Key"},
+			FieldNameSplit: []string{"API", "Key"},
+		},
+		{
+			CredNameSplit:  []string{"GitHub", "API", "Key"},
+			FieldNameSplit: []string{"API", "Key"},
+		},
+		{
+			CredNameSplit:  []string{"Credentials"},
+			FieldNameSplit: []string{"Credentials"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(strings.Join(c.CredNameSplit, " "), func(t *testing.T) {
+			fieldNameSplit := fieldNameSplitFromCredNameSplit(c.CredNameSplit, lengthCutoff)
+			assert.Equal(t, c.FieldNameSplit, fieldNameSplit)
 		})
 	}
 }


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Prior to this change, when the credential name's last word is larger than seven characters, the field name generated by the "make new-plugin" template is empty. 

With this change, the last word of the credential name is set as the field name. In the example below, field name `Credentials` is generated for the credential name `GitHub Access Credentials`.

![image](https://github.com/1Password/shell-plugins/assets/18581859/f2962cb0-1226-4f4c-bc90-99fe4778f085)

If the last word is smaller than seven characters, the usual pattern of stitching together the last several words of the credential name (proposed originally on this PR https://github.com/1Password/shell-plugins/pull/72) will be retained. In the example below, field name `API Key` is generated for the credential name `GitHub API Key`.

![image](https://github.com/1Password/shell-plugins/assets/18581859/a6823651-3e6c-476d-99cd-7075d6faf415)

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: https://github.com/1Password/shell-plugins/issues/164

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Clone this branch and switch to it.
- Run `make new-plugin`
- When prompted to enter a credential name, try two variants: one with the last word less than seven characters, and one with the last word having greater than seven characters. See that both work as expected, especially the latter variant should have only the last word as the field name.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Set only the last word of the credential name as the field name, if it's larger than seven characters