### PR TITLE
Add GitHub Actions workflow to check signed commits

### DIFF
--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,0 +1,13 @@
+name: Check signed commits in PR 
+on: pull_request
+
+jobs:
+  build:
+    name: Check signed commits in PR 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1


### PR DESCRIPTION
## Overview

Adds a GitHub Actions workflow on PRs to ensure all commits are signed, using the [check-signed-commits-action](https://github.com/1Password/check-signed-commits-action).


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## How To Test

Fork the repo and create a PR with an unsigned commit. The check should fail and you should see a comment on the PR.

## Changelog

N/A