### PR TITLE
Silence logs generated by aws-vault on the AWS shell plugin

### DIFF
--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -3,8 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"time"
 
@@ -185,11 +183,8 @@ func (m CacheProviderFactory) NewAccessKeysProvider() aws.CredentialsProvider {
 
 // getAWSAuthConfigurationForProfile loads specified configurations from both config file and environment
 func getAWSAuthConfigurationForProfile(profile string) (*confighelpers.Config, error) {
-	// Disable log output produced by AWS Vault code
-	log.SetOutput(io.Discard)
-
 	// Read config file from the location set in AWS_CONFIG_FILE env var or from  ~/.aws/config
-	configFile, err := confighelpers.LoadConfigFromEnv()
+	configFile, err := ExecuteSilently(confighelpers.LoadConfigFromEnv)()
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"time"
 
@@ -179,6 +181,14 @@ func (m CacheProviderFactory) NewMFASessionTokenProvider(awsConfig *confighelper
 
 func (m CacheProviderFactory) NewAccessKeysProvider() aws.CredentialsProvider {
 	return accessKeysProvider{itemFields: m.ItemFields}
+}
+
+func ExecuteSilently[G interface{}, e error](f func() (G, e)) func() (G, e) {
+	return func() (G, e) {
+		log.SetOutput(io.Discard)
+		defer log.SetOutput(os.Stderr)
+		return f()
+	}
 }
 
 // getAWSAuthConfigurationForProfile loads specified configurations from both config file and environment

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -69,7 +69,7 @@ func (p STSProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, ou
 		return
 	}
 
-	tempCredentials, err := tempCredentialsProvider.Retrieve(ctx)
+	tempCredentials, err := ExecuteSilently(tempCredentialsProvider.Retrieve)(ctx)
 	if err != nil {
 		out.AddError(err)
 		return
@@ -266,7 +266,7 @@ type assumeRoleProvider struct {
 }
 
 func (p assumeRoleProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	credentials, err := ExecuteSilently(p.AssumeRoleProvider.Retrieve)(ctx)
+	credentials, err := p.AssumeRoleProvider.Retrieve(ctx)
 	if err != nil {
 		return aws.Credentials{}, err
 	}
@@ -303,7 +303,7 @@ type mfaSessionTokenProvider struct {
 }
 
 func (p mfaSessionTokenProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	credentials, err := ExecuteSilently(p.SessionTokenProvider.Retrieve)(ctx)
+	credentials, err := p.SessionTokenProvider.Retrieve(ctx)
 	if err != nil {
 		return aws.Credentials{}, err
 	}

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"time"
 
@@ -183,6 +185,9 @@ func (m CacheProviderFactory) NewAccessKeysProvider() aws.CredentialsProvider {
 
 // getAWSAuthConfigurationForProfile loads specified configurations from both config file and environment
 func getAWSAuthConfigurationForProfile(profile string) (*confighelpers.Config, error) {
+	// Disable log output produced by AWS Vault code
+	log.SetOutput(io.Discard)
+
 	// Read config file from the location set in AWS_CONFIG_FILE env var or from  ~/.aws/config
 	configFile, err := confighelpers.LoadConfigFromEnv()
 	if err != nil {

--- a/plugins/aws/utils.go
+++ b/plugins/aws/utils.go
@@ -2,7 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"os"
 
+	"github.com/99designs/aws-vault/v7/vault"
 	"gopkg.in/ini.v1"
 )
 
@@ -19,4 +23,13 @@ func getConfigSectionByProfile(configFile *ini.File, profileName string) *ini.Se
 	}
 
 	return nil
+}
+
+func ExecuteSilently(f func() (*vault.ConfigFile, error)) func() (*vault.ConfigFile, error) {
+	return func() (*vault.ConfigFile, error) {
+		log.SetOutput(io.Discard)
+		vaultConfig, err := f()
+		defer log.SetOutput(os.Stderr)
+		return vaultConfig, err
+	}
 }

--- a/plugins/aws/utils.go
+++ b/plugins/aws/utils.go
@@ -2,11 +2,7 @@ package aws
 
 import (
 	"fmt"
-	"io"
-	"log"
-	"os"
 
-	"github.com/99designs/aws-vault/v7/vault"
 	"gopkg.in/ini.v1"
 )
 
@@ -23,13 +19,4 @@ func getConfigSectionByProfile(configFile *ini.File, profileName string) *ini.Se
 	}
 
 	return nil
-}
-
-func ExecuteSilently(f func() (*vault.ConfigFile, error)) func() (*vault.ConfigFile, error) {
-	return func() (*vault.ConfigFile, error) {
-		log.SetOutput(io.Discard)
-		vaultConfig, err := f()
-		defer log.SetOutput(os.Stderr)
-		return vaultConfig, err
-	}
 }


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

When any `aws` command is run, the shell plugin currently outputs some additional logs related to the config file reader/importer. With the changes proposed on this PR, we'd hide those logs for now, but a long-term effort would be to identify why those logs are appearing and not printing them in the first place.

I have used the same solution that @williamhpark [outlined on the issue](https://github.com/1Password/shell-plugins/issues/254).

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: https://github.com/1Password/shell-plugins/issues/254

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Clone this branch
- Run `make aws/build`
- Set up AWS shell plugin with `op plugin init aws`
- Run any AWS command, like `aws s3 ls`
- Make sure that no additional logs appear before the `aws s3 ls`'s output appears.

Here's how it looks for me with the proposed changes:

<img width="1113" alt="image" src="https://github.com/1Password/shell-plugins/assets/18581859/ba282439-8ffb-4842-a662-7c89d1d85a5e">

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Silence AWS config file import logs while running any aws commands
