### PR TITLE
Add support for docker cli login using Username and Email plugin

### DIFF
--- a/plugins/docker/docker.go
+++ b/plugins/docker/docker.go
@@ -1,0 +1,25 @@
+package docker
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func DockerCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Docker CLI",
+		Runs:    []string{"docker"},
+		DocsURL: sdk.URL("https://docker.com/docs/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.UserLogin,
+			},
+		},
+	}
+}

--- a/plugins/docker/plugin.go
+++ b/plugins/docker/plugin.go
@@ -1,0 +1,22 @@
+package docker
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "docker",
+		Platform: schema.PlatformInfo{
+			Name:     "Docker",
+			Homepage: sdk.URL("https://docker.com"),
+		},
+		Credentials: []schema.CredentialType{
+			UserLogin(),
+		},
+		Executables: []schema.Executable{
+			DockerCLI(),
+		},
+	}
+}

--- a/plugins/docker/user_login.go
+++ b/plugins/docker/user_login.go
@@ -1,0 +1,85 @@
+package docker
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func UserLogin() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.UserLogin,
+		DocsURL:       sdk.URL("https://docker.com/docs/user_login"),              // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.docker.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Username,
+				MarkdownDescription: "Username of the user registered in Docker.",
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password of the user registered in Docker.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+
+			TryDockerConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"DOCKER_USERNAME": fieldname.Username,
+	"DOCKER_PASSWORD": fieldname.Password,
+}
+
+func TryDockerConfigFile() sdk.Importer {
+	return importer.TryFile("~/.docker/config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+
+		var config struct {
+			Auths map[string]struct {
+				Auth string `json:"auth"`
+			} `json:"auths"`
+		}
+
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+		for _, auth := range config.Auths {
+			decoded, err := base64.StdEncoding.DecodeString(auth.Auth)
+			if err != nil {
+				out.AddError(err)
+				return
+			}
+			credentials := string(decoded)
+			username, password := parseCredentials(credentials)
+			if username != "" {
+				out.AddCandidate(sdk.ImportCandidate{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Username: username,
+						fieldname.Password: password,
+					},
+				})
+			}
+		}
+
+	})
+}
+
+func parseCredentials(credentials string) (username string, password string) {
+	parts := strings.SplitN(credentials, ":", 2)
+	if len(parts) == 2 {
+		username = parts[0]
+		password = parts[1]
+	}
+	return username, password
+}

--- a/plugins/docker/user_login_test.go
+++ b/plugins/docker/user_login_test.go
@@ -1,0 +1,59 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestUserLoginProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, UserLogin().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Username: "4LjPnJ2u4Yo02KRfP7ffF1Tf2eoDZxnvNEXAMPLE",
+				fieldname.Password: "12345",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"DOCKER_USERNAME": "4LjPnJ2u4Yo02KRfP7ffF1Tf2eoDZxnvNEXAMPLE",
+					"DOCKER_PASSWORD": "12345",
+				},
+			},
+		},
+	})
+}
+
+func TestUserLoginImporter(t *testing.T) {
+	plugintest.TestImporter(t, UserLogin().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"DOCKER_USERNAME": "4LjPnJ2u4Yo02KRfP7ffF1Tf2eoDZxnvNEXAMPLE",
+				"DOCKER_PASSWORD": "12345",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Username: "4LjPnJ2u4Yo02KRfP7ffF1Tf2eoDZxnvNEXAMPLE",
+						fieldname.Password: "12345",
+					},
+				},
+			},
+		},
+
+		"config file": {
+			Files: map[string]string{
+				"~/.docker/config.json": plugintest.LoadFixture(t, "config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Username: "4LjPnJ2u4Yo02KRfP7ffF1Tf2eoDZxnvNEXAMPLE",
+						fieldname.Password: "12345",
+					},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
Install docker cli
run `docker login` to import username and password of user logins
and run other command like `docker search` for searching the Docker Hub for images

<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
![image](https://github.com/1Password/shell-plugins/assets/85927700/b2369b50-2546-423d-9126-afbf37c087e9)

![image](https://github.com/1Password/shell-plugins/assets/85927700/6f86de19-e88f-46b0-b42a-a26c8a2a9735)



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


