### PR TITLE
update(akamai): Move provisioner to the executable-level CredentialUsage configuration

### DIFF
--- a/plugins/akamai/akamai.go
+++ b/plugins/akamai/akamai.go
@@ -3,6 +3,7 @@ package akamai
 import (
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/provision"
 	"github.com/1Password/shell-plugins/sdk/schema"
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
@@ -27,6 +28,14 @@ func AkamaiCLI() schema.Executable {
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIClientCredentials,
+				Provisioner: provision.TempFile(configFile,
+					provision.Filename(".edgerc"),
+					provision.AddArgs(
+						"--edgerc", "{{ .Path }}",
+						"--section", "default",
+					),
+					provision.SetPathAsEnvVar("EDGERC"), // for Akamai Terraform provider
+				),
 			},
 		},
 	}

--- a/plugins/akamai/api_client_credentials.go
+++ b/plugins/akamai/api_client_credentials.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
-	"github.com/1Password/shell-plugins/sdk/provision"
 	"github.com/1Password/shell-plugins/sdk/schema"
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
@@ -71,14 +70,7 @@ func APIClientCredentials() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.TempFile(configFile,
-			provision.Filename(".edgerc"),
-			provision.AddArgs(
-				"--edgerc", "{{ .Path }}",
-				"--section", "default",
-			),
-			provision.SetPathAsEnvVar("EDGERC"), // for Akamai Terraform provider
-		),
+		DefaultProvisioner: nil,
 		Importer: importer.TryAll(
 			TryAkamaiConfigFile(),
 		)}

--- a/plugins/akamai/api_client_credentials_test.go
+++ b/plugins/akamai/api_client_credentials_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAPIClientCredentialsProvisioner(t *testing.T) {
-	plugintest.TestProvisioner(t, APIClientCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+	plugintest.TestProvisioner(t, AkamaiCLI().Uses[0].Provisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.ClientSecret: "abcdE23FNkBxy456z25qx9Yp5CPUxlEfQeTDkfh4QA=I",


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Akamai provisioner is moved to the executable-level CredentialUsage configuration, thus making it work only for `akamai` commands. Akamai Terraform provider supported, if any in the future, will use the DefaultProvisioner instead. For now, the default provisioner is set to nil.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Relates: https://github.com/1Password/shell-plugins/issues/277

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Clone this branch and run `make akamai/build`
- Run `op plugin init akamai` to set up your Akamai credentials as a 1Password item.
- Follow the same testing instructions on [the original Akamai work](https://github.com/1Password/shell-plugins/pull/234). Does the command still succeed?

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Move Akamai provisioner to the executable-level CredentialUsage configuration.
