### PR TITLE
Added Shell Plugin for Yugabyte

### DIFF
--- a/plugins/yugabytedb/database_credentials.go
+++ b/plugins/yugabytedb/database_credentials.go
@@ -1,0 +1,54 @@
+package yugabytedb
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func DatabaseCredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.DatabaseCredentials,
+		DocsURL:       sdk.URL("https://docs.yugabyte.com/preview/admin/ysqlsh/#connect-to-a-database"), 
+		ManagementURL: sdk.URL("https://cloud.yugabyte.com/"), 
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "Yugabyte host to connect to.",
+			},
+			{
+				Name:                fieldname.Port,
+				MarkdownDescription: "Port used to connect to Yugabyte.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.User,
+				MarkdownDescription: "Yugabyte user to authenticate as.",
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password used to authenticate to Yugabyte.",
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Database,
+				MarkdownDescription: "Database name to connect to.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"PGHOST":     fieldname.Host,
+	"PGPORT":     fieldname.Port,
+	"PGUSER":     fieldname.User,
+	"PGPASSWORD": fieldname.Password,
+	"PGDATABASE": fieldname.Database,
+}

--- a/plugins/yugabytedb/database_credentials.go
+++ b/plugins/yugabytedb/database_credentials.go
@@ -1,8 +1,6 @@
 package yugabytedb
 
 import (
-	"context"
-
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -14,8 +12,8 @@ import (
 func DatabaseCredentials() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.DatabaseCredentials,
-		DocsURL:       sdk.URL("https://docs.yugabyte.com/preview/admin/ysqlsh/#connect-to-a-database"), 
-		ManagementURL: sdk.URL("https://cloud.yugabyte.com/"), 
+		DocsURL:       sdk.URL("https://docs.yugabyte.com/preview/admin/ysqlsh/#connect-to-a-database"),
+		ManagementURL: sdk.URL("https://cloud.yugabyte.com/clusters"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Host,
@@ -27,8 +25,8 @@ func DatabaseCredentials() schema.CredentialType {
 				Optional:            true,
 			},
 			{
-				Name:                fieldname.User,
-				MarkdownDescription: "Yugabyte user to authenticate as.",
+				Name:                fieldname.Username,
+				MarkdownDescription: "Yugabyte user to get authenticate.",
 			},
 			{
 				Name:                fieldname.Password,
@@ -37,7 +35,7 @@ func DatabaseCredentials() schema.CredentialType {
 			},
 			{
 				Name:                fieldname.Database,
-				MarkdownDescription: "Database name to connect to.",
+				MarkdownDescription: "Database name to connect to Yugabyte.",
 				Optional:            true,
 			},
 		},
@@ -45,10 +43,11 @@ func DatabaseCredentials() schema.CredentialType {
 		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
 	}
 }
+
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"PGHOST":     fieldname.Host,
 	"PGPORT":     fieldname.Port,
-	"PGUSER":     fieldname.User,
+	"PGUSER":     fieldname.Username,
 	"PGPASSWORD": fieldname.Password,
 	"PGDATABASE": fieldname.Database,
 }

--- a/plugins/yugabytedb/database_credentials_test.go
+++ b/plugins/yugabytedb/database_credentials_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDatabaseCredentialsImporter(t *testing.T) {
 	plugintest.TestImporter(t, DatabaseCredentials().Importer, map[string]plugintest.ImportCase{
-		"default": {
+		"yugabyte": {
 			Environment: map[string]string{
 				"PGHOST":     "localhost",
 				"PGPORT":     "5432",
@@ -23,7 +23,7 @@ func TestDatabaseCredentialsImporter(t *testing.T) {
 					Fields: map[sdk.FieldName]string{
 						fieldname.Host:     "localhost",
 						fieldname.Port:     "5432",
-						fieldname.User:     "root",
+						fieldname.Username: "root",
 						fieldname.Password: "123456",
 						fieldname.Database: "test",
 					},
@@ -39,7 +39,7 @@ func TestDatabaseCredentialsProvisioner(t *testing.T) {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.Host:     "localhost",
 				fieldname.Port:     "5432",
-				fieldname.User:     "root",
+				fieldname.Username: "root",
 				fieldname.Password: "123456",
 				fieldname.Database: "test",
 			},
@@ -53,5 +53,6 @@ func TestDatabaseCredentialsProvisioner(t *testing.T) {
 				},
 			},
 		},
-	})
+	},
+	)
 }

--- a/plugins/yugabytedb/database_credentials_test.go
+++ b/plugins/yugabytedb/database_credentials_test.go
@@ -1,0 +1,57 @@
+package yugabytedb
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestDatabaseCredentialsImporter(t *testing.T) {
+	plugintest.TestImporter(t, DatabaseCredentials().Importer, map[string]plugintest.ImportCase{
+		"default": {
+			Environment: map[string]string{
+				"PGHOST":     "localhost",
+				"PGPORT":     "5432",
+				"PGUSER":     "root",
+				"PGPASSWORD": "123456",
+				"PGDATABASE": "test",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:     "localhost",
+						fieldname.Port:     "5432",
+						fieldname.User:     "root",
+						fieldname.Password: "123456",
+						fieldname.Database: "test",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestDatabaseCredentialsProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, DatabaseCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Host:     "localhost",
+				fieldname.Port:     "5432",
+				fieldname.User:     "root",
+				fieldname.Password: "123456",
+				fieldname.Database: "test",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"PGHOST":     "localhost",
+					"PGPORT":     "5432",
+					"PGUSER":     "root",
+					"PGPASSWORD": "123456",
+					"PGDATABASE": "test",
+				},
+			},
+		},
+	})
+}

--- a/plugins/yugabytedb/plugin.go
+++ b/plugins/yugabytedb/plugin.go
@@ -1,0 +1,22 @@
+package yugabytedb
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "yugabytedb",
+		Platform: schema.PlatformInfo{
+			Name:     "YugabyteDB",
+			Homepage: sdk.URL("https://yugabyte.com"),
+		},
+		Credentials: []schema.CredentialType{
+			DatabaseCredentials(),
+		},
+		Executables: []schema.Executable{
+			YugabyteDBCLI(),
+		},
+	}
+}

--- a/plugins/yugabytedb/ysqlsh.go
+++ b/plugins/yugabytedb/ysqlsh.go
@@ -1,0 +1,25 @@
+package yugabytedb
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func YugabyteDBCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "YugabyteDB SQL Shell",
+		Runs:      []string{"ysqlsh"},
+		DocsURL:   sdk.URL("https://docs.yugabyte.com/preview/admin/ysqlsh/"), 
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}

--- a/plugins/yugabytedb/ysqlsh.go
+++ b/plugins/yugabytedb/ysqlsh.go
@@ -9,12 +9,11 @@ import (
 
 func YugabyteDBCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "YugabyteDB SQL Shell",
-		Runs:      []string{"ysqlsh"},
-		DocsURL:   sdk.URL("https://docs.yugabyte.com/preview/admin/ysqlsh/"), 
+		Name:    "YugabyteDB SQL Shell",
+		Runs:    []string{"ysqlsh"},
+		DocsURL: sdk.URL("https://docs.yugabyte.com/preview/admin/ysqlsh/"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
-			needsauth.NotWithoutArgs(),
 		),
 		Uses: []schema.CredentialUsage{
 			{


### PR DESCRIPTION
## Overview
Added Yugabyte Shell Plugin Similar to Postgres



- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

