### PR TITLE
Warn when plugin name set in credential usage is the same as where the credential is from

### DIFF
--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -90,6 +90,12 @@ func (p Plugin) Validate() (bool, ValidationReport) {
 		Severity:    ValidationSeverityError,
 	})
 
+	report.AddCheck(ValidationCheck{
+		Description: "Do not specify plugin name in credential usage because credential is from the same plugin",
+		Assertion:   !UnnecessaryPluginNameDefined(p),
+		Severity:    ValidationSeverityWarning,
+	})
+
 	return report.IsValid(), report
 }
 

--- a/sdk/schema/validation.go
+++ b/sdk/schema/validation.go
@@ -136,3 +136,14 @@ func IsStringSliceASet(slice []string) bool {
 
 	return true
 }
+
+func UnnecessaryPluginNameDefined(plugin Plugin) bool {
+	for _, executable := range plugin.Executables {
+		for _, execCredential := range executable.Uses {
+			if execCredential.Plugin == plugin.Name {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

When the plugin name defined in the credential usage block is the same as where the credential is from, that optional field needn't be defined. That field is designed to automatically default to the current plugin/package, so that field can be completely ignored in such cases.

The validation check proposed in this PR checks if it's from the same plugin and warns (does not appear as an error, just shows a warning) the contributor to remove it, when `make plugin-name/validate` command is run.

Example from the AWS plugin, both for AWS executable and CDK executables:

<img width="506" alt="image" src="https://github.com/1Password/shell-plugins/assets/18581859/20d30495-2523-4f1a-aadf-8ff3e734dc7b">

<img width="421" alt="image" src="https://github.com/1Password/shell-plugins/assets/18581859/d5efede3-ffc9-4f60-8c2d-1212b142e9d9">

<img width="1728" alt="image" src="https://github.com/1Password/shell-plugins/assets/18581859/8c8ea1c4-133e-4c9a-a42f-993a747a7058">

Without that plugin field defined:

<img width="1728" alt="image" src="https://github.com/1Password/shell-plugins/assets/18581859/b3fe442e-41cc-468c-92dd-003308189ba3">

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: https://github.com/1Password/shell-plugins/issues/264

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Clone this branch and switch to it.
- Edit AWS shell plugin's executables (either AWS, CDK or both) to add `Plugin: "aws",` to the CredentialUsage block.
- Run `make aws/validate` to see the warning.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Warn when plugin name set in credential usage is the same as where the credential is from