### PR TITLE
Add support for binance-cli plugin

### DIFF
--- a/plugins/binance/api_key.go
+++ b/plugins/binance/api_key.go
@@ -12,8 +12,8 @@ import (
 func APIKey() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIKey,
-		DocsURL:       sdk.URL("https://github.com/binance/binance-cli"), 
-		ManagementURL: sdk.URL("https://www.binance.com/en/my/settings/api-management"), 
+		DocsURL:       sdk.URL("https://github.com/binance/binance-cli"),
+		ManagementURL: sdk.URL("https://www.binance.com/en/my/settings/api-management"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,
@@ -49,7 +49,6 @@ func APIKey() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"BINANCE_API_KEY": fieldname.APIKey, 
-	"BINANCE_API_SECRET": fieldname.APISecret, 
+	"BINANCE_API_KEY":    fieldname.APIKey,
+	"BINANCE_API_SECRET": fieldname.APISecret,
 }
-

--- a/plugins/binance/api_key.go
+++ b/plugins/binance/api_key.go
@@ -43,8 +43,7 @@ func APIKey() schema.CredentialType {
 			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
-		Importer: importer.TryEnvVarPair(defaultEnvVarMapping,
-		)}
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{

--- a/plugins/binance/api_key.go
+++ b/plugins/binance/api_key.go
@@ -43,8 +43,7 @@ func APIKey() schema.CredentialType {
 			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
-		Importer: importer.TryAll(
-			importer.TryEnvVarPair(defaultEnvVarMapping),
+		Importer: importer.TryEnvVarPair(defaultEnvVarMapping,
 		)}
 }
 

--- a/plugins/binance/api_key.go
+++ b/plugins/binance/api_key.go
@@ -1,0 +1,55 @@
+package binance
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://github.com/binance/binance-cli"), 
+		ManagementURL: sdk.URL("https://www.binance.com/en/my/settings/api-management"), 
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Binance.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 64,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.APISecret,
+				MarkdownDescription: "API Key secret used to authenticate to Binance.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 64,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"BINANCE_API_KEY": fieldname.APIKey, 
+	"BINANCE_API_SECRET": fieldname.APISecret, 
+}
+

--- a/plugins/binance/api_key_test.go
+++ b/plugins/binance/api_key_test.go
@@ -2,24 +2,23 @@ package binance
 
 import (
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ 
-				fieldname.APIKey: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey:    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
 				fieldname.APISecret: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"BINANCE_API_KEY": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+					"BINANCE_API_KEY":    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
 					"BINANCE_API_SECRET": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
-
 				},
 			},
 		},
@@ -29,14 +28,14 @@ func TestAPIKeyProvisioner(t *testing.T) {
 func TestAPIKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ 
-				"BINANCE_API_KEY": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+			Environment: map[string]string{
+				"BINANCE_API_KEY":    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
 				"BINANCE_API_SECRET": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.APIKey: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+						fieldname.APIKey:    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
 						fieldname.APISecret: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
 					},
 				},

--- a/plugins/binance/api_key_test.go
+++ b/plugins/binance/api_key_test.go
@@ -13,12 +13,12 @@ func TestAPIKeyProvisioner(t *testing.T) {
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.APIKey:    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
-				fieldname.APISecret: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+				fieldname.APISecret: "2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qjThmEycY2J0RgJgNNrWQBqEXAMPLE",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
 					"BINANCE_API_KEY":    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
-					"BINANCE_API_SECRET": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+					"BINANCE_API_SECRET": "2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qjThmEycY2J0RgJgNNrWQBqEXAMPLE",
 				},
 			},
 		},
@@ -30,13 +30,13 @@ func TestAPIKeyImporter(t *testing.T) {
 		"environment": {
 			Environment: map[string]string{
 				"BINANCE_API_KEY":    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
-				"BINANCE_API_SECRET": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+				"BINANCE_API_SECRET": "2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qjThmEycY2J0RgJgNNrWQBqEXAMPLE",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
 						fieldname.APIKey:    "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
-						fieldname.APISecret: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+						fieldname.APISecret: "2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qjThmEycY2J0RgJgNNrWQBqEXAMPLE",
 					},
 				},
 			},

