### PR TITLE
AWS: Support source_profile

### DIFF
--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -411,7 +411,7 @@ func TestSTSProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, STSProvisioner{
 		profileName: "testSourceSimple",
 		newProviderFactory: func(cacheState sdk.CacheState, cacheOps sdk.CacheOperations, fields map[sdk.FieldName]string) STSProviderFactory {
-			return &mockProviderManager{map[sdk.FieldName]string{
+			return &mockProviderManager{itemFields: map[sdk.FieldName]string{
 				fieldname.AccessKeyID:     "AKIAHPIZFMD5EEXAMPLE",
 				fieldname.SecretAccessKey: "lBfKB7P5ScmpxDeRoFLZvhJbqNGPoV0vIEXAMPLE",
 			}}
@@ -729,5 +729,5 @@ func (m mockProviderManager) NewAssumeRoleProvider(awsConfig *confighelpers.Conf
 }
 
 func (m mockProviderManager) NewAccessKeysProvider() aws.CredentialsProvider {
-	return accessKeysProvider{m.itemFields}
+	return accessKeysProvider{itemFields: m.itemFields}
 }

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -620,7 +620,7 @@ func TestResolveLocalAnd1PasswordConfigurations(t *testing.T) {
 				ProfileName: "dev",
 				MfaSerial:   "arn:aws:iam::123456789012:mfa/user",
 			},
-			err: fmt.Errorf("MFA failed: an MFA serial was found but no OTP has been set up in 1Password"),
+			err: fmt.Errorf("MFA failed: the selected profile requires an OTP because an MFA serial (arn:aws:iam::123456789012:mfa/user) was detected but no 'One-Time Password' field was found in the associated item"),
 		},
 		{
 			description: "has region only in 1Password",

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -620,7 +620,7 @@ func TestResolveLocalAnd1PasswordConfigurations(t *testing.T) {
 				ProfileName: "dev",
 				MfaSerial:   "arn:aws:iam::123456789012:mfa/user",
 			},
-			err: fmt.Errorf("MFA failed: MFA serial \"arn:aws:iam::123456789012:mfa/user\" was detected on the associated item or in the config file for the selected profile, but no 'One-Time Password' field was found. Learn how to add an OTP field to your item: https://developer.1password.com/docs/cli/shell-plugins/aws/#optional-set-up-multi-factor-authentication"),
+			err: fmt.Errorf("MFA failed: MFA serial \"arn:aws:iam::123456789012:mfa/user\" was detected on the associated item or in the config file for the selected profile, but no 'One-Time Password' field was found.\nLearn how to add an OTP field to your item:\nhttps://developer.1password.com/docs/cli/shell-plugins/aws/#optional-set-up-multi-factor-authentication"),
 		},
 		{
 			description: "has region only in 1Password",

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -623,16 +623,6 @@ func TestResolveLocalAnd1PasswordConfigurations(t *testing.T) {
 			err: fmt.Errorf("MFA failed: an MFA serial was found but no OTP has been set up in 1Password"),
 		},
 		{
-			description: "has mfa token but no mfa serial",
-			itemFields: map[sdk.FieldName]string{
-				fieldname.OneTimePassword: "515467",
-			},
-			awsConfig: &confighelpers.Config{
-				ProfileName: "dev",
-			},
-			err: fmt.Errorf("MFA failed: an OTP was found wihtout a corresponding MFA serial"),
-		},
-		{
 			description: "has region only in 1Password",
 			itemFields: map[sdk.FieldName]string{
 				fieldname.OneTimePassword: "515467",

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -411,7 +411,7 @@ func TestSTSProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, STSProvisioner{
 		profileName: "testSourceSimple",
 		newProviderFactory: func(cacheState sdk.CacheState, cacheOps sdk.CacheOperations, fields map[sdk.FieldName]string) STSProviderFactory {
-			return &mockProviderManager{itemFields: map[sdk.FieldName]string{
+			return &mockProviderManager{ItemFields: map[sdk.FieldName]string{
 				fieldname.AccessKeyID:     "AKIAHPIZFMD5EEXAMPLE",
 				fieldname.SecretAccessKey: "lBfKB7P5ScmpxDeRoFLZvhJbqNGPoV0vIEXAMPLE",
 			}}
@@ -717,7 +717,7 @@ func (p mockAwsProvider) Retrieve(ctx context.Context) (aws.Credentials, error) 
 }
 
 type mockProviderManager struct {
-	itemFields map[sdk.FieldName]string
+	ItemFields map[sdk.FieldName]string
 }
 
 func (m mockProviderManager) NewMFASessionTokenProvider(awsConfig *confighelpers.Config, srcCredProvider aws.CredentialsProvider) aws.CredentialsProvider {
@@ -729,5 +729,5 @@ func (m mockProviderManager) NewAssumeRoleProvider(awsConfig *confighelpers.Conf
 }
 
 func (m mockProviderManager) NewAccessKeysProvider() aws.CredentialsProvider {
-	return accessKeysProvider{itemFields: m.itemFields}
+	return accessKeysProvider{itemFields: m.ItemFields}
 }

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -252,6 +252,16 @@ func TestAccessKeyDefaultProvisioner(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "awsConfig")
 	t.Setenv("AWS_CONFIG_FILE", configPath)
 
+	// setup profiles in config file
+	file := ini.Empty()
+	profileDefault, err := file.NewSection("default")
+	require.NoError(t, err)
+	_, err = profileDefault.NewKey("region", "us-central-1")
+	require.NoError(t, err)
+
+	err = file.SaveTo(configPath)
+	require.NoError(t, err)
+
 	plugintest.TestProvisioner(t, AccessKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -620,7 +620,7 @@ func TestResolveLocalAnd1PasswordConfigurations(t *testing.T) {
 				ProfileName: "dev",
 				MfaSerial:   "arn:aws:iam::123456789012:mfa/user",
 			},
-			err: fmt.Errorf("MFA failed: the selected profile requires an OTP because an MFA serial (arn:aws:iam::123456789012:mfa/user) was detected but no 'One-Time Password' field was found in the associated item"),
+			err: fmt.Errorf("MFA failed: an MFA serial (arn:aws:iam::123456789012:mfa/user) was detected on the associated item for the selected profile, but no 'One-Time Password' field was found. Add an OTP to your item to use multi-factor authentication"),
 		},
 		{
 			description: "has region only in 1Password",

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -620,7 +620,7 @@ func TestResolveLocalAnd1PasswordConfigurations(t *testing.T) {
 				ProfileName: "dev",
 				MfaSerial:   "arn:aws:iam::123456789012:mfa/user",
 			},
-			err: fmt.Errorf("MFA failed: an MFA serial (arn:aws:iam::123456789012:mfa/user) was detected on the associated item for the selected profile, but no 'One-Time Password' field was found. Add an OTP to your item to use multi-factor authentication"),
+			err: fmt.Errorf("MFA failed: MFA serial \"arn:aws:iam::123456789012:mfa/user\" was detected on the associated item or in the config file for the selected profile, but no 'One-Time Password' field was found. Learn how to add an OTP field to your item: https://developer.1password.com/docs/cli/shell-plugins/aws/#optional-set-up-multi-factor-authentication"),
 		},
 		{
 			description: "has region only in 1Password",

--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -656,10 +656,10 @@ type mockProviderManager struct {
 	CacheProviderFactory
 }
 
-func (m mockProviderManager) NewMFASessionTokenProvider(awsConfig *confighelpers.Config) aws.CredentialsProvider {
+func (m mockProviderManager) NewMFASessionTokenProvider(awsConfig *confighelpers.Config, srcCredProvider aws.CredentialsProvider) aws.CredentialsProvider {
 	return mockAwsProvider{}
 }
 
-func (m mockProviderManager) NewAssumeRoleProvider(awsConfig *confighelpers.Config) aws.CredentialsProvider {
+func (m mockProviderManager) NewAssumeRoleProvider(awsConfig *confighelpers.Config, srcCredProvider aws.CredentialsProvider) aws.CredentialsProvider {
 	return mockAwsProvider{}
 }

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -243,7 +243,7 @@ func resolveLocalAnd1PasswordConfigurations(itemFields map[sdk.FieldName]string,
 	}
 
 	if awsConfig.HasMfaSerial() && awsConfig.MfaToken == "" {
-		return fmt.Errorf("MFA failed: the selected profile requires an OTP because an MFA serial (%s) was detected but no 'One-Time Password' field was found in the associated item", awsConfig.MfaSerial)
+		return fmt.Errorf("MFA failed: an MFA serial (%s) was detected on the associated item for the selected profile, but no 'One-Time Password' field was found. Add an OTP to your item to use multi-factor authentication", awsConfig.MfaSerial)
 	}
 
 	if hasRegion && awsConfig.Region != "" && region != awsConfig.Region {
@@ -374,7 +374,7 @@ func DetectSourceProfileLoop(profile string, config *confighelpers.ConfigFile) e
 
 		profileSection, ok := config.ProfileSection(sourceProfile)
 		if !ok {
-			return fmt.Errorf("source profile %s does not exist in the config file", sourceProfile)
+			return fmt.Errorf("source profile %s does not exist in your AWS config file", sourceProfile)
 		}
 
 		sourceProfile = profileSection.SourceProfile

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -243,7 +243,7 @@ func resolveLocalAnd1PasswordConfigurations(itemFields map[sdk.FieldName]string,
 	}
 
 	if awsConfig.HasMfaSerial() && awsConfig.MfaToken == "" {
-		return fmt.Errorf("MFA failed: an MFA serial was found but no OTP has been set up in 1Password")
+		return fmt.Errorf("MFA failed: the selected profile requires an OTP because an MFA serial (%s) was detected but no 'One-Time Password' field was found in the associated item", awsConfig.MfaSerial)
 	}
 
 	if hasRegion && awsConfig.Region != "" && region != awsConfig.Region {
@@ -374,12 +374,12 @@ func DetectSourceProfileLoop(profile string, config *confighelpers.ConfigFile) e
 
 		profileSection, ok := config.ProfileSection(sourceProfile)
 		if !ok {
-			return fmt.Errorf("profile %s does not exist in the config file", sourceProfile)
+			return fmt.Errorf("source profile %s does not exist in the config file", sourceProfile)
 		}
 
 		sourceProfile = profileSection.SourceProfile
 
-		// profiles could source credentials from themselves. Ignore this case, as it gets nicely handled later.
+		// profiles could source credentials from themselves. Ignore this case, as it gets gracefully handled later.
 		if profileSection.Name == sourceProfile {
 			break
 		}

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -243,7 +243,9 @@ func resolveLocalAnd1PasswordConfigurations(itemFields map[sdk.FieldName]string,
 	}
 
 	if awsConfig.HasMfaSerial() && awsConfig.MfaToken == "" {
-		return fmt.Errorf("MFA failed: MFA serial %q was detected on the associated item or in the config file for the selected profile, but no 'One-Time Password' field was found. Learn how to add an OTP field to your item: https://developer.1password.com/docs/cli/shell-plugins/aws/#optional-set-up-multi-factor-authentication", awsConfig.MfaSerial)
+		return fmt.Errorf(`MFA failed: MFA serial %q was detected on the associated item or in the config file for the selected profile, but no 'One-Time Password' field was found.
+Learn how to add an OTP field to your item:
+https://developer.1password.com/docs/cli/shell-plugins/aws/#optional-set-up-multi-factor-authentication`, awsConfig.MfaSerial)
 	}
 
 	if hasRegion && awsConfig.Region != "" && region != awsConfig.Region {


### PR DESCRIPTION
## Overview
This change makes so that having `source_profile` in your `.aws/config` file doesn't error out and instead behaves as expected.

**This is the expected behaviour:**

1. Case 1: Only `source_profile` is specified in a profile. --> The source profile is inspected recursively and the right credentials provider is chosen to be used for the current profile. 

2. Case 2: `source_profile` is specified, alongside other role/mfa specific information (`role_arn`. `mfa_serial` etc) --> the source profile is inspected recursively to determine the right provider. This provider is then used as "base" credentials for executing SDK calls to the STS service for retrieving another set of temporary credentials as marked by the other role/mfa specific information present in the current profile.

**Further aspects regarding recursivity:**

- Base case for recursivity is using the access keys stored in the associated 1Password item.
- Endless loops caused by `source_profile` are handled when parsing the config file using was-vault's `LoadFromProfile` function.


## Type of change
<!--  
Check the box below that describes your change best:
--> 
- [x] Improved an existing plugin

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #212 

## How To Test
Use a config file that specifies `source_profile` and execute `aws sts get-caller-identity --profile <name>` to check that the right credentials were retrieved.

Example of config file:
```
[default]
source_profile=andy
output=json
region=us-east-1

[profile andy]
role_arn=arn:aws:iam::123456789012:role/testRole
mfa_serial=arn:aws:iam::123456789012:mfa/andi

[profile dev]
source_profile=Andy
role_arn=arn:aws:iam::123456789012:role/testRole1

[profile prod]
source_profile=dev
role_arn=arn:aws:iam::123456789012:role/testRole2
```


## Changelog
AWS Shell Plugin now supports sourcing credentials from another profile.

