### PR TITLE
Allow commit signing PR comment on fork PRs

### DIFF
--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,9 +1,12 @@
 name: Check signed commits in PR 
-on: pull_request
+on: pull_request_target
 
 jobs:
   build:
     name: Check signed commits in PR 
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/1Password/shell-plugins/pull/289

Currently, the commit signing check on PRs doesn't show the PR comment if the PR author is external.

This is because the passed in `GITHUB_TOKEN` does not have write access to the PR.

For more info about the problem and the solution, see [this write-up on the `actions/labeler` repo](https://github.com/actions/labeler#permissions) which has the same problem.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## How To Test

1. Create shell-plugins fork on personal namespace
2. Create a PR from a different account that does not have write access to the fork

## Changelog

N/A