### PR TITLE
 Netlify Shell Plugin

### DIFF
--- a/plugins/netlify/netlify.go
+++ b/plugins/netlify/netlify.go
@@ -1,0 +1,25 @@
+package netlify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func NetlifyCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Netlify CLI",
+		Runs:    []string{"netlify"},
+		DocsURL: sdk.URL("https://docs.netlify.com/cli/get-started/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAPIToken,
+			},
+		},
+	}
+}

--- a/plugins/netlify/personal_api_token.go
+++ b/plugins/netlify/personal_api_token.go
@@ -1,0 +1,68 @@
+package netlify
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAPIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAPIToken,
+		DocsURL:       sdk.URL("https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui"),
+		ManagementURL: sdk.URL("https://app.netlify.com/USER/applications"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Netlify.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 13,
+					Charset: schema.Charset{
+						Lowercase: true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryNetlifyConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"NETLIFY_AUTH_TOKEN": fieldname.Token, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the Personal API Token in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryNetlifyConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.Token == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.Token: config.Token,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	Token string
+// }

--- a/plugins/netlify/personal_api_token_test.go
+++ b/plugins/netlify/personal_api_token_test.go
@@ -1,0 +1,55 @@
+package netlify
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAPIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "qaywqkexample",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NETLIFY_AUTH_TOKEN": "qaywqkexample",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAPIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"NETLIFY_AUTH_TOKEN": "qaywqkexample",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "qaywqkexample",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in netlify/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				// 	{
+				// 		Fields: map[sdk.FieldName]string{
+				// 			fieldname.Token: "qaywqkexample",
+				// 		},
+				// 	},
+			},
+		},
+	})
+}

--- a/plugins/netlify/plugin.go
+++ b/plugins/netlify/plugin.go
@@ -1,0 +1,22 @@
+package netlify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "netlify",
+		Platform: schema.PlatformInfo{
+			Name:     "Netlify",
+			Homepage: sdk.URL("https://app.netlify.com/"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAPIToken(),
+		},
+		Executables: []schema.Executable{
+			NetlifyCLI(),
+		},
+	}
+}


### PR DESCRIPTION
Created a shell plugin for Netlify

## Overview
Created a new shell plugin for Netlify to enable seamless integration with 1Password Security.

## Type of change
- [ ✓] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
To test the Netlify shell plugin:
1. Install the latest version of 1Password CLI.
2. Run the `op plugin install netlify` command to install the Netlify plugin.
3. Configure your Netlify account credentials using  1password
4. Use various commands like `netlify Sites` to interact with Netlify resources and a popup will come out every time to authenticate using 1Password.

## Changelog
Created a shell plugin for seamless integration with Netlify Cli with 1Password.

## Additional information
- [ ✓] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/h
