### PR TITLE
Add support for multiple secrets to Pulumi shell plugin

### DIFF
--- a/plugins/pulumi/plugin.go
+++ b/plugins/pulumi/plugin.go
@@ -14,6 +14,7 @@ func New() schema.Plugin {
 		},
 		Credentials: []schema.CredentialType{
 			PulumiAccessToken(),
+			PulumiBackendEndpoint(),
 		},
 		Executables: []schema.Executable{
 			PulumiCLI(),

--- a/plugins/pulumi/pulumi.go
+++ b/plugins/pulumi/pulumi.go
@@ -7,6 +7,19 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
 
+var PulumiSubCommandsNeedingAuth = needsauth.IfAny(
+	needsauth.ForCommand("destroy"),
+	needsauth.ForCommand("import"),
+	needsauth.ForCommand("new"),
+	needsauth.ForCommand("org"),
+	needsauth.ForCommand("preview"),
+	needsauth.ForCommand("refresh"),
+	needsauth.ForCommand("stack"),
+	needsauth.ForCommand("state"),
+	needsauth.ForCommand("up"),
+	needsauth.ForCommand("whoami"),
+)
+
 func PulumiCLI() schema.Executable {
 	return schema.Executable{
 		Name:    "Pulumi CLI",
@@ -18,7 +31,26 @@ func PulumiCLI() schema.Executable {
 		),
 		Uses: []schema.CredentialUsage{
 			{
-				Name: credname.PersonalAccessToken,
+				Name:        credname.PersonalAccessToken,
+				Description: "Pulumi state backend configuration (token)",
+				Optional:    true,
+				NeedsAuth:   PulumiSubCommandsNeedingAuth,
+			},
+			{
+				Name:        BackendOnlyCredentialName,
+				Description: "Pulumi state backend configuration (backend)",
+				Optional:    true,
+				NeedsAuth:   PulumiSubCommandsNeedingAuth,
+			},
+			{
+				Description: "Credentials to use within the Pulumi project",
+				SelectFrom: &schema.CredentialSelection{
+					ID:                    "project",
+					IncludeAllCredentials: true,
+					AllowMultiple:         true,
+				},
+				Optional:  true,
+				NeedsAuth: PulumiSubCommandsNeedingAuth,
 			},
 		},
 	}


### PR DESCRIPTION
## Overview

Add support for multiple secrets in the Pulumi shell plugin.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Relates: #192

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
* Activate multiple plugins.
* Create a Pulumi project and create resources from a provider matching one of the shell plugins, e.g. Github.
* Run `pulumi up`
* Verify that:
   * the Pulumi access token was injected
   * the Github token was injected


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


