### PR TITLE
Firebase Shell Plugin

### DIFF
--- a/plugins/firebase/access_token.go
+++ b/plugins/firebase/access_token.go
@@ -1,0 +1,70 @@
+package firebase
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://firebase.google.com/docs/cli#cli-ci-systems"),
+		ManagementURL: sdk.URL("https://firebase.google.com/docs/cli#cli-ci-systems"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to firebase.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 53,
+					Prefix: "dummy_firebase_", // TODO: Check if this is correct
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryfirebaseConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"FIREBASE_TOKEN": fieldname.Token, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the Access Token in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryfirebaseConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.Token == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.Token: config.Token,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	Token string
+// }

--- a/plugins/firebase/access_token_test.go
+++ b/plugins/firebase/access_token_test.go
@@ -1,0 +1,55 @@
+package firebase
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "dummy_firebase_3bhfuelt31a99503j251bua8rov58m2example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"FIREBASE_TOKEN": "dummy_firebase_3bhfuelt31a99503j251bua8rov58m2example",
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"FIREBASE_TOKEN": "dummy_firebase_3bhfuelt31a99503j251bua8rov58m2example",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "dummy_firebase_3bhfuelt31a99503j251bua8rov58m2example",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in firebase/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "dummy_firebase_3bhfuelt31a99503j251bua8rov58m2example",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/firebase/firebase.go
+++ b/plugins/firebase/firebase.go
@@ -1,0 +1,25 @@
+package firebase
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func firebaseCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Firebase CLI",
+		Runs:    []string{"firebase"},
+		DocsURL: sdk.URL("https://firebase.google.com/docs/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/plugins/firebase/plugin.go
+++ b/plugins/firebase/plugin.go
@@ -1,0 +1,22 @@
+package firebase
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "firebase",
+		Platform: schema.PlatformInfo{
+			Name:     "firebase",
+			Homepage: sdk.URL("https://firebase.google.com/"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			firebaseCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
Added support for Firebase Shell plugin to authenticate using 1Password.

## Type of change
- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience



## How To Test
To test the changes:
1. Install the Firebase CLI on a machine with a browser.
2. Run the command `firebase login:ci` to start the signin process.
3. Visit the provided URL and log in using a Google account.
4. Print the new refresh token.
5. Store the output token securely in your CI system.
6. Run Firebase CLI commands using the token with `firebase <command> --token <token>`.

## Changelog
Authenticate Firebase CLI using 1Password for secure token storage.

## Additional information
- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission
