### PR TITLE
 Add support for Nirmata,cloud-native application management 

### DIFF
--- a/plugins/nirmata/api_token.go
+++ b/plugins/nirmata/api_token.go
@@ -32,6 +32,7 @@ func APIToken() schema.CredentialType {
 			{
 				Name:                fieldname.Email,
 				MarkdownDescription: "Email address registered in Nirmata.",
+				Optional:            true,
 			},
 			{
 				Name:                fieldname.Address,
@@ -65,13 +66,13 @@ func TryNirmataConfigFile() sdk.Importer {
 			if section.HasKey("address") && section.Key("address").Value() != "" {
 				fields[fieldname.Address] = section.Key("address").Value()
 			}
-			if section.HasKey("email") && section.Key("email").Value() != "" {
-				fields[fieldname.Email] = section.Key("email").Value()
-			}
+			// if section.HasKey("email") && section.Key("email").Value() != "" {
+			// 	fields[fieldname.Email] = section.Key("email").Value()
+			// }
 			if section.HasKey("token") && section.Key("token").Value() != "" {
 				fields[fieldname.Token] = section.Key("token").Value()
 			}
-			if fields[fieldname.Address] != "" && fields[fieldname.Email] != "" && fields[fieldname.Token] != "" {
+			if fields[fieldname.Token] != "" {
 				out.AddCandidate(sdk.ImportCandidate{
 					Fields: fields,
 				})
@@ -83,7 +84,6 @@ func TryNirmataConfigFile() sdk.Importer {
 }
 
 type Config struct {
-	Address string
-	Email   string
 	Token   string
+	Address string
 }

--- a/plugins/nirmata/api_token.go
+++ b/plugins/nirmata/api_token.go
@@ -45,17 +45,6 @@ func APIToken() schema.CredentialType {
 			TryNirmataConfigFile(),
 		)}
 }
-func configFile(in sdk.ProvisionInput) ([]byte, error) {
-	address := in.ItemFields[fieldname.Address]
-	email := in.ItemFields[fieldname.Email]
-	token := in.ItemFields[fieldname.Token]
-
-	contents := "address: " + address + "\n"
-	contents += "email: " + email + "\n"
-	contents += "token: " + token + "\n"
-
-	return []byte(contents), nil
-}
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"NIRMATA_TOKEN": fieldname.Token,

--- a/plugins/nirmata/api_token.go
+++ b/plugins/nirmata/api_token.go
@@ -14,8 +14,8 @@ import (
 func APIToken() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIToken,
-		DocsURL:       sdk.URL("https://nirmata.com/docs/api_token"),               // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://console.nirmata.com/user/security/tokens"), // TODO: Replace with actual URL
+		DocsURL:       sdk.URL("https://downloads.nirmata.io/nctl/downloads/"),
+		ManagementURL: sdk.URL("https://www.nirmata.io/security/login.html"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,

--- a/plugins/nirmata/api_token.go
+++ b/plugins/nirmata/api_token.go
@@ -36,6 +36,7 @@ func APIToken() schema.CredentialType {
 			{
 				Name:                fieldname.Address,
 				MarkdownDescription: "Url address of Nirmata[https://nirmata.io].",
+				Optional:            true,
 			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
@@ -48,7 +49,7 @@ func APIToken() schema.CredentialType {
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"NIRMATA_TOKEN": fieldname.Token,
-	"NIRMATA_URL":   fieldname.URL,
+	"NIRMATA_URL":   fieldname.Address,
 }
 
 func TryNirmataConfigFile() sdk.Importer {

--- a/plugins/nirmata/api_token.go
+++ b/plugins/nirmata/api_token.go
@@ -1,0 +1,99 @@
+package nirmata
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://nirmata.com/docs/api_token"),               // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.nirmata.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Nirmata.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 116,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Email,
+				MarkdownDescription: "Email address registered in Nirmata.",
+			},
+			{
+				Name:                fieldname.Address,
+				MarkdownDescription: "Url address of Nirmata[https://nirmata.io].",
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryNirmataConfigFile(),
+		)}
+}
+func configFile(in sdk.ProvisionInput) ([]byte, error) {
+	address := in.ItemFields[fieldname.Address]
+	email := in.ItemFields[fieldname.Email]
+	token := in.ItemFields[fieldname.Token]
+
+	contents := "address: " + address + "\n"
+	contents += "email: " + email + "\n"
+	contents += "token: " + token + "\n"
+
+	return []byte(contents), nil
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"NIRMATA_TOKEN": fieldname.Token,
+	"NIRMATA_URL":   fieldname.URL,
+}
+
+func TryNirmataConfigFile() sdk.Importer {
+	return importer.TryFile("~/.nirmata/config", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+
+		credentialsFile, err := contents.ToINI()
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+		for _, section := range credentialsFile.Sections() {
+			fields := make(map[sdk.FieldName]string)
+			if section.HasKey("address") && section.Key("address").Value() != "" {
+				fields[fieldname.Address] = section.Key("address").Value()
+			}
+			if section.HasKey("email") && section.Key("email").Value() != "" {
+				fields[fieldname.Email] = section.Key("email").Value()
+			}
+			if section.HasKey("token") && section.Key("token").Value() != "" {
+				fields[fieldname.Token] = section.Key("token").Value()
+			}
+			if fields[fieldname.Address] != "" && fields[fieldname.Email] != "" && fields[fieldname.Token] != "" {
+				out.AddCandidate(sdk.ImportCandidate{
+					Fields: fields,
+				})
+			}
+
+		}
+
+	})
+}
+
+type Config struct {
+	Address string
+	Email   string
+	Token   string
+}

--- a/plugins/nirmata/api_token_test.go
+++ b/plugins/nirmata/api_token_test.go
@@ -28,7 +28,7 @@ func TestAPITokenProvisioner(t *testing.T) {
 func TestAPITokenImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
+			Environment: map[string]string{
 				"NIRMATA_TOKEN": "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
 				"NIRMATA_URL":   "https://nirmata.io",
 			},

--- a/plugins/nirmata/api_token_test.go
+++ b/plugins/nirmata/api_token_test.go
@@ -12,8 +12,8 @@ func TestAPITokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.Token: "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
-				fieldname.URL:   "https://nirmata.io",
+				fieldname.Token:   "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+				fieldname.Address: "https://nirmata.io",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
@@ -35,8 +35,8 @@ func TestAPITokenImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Token: "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
-						fieldname.URL:   "https://nirmata.io",
+						fieldname.Token:   "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+						fieldname.Address: "https://nirmata.io",
 					},
 				},
 			},
@@ -49,9 +49,9 @@ func TestAPITokenImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Token: "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
-						fieldname.URL:   "https://nirmata.io",
-						fieldname.Email: "user@email.com",
+						fieldname.Token:   "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+						fieldname.Address: "https://nirmata.io",
+						fieldname.Email:   "user@email.com",
 					},
 				},
 			},

--- a/plugins/nirmata/api_token_test.go
+++ b/plugins/nirmata/api_token_test.go
@@ -1,0 +1,60 @@
+package nirmata
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+				fieldname.URL:   "https://nirmata.io",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NIRMATA_TOKEN": "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+					"NIRMATA_URL":   "https://nirmata.io",
+				},
+			},
+		},
+	})
+}
+
+func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"NIRMATA_TOKEN": "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+				"NIRMATA_URL":   "https://nirmata.io",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+						fieldname.URL:   "https://nirmata.io",
+					},
+				},
+			},
+		},
+
+		"config file": {
+			Files: map[string]string{
+				"~/.nirmata/config": plugintest.LoadFixture(t, "config"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
+						fieldname.URL:   "https://nirmata.io",
+						fieldname.Email: "user@email.com",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/nirmata/api_token_test.go
+++ b/plugins/nirmata/api_token_test.go
@@ -51,7 +51,6 @@ func TestAPITokenImporter(t *testing.T) {
 					Fields: map[sdk.FieldName]string{
 						fieldname.Token:   "fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample",
 						fieldname.Address: "https://nirmata.io",
-						fieldname.Email:   "user@email.com",
 					},
 				},
 			},

--- a/plugins/nirmata/nctl.go
+++ b/plugins/nirmata/nctl.go
@@ -1,0 +1,25 @@
+package nirmata
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func NirmataCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Nirmata CLI",
+		Runs:    []string{"nctl"},
+		DocsURL: sdk.URL("https://nirmata.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIToken,
+			},
+		},
+	}
+}

--- a/plugins/nirmata/nctl.go
+++ b/plugins/nirmata/nctl.go
@@ -15,6 +15,7 @@ func NirmataCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("login"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/nirmata/plugin.go
+++ b/plugins/nirmata/plugin.go
@@ -1,0 +1,22 @@
+package nirmata
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "nirmata",
+		Platform: schema.PlatformInfo{
+			Name:     "Nirmata",
+			Homepage: sdk.URL("https://nirmata.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIToken(),
+		},
+		Executables: []schema.Executable{
+			NirmataCLI(),
+		},
+	}
+}

--- a/plugins/nirmata/test-fixtures/config
+++ b/plugins/nirmata/test-fixtures/config
@@ -1,2 +1,2 @@
 address: https://nirmata.io
-token: oXcdvSstvdvx5uC+bfbDrv+UyQzalwluvcdfQa0HMzzRpjdvdUe9taD9cdsknlkca7IeVdHUibaxjakbcdlcVHcP9yA14A=
+token: fw90xpbsq8d1nzmdmbie0bcwk99x9rodqx72wfwif7y2hfbhq3gjg4bhcluw8b5qto5hwzfagsztgibbjs4rm8vswu6ppez8za9vhc2ozv5trexample

--- a/plugins/nirmata/test-fixtures/config
+++ b/plugins/nirmata/test-fixtures/config
@@ -1,3 +1,2 @@
 address: https://nirmata.io
-email: user@gmail.com
 token: oXcdvSstvdvx5uC+bfbDrv+UyQzalwluvcdfQa0HMzzRpjdvdUe9taD9cdsknlkca7IeVdHUibaxjakbcdlcVHcP9yA14A=

--- a/plugins/nirmata/test-fixtures/config
+++ b/plugins/nirmata/test-fixtures/config
@@ -1,0 +1,3 @@
+address: https://nirmata.io
+email: user@gmail.com
+token: oXcdvSstvdvx5uC+bfbDrv+UyQzalwluvcdfQa0HMzzRpjdvdUe9taD9cdsknlkca7IeVdHUibaxjakbcdlcVHcP9yA14A=


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
Download nctl CLI [from here](https://downloads.nirmata.io/nctl/downloads/)
Run the command
`nctl info`
to get 

![image](https://github.com/1Password/shell-plugins/assets/85927700/d07991e6-9639-473b-8589-fe29fc53e88d)
![image](https://github.com/1Password/shell-plugins/assets/85927700/3a2104dd-a0b9-4e4a-b923-723a406cc6c7)

<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


