### PR TITLE
gh: do not require auth if running for shell completion

### DIFF
--- a/plugins/github/gh.go
+++ b/plugins/github/gh.go
@@ -15,6 +15,7 @@ func GitHubCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("__complete"),
 		),
 		Uses: []schema.CredentialUsage{
 			{


### PR DESCRIPTION
## Overview

Do not require auth if running `gh __complete` for shell completion. 

## Type of change

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience


