### PR TITLE
Netlify shell plugin

### DIFF
--- a/plugins/netlify/netlify.go
+++ b/plugins/netlify/netlify.go
@@ -1,0 +1,26 @@
+package netlify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func NetlifyCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Netlify CLI",
+    	Runs:      []string{"netlify"},
+		DocsURL:   sdk.URL("https://netlify.com/docs/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("config"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/netlify/personal_access_token.go
+++ b/plugins/netlify/personal_access_token.go
@@ -1,0 +1,87 @@
+package netlify
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAccessToken,
+		DocsURL:       sdk.URL("https://docs.netlify.com/cli/get-started/#authentication"),
+		ManagementURL: sdk.URL("https://app.netlify.com/user/applications#personal-access-tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Netlify.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 43,
+					Prefix: "tGtp-",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryNetlifyConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName {
+"NETLIFY_AUTH_TOKEN": fieldname.Token,
+}
+
+func TryNetlifyConfigFile() sdk.Importer {
+	return importer.TryFile("~/Library/Preferences/netlify/config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.Users != nil {
+			for _, user := range config.Users {
+				if user.Auth != nil && user.Auth.Token != "" {
+					out.AddCandidate(sdk.ImportCandidate{
+						Fields: map[sdk.FieldName]string{
+							fieldname.Token: user.Auth.Token,
+						},
+					})
+				}
+			}
+		}
+	})
+}
+
+type Config struct {
+	TelemetryDisabled bool                `json:"telemetryDisabled"`
+	CliID             string              `json:"cliId"`
+	UserID            string              `json:"userId"`
+	Users             map[string]UserInfo `json:"users"`
+}
+
+// UserInfo represents the user information in the config file
+type UserInfo struct {
+	ID    string        `json:"id"`
+	Name  string        `json:"name"`
+	Email string        `json:"email"`
+	Auth  *UserAuthInfo `json:"auth"`
+}
+
+// UserAuthInfo represents the authentication information of a user
+type UserAuthInfo struct {
+	Token   string `json:"token"`
+	Github  struct{} `json:"github"` // Empty struct for placeholder, you can add additional fields if needed
+}

--- a/plugins/netlify/personal_access_token_test.go
+++ b/plugins/netlify/personal_access_token_test.go
@@ -1,0 +1,54 @@
+package netlify
+
+import (
+	"testing"
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "tGtp-IMFGyRcoLdK40zQ4ENKfvDeIOASs1ilEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NETLIFY_TOKEN": "tGtp-IMFGyRcoLdK40zQ4ENKfvDeIOASs1ilEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"NETLIFY_TOKEN": "tGtp-IMFGyRcoLdK40zQ4ENKfvDeIOASs1ilEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "tGtp-IMFGyRcoLdK40zQ4ENKfvDeIOASs1ilEXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in netlify/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "tGtp-IMFGyRcoLdK40zQ4ENKfvDeIOASs1ilEXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/netlify/plugin.go
+++ b/plugins/netlify/plugin.go
@@ -1,0 +1,22 @@
+package netlify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "netlify",
+		Platform: schema.PlatformInfo{
+			Name:     "Netlify",
+			Homepage: sdk.URL("https://netlify.com"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			NetlifyCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Netlify 1Password shell plugin for Netlify CLI

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

netlify login

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
The shell plugin looks for the Netlify CLI's environment variables and imports them into 1Password.
If there are no environment variables in the current shell session, 1Password prompts the user to manually enter them.
Provisions the shell plugin for every "netlify" command (except help and version commands) with the environment variables.

## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

