### PR TITLE
civo plugin added

### DIFF
--- a/plugins/civo/api_key.go
+++ b/plugins/civo/api_key.go
@@ -89,20 +89,6 @@ func TryCivoConfigFile() sdk.Importer {
 	})
 }
 
-// {
-// 	"apikeys": {
-// 	  "newspidey": "Vdi1GHFqXLG47VcfdvfvfvfvfvfvfvfvEgOd",
-// 	},
-// 	"meta": {
-// 	  "admin": false,
-// 	  "current_apikey": "newspidey",
-// 	  "default_region": "LON1",
-// 	  "latest_release_check": "2023-06-11T20:25:06.916682112+05:30",
-// 	  "url": "https://api.civo.com",
-// 	  "last_command_executed": "2023-06-11T20:25:06.916237569+05:30"
-// 	}
-//   }
-
 type Config struct {
 	Properties map[string]json.RawMessage `json:"apikeys"`
 

--- a/plugins/civo/api_key.go
+++ b/plugins/civo/api_key.go
@@ -1,0 +1,117 @@
+package civo
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://www.civo.com/docs/account/api-keys"),
+		ManagementURL: sdk.URL("https://dashboard.civo.com/security"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Civo.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 50,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.APIKeyID,
+				MarkdownDescription: "API Name to identify the API Key.",
+			},
+			{
+				Name:                fieldname.DefaultRegion,
+				MarkdownDescription: "The default region to use for this API Key.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryCivoConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"CIVO_API_KEY_NAME": fieldname.APIKeyID,
+	"CIVO_API_KEY":      fieldname.APIKey,
+}
+
+func TryCivoConfigFile() sdk.Importer {
+
+	return importer.TryFile("~/.civo.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+
+		}
+		if len(config.Properties) == 0 && config.Meta.CurrentAPIKey == "" {
+			return
+		}
+
+		var apiKey string
+		for key, value := range config.Properties {
+			if key == config.Meta.CurrentAPIKey {
+				err := json.Unmarshal(value, &apiKey)
+				if err != nil {
+					out.AddError(err)
+					return
+				}
+			}
+			break
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.APIKey:        apiKey,
+				fieldname.APIKeyID:      config.Meta.CurrentAPIKey,
+				fieldname.DefaultRegion: config.Meta.DefaultRegion,
+			},
+		})
+
+	})
+}
+
+// {
+// 	"apikeys": {
+// 	  "newspidey": "Vdi1GHFqXLG47VcfdvfvfvfvfvfvfvfvEgOd",
+// 	},
+// 	"meta": {
+// 	  "admin": false,
+// 	  "current_apikey": "newspidey",
+// 	  "default_region": "LON1",
+// 	  "latest_release_check": "2023-06-11T20:25:06.916682112+05:30",
+// 	  "url": "https://api.civo.com",
+// 	  "last_command_executed": "2023-06-11T20:25:06.916237569+05:30"
+// 	}
+//   }
+
+type Config struct {
+	Properties map[string]json.RawMessage `json:"apikeys"`
+
+	Meta struct {
+		Admin               bool   `json:"admin"`
+		CurrentAPIKey       string `json:"current_apikey"`
+		DefaultRegion       string `json:"default_region"`
+		LatestReleaseCheck  string `json:"latest_release_check"`
+		URL                 string `json:"url"`
+		LastCommandExecuted string `json:"last_command_executed"`
+	} `json:"meta"`
+}

--- a/plugins/civo/api_key_test.go
+++ b/plugins/civo/api_key_test.go
@@ -11,12 +11,14 @@ import (
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
-				fieldname.APIKey: "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey:   "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+				fieldname.APIKeyID: "testdemoname",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"CIVO_API_KEY": "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+					"CIVO_API_KEY":      "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+					"CIVO_API_KEY_NAME": "testdemoname",
 				},
 			},
 		},

