### PR TITLE
Deta Shell Plugin

### DIFF
--- a/plugins/deta/api_key.go
+++ b/plugins/deta/api_key.go
@@ -15,7 +15,7 @@ func APIKey() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIKey,
 		DocsURL:       sdk.URL("https://deta.space/docs/en"), // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://deta.space"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://deta.space"),         // TODO: Replace with actual URL
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,

--- a/plugins/deta/api_key.go
+++ b/plugins/deta/api_key.go
@@ -40,7 +40,7 @@ func APIKey() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"DETA_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+	// "DETA_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
 }
 
 // TODO: Check if the platform stores the API Key in a local config file, and if so,

--- a/plugins/deta/api_key.go
+++ b/plugins/deta/api_key.go
@@ -46,7 +46,7 @@ var defaultEnvVarMapping = map[string]sdk.FieldName{
 // TODO: Check if the platform stores the API Key in a local config file, and if so,
 // implement the function below to add support for importing it.
 func TryDetaConfigFile() sdk.Importer {
-	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+	return importer.TryFile("~/.detaspace/space_tokens", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
 		// var config Config
 		// if err := contents.ToYAML(&config); err != nil {
 		// 	out.AddError(err)

--- a/plugins/deta/api_key.go
+++ b/plugins/deta/api_key.go
@@ -14,8 +14,8 @@ import (
 func APIKey() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIKey,
-		DocsURL:       sdk.URL("https://deta.com/docs/api_key"), // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://console.deta.com/user/security/tokens"), // TODO: Replace with actual URL
+		DocsURL:       sdk.URL("https://deta.space/docs/en"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://deta.space"), // TODO: Replace with actual URL
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,

--- a/plugins/deta/api_key.go
+++ b/plugins/deta/api_key.go
@@ -1,0 +1,71 @@
+package deta
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://deta.com/docs/api_key"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.deta.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Deta.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 25,
+					Prefix: "bE53FsM6_", // TODO: Check if this is correct
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryDetaConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"DETA_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the API Key in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryDetaConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.APIKey == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.APIKey: config.APIKey,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	APIKey string
+// }

--- a/plugins/deta/api_key_test.go
+++ b/plugins/deta/api_key_test.go
@@ -1,0 +1,55 @@
+package deta
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.APIKey: "bE53FsM6_z5lQ0VhneEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"DETA_API_KEY": "bE53FsM6_z5lQ0VhneEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"DETA_API_KEY": "bE53FsM6_z5lQ0VhneEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "bE53FsM6_z5lQ0VhneEXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in deta/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "bE53FsM6_z5lQ0VhneEXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/deta/plugin.go
+++ b/plugins/deta/plugin.go
@@ -1,0 +1,22 @@
+package deta
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "deta",
+		Platform: schema.PlatformInfo{
+			Name:     "Deta",
+			Homepage: sdk.URL("https://deta.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			DetaCLI(),
+		},
+	}
+}

--- a/plugins/deta/plugin.go
+++ b/plugins/deta/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "deta",
 		Platform: schema.PlatformInfo{
 			Name:     "Deta",
-			Homepage: sdk.URL("https://deta.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://deta.space"), // TODO: Check if this is correct
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),

--- a/plugins/deta/space.go
+++ b/plugins/deta/space.go
@@ -11,7 +11,7 @@ func DetaCLI() schema.Executable {
 	return schema.Executable{
 		Name:      "Deta CLI", // TODO: Check if this is correct
 		Runs:      []string{"space"},
-		DocsURL:   sdk.URL("https://deta.com/docs/cli"), // TODO: Replace with actual URL
+		DocsURL:   sdk.URL("https://deta.space/docs/en/build/fundamentals/space-cli"), // TODO: Replace with actual URL
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/deta/space.go
+++ b/plugins/deta/space.go
@@ -1,0 +1,25 @@
+package deta
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func DetaCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Deta CLI", // TODO: Check if this is correct
+		Runs:      []string{"space"},
+		DocsURL:   sdk.URL("https://deta.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin


## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


