### PR TITLE
Added plugin for DBT Redshift

### DIFF
--- a/plugins/dbtredshift/database_credentials.go
+++ b/plugins/dbtredshift/database_credentials.go
@@ -1,0 +1,51 @@
+package dbtredshift
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func DatabaseCredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.DatabaseCredentials,
+		DocsURL: sdk.URL("https://docs.getdbt.com/docs/core/connect-data-platform/redshift-setup#password-based-authentication"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "Redshift host to connect to.",
+			},
+			{
+				Name:                fieldname.Port,
+				MarkdownDescription: "Port used to connect to Redshift.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.User,
+				MarkdownDescription: "Redshift user to authenticate as.",
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password used to authenticate to Redshift.",
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Database,
+				MarkdownDescription: "Database name to connect to.",
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"DBT_HOST":     fieldname.Host,
+	"DBT_PORT":     fieldname.Port,
+	"DBT_USER":     fieldname.User,
+	"DBT_PASSWORD": fieldname.Password,
+	"DBT_DB":       fieldname.Database,
+}

--- a/plugins/dbtredshift/database_credentials_test.go
+++ b/plugins/dbtredshift/database_credentials_test.go
@@ -1,0 +1,57 @@
+package dbtredshift
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestDatabaseCredentialsProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, DatabaseCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Host:     "examplecluster.abc123xyz789.us-west-1.redshift.amazonaws.com",
+				fieldname.Port:     "5439",
+				fieldname.User:     "awsuser",
+				fieldname.Password: "my_password",
+				fieldname.Database: "dev",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"DBT_HOST":     "examplecluster.abc123xyz789.us-west-1.redshift.amazonaws.com",
+					"DBT_PORT":     "5439",
+					"DBT_USER":     "awsuser",
+					"DBT_PASSWORD": "my_password",
+					"DBT_DB":       "dev",
+				},
+			},
+		},
+	})
+}
+
+func TestDatabaseCredentialsImporter(t *testing.T) {
+	plugintest.TestImporter(t, DatabaseCredentials().Importer, map[string]plugintest.ImportCase{
+		"default": {
+			Environment: map[string]string{
+				"DBT_HOST":     "examplecluster.abc123xyz789.us-west-1.redshift.amazonaws.com",
+				"DBT_PORT":     "5439",
+				"DBT_USER":     "awsuser",
+				"DBT_PASSWORD": "my_password",
+				"DBT_DB":       "dev",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:     "examplecluster.abc123xyz789.us-west-1.redshift.amazonaws.com",
+						fieldname.Port:     "5439",
+						fieldname.User:     "awsuser",
+						fieldname.Password: "my_password",
+						fieldname.Database: "dev",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/dbtredshift/dbtredshift.go
+++ b/plugins/dbtredshift/dbtredshift.go
@@ -1,0 +1,25 @@
+package dbtredshift
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func dbtredshiftCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "dbtredshift",
+		Runs:    []string{"dbt"},
+		DocsURL: sdk.URL("https://docs.getdbt.com/docs/core/connect-data-platform/redshift-setup"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}

--- a/plugins/dbtredshift/plugin.go
+++ b/plugins/dbtredshift/plugin.go
@@ -1,0 +1,22 @@
+package dbtredshift
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "dbtredshift",
+		Platform: schema.PlatformInfo{
+			Name:     "DBT Redshift",
+			Homepage: sdk.URL("https://www.getdbt.com"),
+		},
+		Credentials: []schema.CredentialType{
+			DatabaseCredentials(),
+		},
+		Executables: []schema.Executable{
+			dbtredshiftCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
Added support for using 1Password to supply credentials when connecting to [Redshift](https://aws.amazon.com/redshift/) via [DBT CLI](https://docs.getdbt.com/docs/introduction).

DBT Redshift prefers password-based authentication with passwords stored in plain text file in project root folder or in `~/.DBT/profiles.yml` file. This plugin removes the need for storing DB passwords in plain text and injects them via env variables as and when required.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

NA

## Description

[DBT](https://www.getdbt.com/product/what-is-dbt/) is a popular data transformation tool. It allows you to connect to multiple data sources (data warehouses and data lakes) to run SQL queries for analytics. Since it can connect to multiple sources, connection setting varies for each source, and it is encapsulated in [profiles.yml](https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles) file.

We cannot use a single shell plugin to serve all sources as connection schema varies by source. This plugin attempts to provide a way to authenticate to AWS Redshift via password-based authentication.

## How To Test

### Pre-requisites
1. Redshift Cluster. (If you don't have redshift cluster, postgres db also works)
2. Install dbt-core and dbt-redshift (dbt-postgres if using postgres) packages. [Guide](https://docs.getdbt.com/docs/core/installation)
3. Create a new entry in your 1Password with credentials for connecting to Redshift. Fill host, port, database, user and password. Type can be 'postgres'.
4. Create new project or clone existing [dbt sample project](https://github.com/aws-samples/redshift-etl-automation-with-dbt/tree/master/src/dbt-project)
5. In the projects.yml file add the content below.
```yaml
config:
1pass_redshift:
  target: dev
  outputs:
    dev:
      type: redshift
      host: "{{ env_var('DBT_HOST') }}"
      port: "{{ env_var('DBT_PORT') | as_number }}"
      user: "{{ env_var('DBT_USER') }}"
      pass: "{{ env_var('DBT_PASSWORD') }}"
      dbname: "{{ env_var('DBT_DB') }}"
      schema: "some_schema_name"
```
6. Run `op init dbt` and use the item created in step 3.
7. You can now run dbt commands to connect to Redshift without having passwords exposed in the `profiles.yml` file.

Run log
```log

<user_name>@ test-folder % dbt run --select model_1 model_2 --profile 1pass_redshift --target dev
###################################################################################################
# WARNING: 'dbtredshift' is not from the official registry.                                       #
# Only proceed if you are the developer of 'dbtredshift'.                                         #
# Otherwise, delete the file at /Users/<user_name>/.config/op/plugins/local/dbtredshift. #
###################################################################################################
13:51:41  Running with dbt=1.5.2
13:51:43  Found 2 models, 0 tests, 0 snapshots, 0 analyses, 572 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
13:51:43   
13:52:33  Concurrency: 1 threads (target='dev')
13:52:33  
13:52:33  1 of 2 START sql table model some_schema_name.model_1 ........................................... [RUN]
13:52:42  1 of 2 OK created sql table model some_schema_name.model_1 ...................................... [SELECT in 8.65s]
13:52:42  2 of 2 START sql table model some_schema_name.model_2 ........................................................ [RUN]
13:52:58  2 of 2 OK created sql table model some_schema_name.model_2 ................................................... [SELECT in 16.78s] 
13:53:02  
13:53:02  Finished running 2 table models in 0 hours 1 minutes and 18.38 seconds (78.38s).
13:53:02  
13:53:02  Completed successfully
13:53:02  
13:53:02  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
```

Testing this plugin is an involved process as we need to have DB, some data in it along with DBT project setup to fully run it.

There is a single DBT CLI for all sources, so even though the plugin name is dbtredshift, we still bind to DBT CLI only.

## References
1. [AWS workshop for DBT](https://catalog.workshops.aws/dbt-cli-and-amazon-redshift/en-US/introduction)
2. [dbt-core](https://github.com/dbt-labs/dbt-core) GitHub repo
3. [dbt-redshift](https://github.com/dbt-labs/dbt-redshift) GitHub repo

PS: Sharing this plugin via GitHub for hackathon as I use this some form of this daily for work. Not endorsing DBT, AWS Redshift or my employer with these changes.

## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission
