### PR TITLE
new(sdk): Arguments Provision for command-line argument injection and Chained Provisioner to merge multiple provisioners

### DIFF
--- a/sdk/provision/args_provisioner.go
+++ b/sdk/provision/args_provisioner.go
@@ -1,0 +1,48 @@
+package provision
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+)
+
+// ArgsProvisioner provisions secrets as command-line arguments.
+// ArgsPosition field is to control where the arguments are placed in the command line. Setting it to 1 provisions the arguments immediately after the executable name, and setting it to the length of the command line provisions the arguments at the end.
+type ArgsProvisioner struct {
+	sdk.Provisioner
+
+	ArgsPosition map[string]uint
+	Schema       map[string]sdk.FieldName
+}
+
+// Args creates an ArgsProvisioner that provisions secrets as command line arguments, based
+// on the specified schema of field name and argument name, and the position of the argument.
+func ArgsAtIndex(argsPosition map[string]uint, schema map[string]sdk.FieldName) sdk.Provisioner {
+	return ArgsProvisioner{
+		ArgsPosition: argsPosition,
+		Schema:       schema,
+	}
+}
+
+func (p ArgsProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	for argName, fieldName := range p.Schema {
+		if value, ok := in.ItemFields[fieldName]; ok {
+			// This safeguard is to ensure that the argsPosition is not out of bounds.
+			//
+			// Example: For a "redis-cli incr key" command, arguments cannot be provisioned at index 4 or higher.
+			if uint(p.ArgsPosition[argName]) > uint(len(out.CommandLine)) {
+				out.AddArgsAtIndex(uint(len(out.CommandLine)), argName, value)
+				return
+			}
+			out.AddArgsAtIndex(uint(p.ArgsPosition[argName]), argName, value)
+		}
+	}
+}
+
+func (p ArgsProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Nothing to do here: credentials get wiped automatically when the process exits.
+}
+
+func (p ArgsProvisioner) Description() string {
+	return "Provision credentials using command-line args."
+}

--- a/sdk/provision/chained_provisioner.go
+++ b/sdk/provision/chained_provisioner.go
@@ -1,0 +1,33 @@
+package provision
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+)
+
+// ChainedProvisioner chains multiple provisioners together for use at the same time.
+type ChainedProvisioner struct {
+	Provisioners []sdk.Provisioner
+}
+
+// ChainProvisioners creates a ChainedProvisioner that chains multiple provisioners together for use at the same time.
+func ChainProvisioners(provisioners ...sdk.Provisioner) sdk.Provisioner {
+	return ChainedProvisioner{
+		Provisioners: provisioners,
+	}
+}
+
+func (p ChainedProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	for _, provisioner := range p.Provisioners {
+		provisioner.Provision(ctx, in, out)
+	}
+}
+
+func (p ChainedProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Nothing to do here: environment variables and args get wiped automatically when the process exits.
+}
+
+func (p ChainedProvisioner) Description() string {
+	return "Handle multiple provisioners at once"
+}

--- a/sdk/provision/file_provisioner.go
+++ b/sdk/provision/file_provisioner.go
@@ -159,7 +159,7 @@ func (p FileProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, o
 			argsResolved[i] = result.String()
 		}
 
-		out.AddArgs(argsResolved...)
+		out.AddArgsAtIndex(uint(len(argsResolved)), argsResolved...)
 	}
 }
 

--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -102,9 +102,13 @@ func (out *ProvisionOutput) AddEnvVar(name string, value string) {
 	out.Environment[name] = value
 }
 
-// AddArgs can be used to add additional arguments to the command line of the provision output.
-func (out *ProvisionOutput) AddArgs(args ...string) {
-	out.CommandLine = append(out.CommandLine, args...)
+// AddArgs can be used to add additional arguments to the command line of the provision output, at a specific index.
+func (out *ProvisionOutput) AddArgsAtIndex(index uint, args ...string) {
+	newCommandLine := []string{}
+	newCommandLine = append(newCommandLine, out.CommandLine[:index]...)
+	newCommandLine = append(newCommandLine, args...)
+	newCommandLine = append(newCommandLine, out.CommandLine[index:]...)
+	out.CommandLine = newCommandLine
 }
 
 // AddSecretFile can be used to add a file containing secrets to the provision output.


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

This PR introduces two new provisioners:

- Arguments Provisioner that injects secrets as command-line arguments/flags.
- Chained Provisioner that stitches together multiple provisioners. One common example is when there's a need to use both an environment variable and flags, [like in the case of redis shell plugin](https://github.com/1Password/shell-plugins/pull/276#issuecomment-1569616959).
 
## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Relates Redis Shell plugin: https://github.com/1Password/shell-plugins/pull/276
* Relates TunnelTo shell plugin: https://github.com/1Password/shell-plugins/pull/171#issuecomment-1523641351

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

The best way to test is on the redis PR. 

- On the redis PR, checkout that branch (the changed proposed on the current PR are already available on the redis PR as well)
- Run `make redis/build`
- Set up redis credentials using `op plugin init redis-cli` (The easiest redis host to sign up for are redis.com and upstash.com)
- Run `redis-cli incr key` with your redis credentials.

When you run that command, what actually runs behind the scenes is `REDISCLI_AUTH=value redis-cli --user value -h value -p value`.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

New provisioners: Arguments Provision to provision secrets as command line arguments at specific indices, and Chained Provisioner to stitch multiple provisioners for use at the same time.