### PR TITLE
Add support for Zapier CLI

### DIFF
--- a/plugins/zapier/deploy_key.go
+++ b/plugins/zapier/deploy_key.go
@@ -1,0 +1,75 @@
+package zapier
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func DeployKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.DeployKey,
+		DocsURL:       sdk.URL("https://platform.zapier.com/cli_docs/docs#quick-setup-guide"),
+		ManagementURL: sdk.URL("https://developer.zapier.com/partner-settings/deploy-keys/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Key,
+				MarkdownDescription: "Deploy Key used to authenticate to Zapier.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 32,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			zapierConfig,
+			provision.AtFixedPath("~/.zapierrc"),
+		),
+		Importer: TryZapierConfigFile(),
+	}
+}
+
+func TryZapierConfigFile() sdk.Importer {
+	return importer.TryFile("~/.zapierrc", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.DeployKey == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Key: config.DeployKey,
+			},
+		})
+	})
+}
+
+type Config struct {
+	DeployKey string `json:"deployKey"`
+}
+
+func zapierConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		DeployKey: in.ItemFields[fieldname.Key],
+	}
+	contents, err := json.MarshalIndent(&config, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return []byte(contents), nil
+}

--- a/plugins/zapier/deploy_key_test.go
+++ b/plugins/zapier/deploy_key_test.go
@@ -1,0 +1,45 @@
+package zapier
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestDeployKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, DeployKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"config file": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Key: "bd0moxtb5vk3koppai1f3ituiexample",
+			},
+			CommandLine: []string{"zapier"},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"zapier"},
+				Files: map[string]sdk.OutputFile{
+					"~/.zapierrc": {
+						Contents: []byte(plugintest.LoadFixture(t, ".zapierrc")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestDeployKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, DeployKey().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.zapierrc": plugintest.LoadFixture(t, ".zapierrc"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Key: "bd0moxtb5vk3koppai1f3ituiexample",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/zapier/plugin.go
+++ b/plugins/zapier/plugin.go
@@ -1,0 +1,22 @@
+package zapier
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "zapier",
+		Platform: schema.PlatformInfo{
+			Name:     "Zapier",
+			Homepage: sdk.URL("https://zapier.com"),
+		},
+		Credentials: []schema.CredentialType{
+			DeployKey(),
+		},
+		Executables: []schema.Executable{
+			ZapierCLI(),
+		},
+	}
+}

--- a/plugins/zapier/test-fixtures/.zapierrc
+++ b/plugins/zapier/test-fixtures/.zapierrc
@@ -1,0 +1,3 @@
+{
+  "deployKey": "bd0moxtb5vk3koppai1f3ituiexample"
+}

--- a/plugins/zapier/zapier.go
+++ b/plugins/zapier/zapier.go
@@ -1,0 +1,25 @@
+package zapier
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ZapierCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Zapier CLI",
+		Runs:    []string{"zapier"},
+		DocsURL: sdk.URL("https://platform.zapier.com/cli_docs/docs"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DeployKey,
+			},
+		},
+	}
+}

--- a/sdk/schema/credname/names.go
+++ b/sdk/schema/credname/names.go
@@ -16,6 +16,7 @@ const (
 	Credential           = sdk.CredentialName("Credential")
 	Credentials          = sdk.CredentialName("Credentials")
 	DatabaseCredentials  = sdk.CredentialName("Database Credentials")
+	DeployKey            = sdk.CredentialName("Deploy Key")
 	LoginDetails         = sdk.CredentialName("Login Details")
 	PersonalAPIToken     = sdk.CredentialName("Personal API Token")
 	PersonalAccessToken  = sdk.CredentialName("Personal Access Token")
@@ -38,6 +39,7 @@ func ListAll() []sdk.CredentialName {
 		Credential,
 		Credentials,
 		DatabaseCredentials,
+		DeployKey,
 		LoginDetails,
 		PersonalAPIToken,
 		PersonalAccessToken,


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add support for Zapier CLI. The shell plugin provisions a configuration file at `~/.zapierrc`. The shell plugin also imports the deploy key from the same file at the same path, if it exists.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install Zapier CLI and set up the shell plugin.
- Create a Zapier project with `zapier init` and enter that Zapier folder.
- Test with `zapier register`. You should get a response asking for `? What is the title of your integration?` Any other response is an indication of a failure of the provisioner.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