--- a/plugins/binance/api_key_test.go
+++ b/plugins/binance/api_key_test.go
@@ -1,0 +1,46 @@
+package binance
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ 
+				fieldname.APIKey: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+				fieldname.APISecret: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"BINANCE_API_KEY": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+					"BINANCE_API_SECRET": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ 
+				"BINANCE_API_KEY": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+				"BINANCE_API_SECRET": "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+						fieldname.APISecret: "jThmEycY2J0RgJgNNrWQBq2raPzKvxCkcwPQFk8AuWUu5QxQSWaItIB1qEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/binance/binance_cli.go
+++ b/plugins/binance/binance_cli.go
@@ -11,7 +11,7 @@ func BinanceCLI() schema.Executable {
 	return schema.Executable{
 		Name:      "Binance CLI", 
 		Runs:      []string{"binance-cli"},
-		DocsURL:   sdk.URL("https://binance.com/docs/cli"), 
+		DocsURL:   sdk.URL("https://github.com/binance/binance-cli"), 
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/binance/binance_cli.go
+++ b/plugins/binance/binance_cli.go
@@ -15,6 +15,16 @@ func BinanceCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("t"),
+			needsauth.NotWhenContainsArgs("i"),
+			needsauth.NotWhenContainsArgs("book"),
+			needsauth.NotWhenContainsArgs("at"),
+			needsauth.NotWhenContainsArgs("k"),
+			needsauth.NotWhenContainsArgs("ap"),
+			needsauth.NotWhenContainsArgs("ticker"),
+			needsauth.NotWhenContainsArgs("price"),
+			needsauth.NotWhenContainsArgs("bt"),
+			needsauth.NotWhenContainsArgs("listen"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/binance/binance_cli.go
+++ b/plugins/binance/binance_cli.go
@@ -9,9 +9,9 @@ import (
 
 func BinanceCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Binance CLI", 
-		Runs:      []string{"binance-cli"},
-		DocsURL:   sdk.URL("https://github.com/binance/binance-cli"), 
+		Name:    "Binance CLI",
+		Runs:    []string{"binance-cli"},
+		DocsURL: sdk.URL("https://github.com/binance/binance-cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/binance/binance_cli.go
+++ b/plugins/binance/binance_cli.go
@@ -1,0 +1,25 @@
+package binance
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func BinanceCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Binance CLI", 
+		Runs:      []string{"binance-cli"},
+		DocsURL:   sdk.URL("https://binance.com/docs/cli"), 
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/binance/plugin.go
+++ b/plugins/binance/plugin.go
@@ -1,0 +1,22 @@
+package binance
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "binance",
+		Platform: schema.PlatformInfo{
+			Name:     "Binance",
+			Homepage: sdk.URL("https://binance.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			BinanceCLI(),
+		},
+	}
+}

--- a/plugins/binance/plugin.go
+++ b/plugins/binance/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "binance",
 		Platform: schema.PlatformInfo{
 			Name:     "Binance",
-			Homepage: sdk.URL("https://binance.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://binance.com"), 
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),

--- a/plugins/binance/plugin.go
+++ b/plugins/binance/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "binance",
 		Platform: schema.PlatformInfo{
 			Name:     "Binance",
-			Homepage: sdk.URL("https://binance.com"), 
+			Homepage: sdk.URL("https://binance.com"),
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),


### PR DESCRIPTION
## Overview
Added support for binance-cli to store the  BINANCE_API_KEY &  BINANCE_API_SECRET in 1Password 


## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test

```
bseetharaman@EXT-C02D27NHMD6M ~ % binance-cli 
#######################################################################################
# WARNING: 'binance' is not from the official registry.                               #
# Only proceed if you are the developer of 'binance'.                                 #
# Otherwise, delete the file at /Users/bseetharaman/.config/op/plugins/local/binance. #
#######################################################################################
Usage: binance-cli [options] [command]

Options:
  -v, --version                            current version
  -h, --help                               display help for command

Commands:
  account|a                                Get account balance.
  agg_trades|at [options] <symbol>         Get compressed/aggregate trades list
  avg_price|ap <symbol>                    Get current average price
  book_ticker|bt [options]                 Get order book price
  buy [options]                            Place a buy order.
  cancel_all|ca <symbol>                   Cancel all open orders.
  cancel_order.|cancel [options] <symbol>  Cancel an order
  get_order.|get [options] <symbol>        Get an order details
  hist_trades|ht [options] <symbol>        Get historical trades. API key is required.
  info|i                                   Get exchange info
  klines|k [options] <symbol> <interval>   Get kline/candlestick data
  listen|l [streams...]                    Listen to a single or multiple streams. API key is required.
  order_book|ob [options] <symbol>         Get order book
  price [options]                          Get ticker price
  sell [options]                           Place a sell order.
  ticker [options]                         Get 24hr ticker data
  time|t                                   Get server time
  trades [options] <symbol>                Get recent trades
  help [command]                           display help for command

```

## Testing Notes
[binance_cli_test_logs.txt](https://github.com/1Password/shell-plugins/files/11893311/binance_cli_test_logs.txt)


## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