--- a/plugins/civo/api_key_test.go
+++ b/plugins/civo/api_key_test.go
@@ -1,0 +1,55 @@
+package civo
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.APIKey: "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"CIVO_API_KEY": "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"CIVO_API_KEY": "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in civo/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/civo/api_key_test.go
+++ b/plugins/civo/api_key_test.go
@@ -2,12 +2,12 @@ package civo
 
 import (
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
@@ -26,29 +26,34 @@ func TestAPIKeyProvisioner(t *testing.T) {
 func TestAPIKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
-				"CIVO_API_KEY": "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+			Environment: map[string]string{
+				"CIVO_API_KEY":      "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+				"CIVO_API_KEY_NAME": "testdemoname",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.APIKey: "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+						fieldname.APIKey:   "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+						fieldname.APIKeyID: "testdemoname",
 					},
 				},
 			},
 		},
-		// TODO: If you implemented a config file importer, add a test file example in civo/test-fixtures
-		// and fill the necessary details in the test template below.
+
 		"config file": {
 			Files: map[string]string{
-				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+
+				"~/.civo.json": plugintest.LoadFixture(t, "civo.json"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
-			// 	{
-			// 		Fields: map[sdk.FieldName]string{
-			// 			fieldname.Token: "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
-			// 		},
-			// 	},
+
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey:        "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE",
+						fieldname.APIKeyID:      "testdemoname",
+						fieldname.DefaultRegion: "LON1",
+					},
+				},
 			},
 		},
 	})

--- a/plugins/civo/civo.go
+++ b/plugins/civo/civo.go
@@ -1,0 +1,25 @@
+package civo
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func CivoCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Civo CLI", // TODO: Check if this is correct
+		Runs:      []string{"civo"},
+		DocsURL:   sdk.URL("https://civo.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/civo/civo.go
+++ b/plugins/civo/civo.go
@@ -9,9 +9,9 @@ import (
 
 func CivoCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Civo CLI", // TODO: Check if this is correct
-		Runs:      []string{"civo"},
-		DocsURL:   sdk.URL("https://civo.com/docs/cli"), // TODO: Replace with actual URL
+		Name:    "Civo CLI",
+		Runs:    []string{"civo"},
+		DocsURL: sdk.URL("https://civo.com/docs/cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/civo/plugin.go
+++ b/plugins/civo/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "civo",
 		Platform: schema.PlatformInfo{
 			Name:     "Civo",
-			Homepage: sdk.URL("https://civo.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://civo.com"),
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),

--- a/plugins/civo/plugin.go
+++ b/plugins/civo/plugin.go
@@ -1,0 +1,22 @@
+package civo
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "civo",
+		Platform: schema.PlatformInfo{
+			Name:     "Civo",
+			Homepage: sdk.URL("https://civo.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			CivoCLI(),
+		},
+	}
+}

--- a/plugins/civo/test-fixtures/civo.json
+++ b/plugins/civo/test-fixtures/civo.json
@@ -1,0 +1,13 @@
+{
+    "apikeys": {
+      "newspidey": "XFIx85McyfCQc490j1tBa5b5s2XiWerNdOdfnkrOnchEXAMPLE"
+    },
+    "meta": {
+      "admin": false,
+      "current_apikey": "newspidey",
+      "default_region": "LON1",
+      "latest_release_check": "2023-06-11T20:25:06.916682112+05:30",
+      "url": "https://api.civo.com",
+      "last_command_executed": "2023-06-11T20:25:06.916237569+05:30"
+    }
+  }

--- a/plugins/civo/test-fixtures/civo.json
+++ b/plugins/civo/test-fixtures/civo.json
@@ -4,7 +4,7 @@
     },
     "meta": {
       "admin": false,
-      "current_apikey": "newspidey",
+      "current_apikey": "newspidey1",
       "default_region": "LON1",
       "latest_release_check": "2023-06-11T20:25:06.916682112+05:30",
       "url": "https://api.civo.com",


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test

Install Civo CLI
 https://www.civo.com/docs/overview/civo-cli
Test the plugin by running 
` op plugin init civo `
` civo region ls `
![image](https://github.com/1Password/shell-plugins/assets/85927700/67592e6d-9db8-4bcb-98d9-584edfd63c09)

<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


