### PR TITLE
Fix AWS importer nil pointer panic

### DIFF
--- a/plugins/aws/importers.go
+++ b/plugins/aws/importers.go
@@ -207,12 +207,14 @@ func GetProfilesInfo() ([]ProfileInfoToImport, error) {
 
 	// Get the region specified for the "default" profile
 	var defaultRegion string
-	if defaultSection, err := f.GetSection(defaultProfileName); err != nil && defaultSection.HasKey(configFileRegionKey) {
-		key, err := defaultSection.GetKey(configFileRegionKey)
-		if err != nil {
-			return nil, err
+	if f.HasSection(defaultProfileName) {
+		if defaultSection, err := f.GetSection(defaultProfileName); err != nil && defaultSection.HasKey(configFileRegionKey) {
+			key, err := defaultSection.GetKey(configFileRegionKey)
+			if err != nil {
+				return nil, err
+			}
+			defaultRegion = key.String()
 		}
-		defaultRegion = key.String()
 	}
 
 	var profiles []ProfileInfoToImport


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
A bug was introduced in this PR, which was uncovered through circumstantial testing. It is reproducible by initialising the aws plugin and importing.
<img width="1221" alt="Screenshot 2023-06-21 at 18 33 35" src="https://github.com/1Password/shell-plugins/assets/45081667/579384c3-e88f-40f8-b244-12ce9e7c6e6a">



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Fixed a bug in an existing plugin

## How To Test
remove the `[default]` section from your `.aws/config` and run `op plugin init aws` & select `Import` option

<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->




