### PR TITLE
Don't require plugins to have executables

### DIFF
--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -100,9 +100,8 @@ func newPlugin() error {
 			Validate: survey.Required,
 		},
 		{
-			Name:     "Executable",
-			Prompt:   &survey.Input{Message: `Executable name (e.g. "aws" or "gh") [required]`},
-			Validate: survey.Required,
+			Name:   "Executable",
+			Prompt: &survey.Input{Message: `Executable name (e.g. "aws" or "gh")`},
 		},
 		{
 			Name: "CredentialName",


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Don't require plugins to have executables.
Since the Terraform plugin can consume credentials of other plugins, there is now a use-case for plugins with no executables. 
If a service offers a Terraform provider, but no CLI, Shell Plugins should still offer a solution to allow for the provisioning of that credential.
In this situation, simply not providing an executable in the creation wizard does the trick.



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [X] Improved contributor utilities or experience


## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

`make new-plugin` and leave the "Executable" prompt empty. The wizard should still work.




