### PR TITLE
Add support for Pipedream CLI

### DIFF
--- a/plugins/pipedream/api_key.go
+++ b/plugins/pipedream/api_key.go
@@ -14,8 +14,8 @@ import (
 func APIKey() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIKey,
-		DocsURL:       sdk.URL("https://pipedream.com/docs/api_key"),                 // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://console.pipedream.com/user/security/tokens"), // TODO: Replace with actual URL
+		DocsURL:       sdk.URL("https://pipedream.com/docs/api_key"),
+		ManagementURL: sdk.URL("https://console.pipedream.com/user/security/tokens"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,

--- a/plugins/pipedream/api_key.go
+++ b/plugins/pipedream/api_key.go
@@ -32,7 +32,7 @@ func APIKey() schema.CredentialType {
 			{
 				Name:                fieldname.OrgID,
 				MarkdownDescription: "OrgId for the Pipedream organization.",
-				Secret:              true,
+				Secret:              false,
 				Optional:            true,
 				Composition: &schema.ValueComposition{
 					Length: 9,

--- a/plugins/pipedream/api_key.go
+++ b/plugins/pipedream/api_key.go
@@ -33,6 +33,7 @@ func APIKey() schema.CredentialType {
 				Name:                fieldname.OrgID,
 				MarkdownDescription: "OrgId for the Pipedream organization.",
 				Secret:              true,
+				Optional:            true,
 				Composition: &schema.ValueComposition{
 					Length: 9,
 					Charset: schema.Charset{
@@ -71,9 +72,10 @@ func TryPipedreamConfigFile() sdk.Importer {
 				fields[fieldname.OrgID] = section.Key("org_id").Value()
 			}
 
-			if fields[fieldname.APIKey] != "" && fields[fieldname.OrgID] != "" {
+			if fields[fieldname.APIKey] != "" {
 				out.AddCandidate(sdk.ImportCandidate{
-					Fields: fields,
+					Fields:   fields,
+					NameHint: importer.SanitizeNameHint(section.Name()),
 				})
 			}
 		}

--- a/plugins/pipedream/api_key.go
+++ b/plugins/pipedream/api_key.go
@@ -1,0 +1,100 @@
+package pipedream
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://pipedream.com/docs/api_key"),                 // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.pipedream.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Pipedream.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 32,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.OrgID,
+				MarkdownDescription: "OrgId for the Pipedream organization.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 9,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Uppercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			pipedreamConfig,
+			provision.AtFixedPath("~/.config/pipedream/config"),
+		),
+		Importer: importer.TryAll(
+			TryPipedreamConfigFile(),
+		)}
+}
+
+func TryPipedreamConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/pipedream/config", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		configFile, err := contents.ToINI()
+
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for _, section := range configFile.Sections() {
+			fields := make(map[sdk.FieldName]string)
+			if section.HasKey("api_key") && section.Key("api_key").Value() != "" {
+				fields[fieldname.APIKey] = section.Key("api_key").Value()
+			}
+			if section.HasKey("org_id") && section.Key("org_id").Value() != "" {
+				fields[fieldname.OrgID] = section.Key("org_id").Value()
+			}
+
+			if fields[fieldname.APIKey] != "" && fields[fieldname.OrgID] != "" {
+				out.AddCandidate(sdk.ImportCandidate{
+					Fields: fields,
+				})
+			}
+		}
+	})
+}
+
+type Config struct {
+	APIKey string
+	OrgId  string
+}
+
+func pipedreamConfig(in sdk.ProvisionInput) ([]byte, error) {
+	contents := ""
+
+	if apikey, ok := in.ItemFields[fieldname.APIKey]; ok {
+		contents += "api_key = " + apikey + "\n"
+	}
+
+	if orgid, ok := in.ItemFields[fieldname.OrgID]; ok {
+		contents += "org_id = " + orgid + "\n"
+	}
+
+	return []byte(contents), nil
+}

--- a/plugins/pipedream/api_key_test.go
+++ b/plugins/pipedream/api_key_test.go
@@ -12,13 +12,13 @@ func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"config file": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.Key:   "9cfvvd7bp6099paodoua5shfoexample",
-				fieldname.OrgID: "b_EXAMPLE",
+				fieldname.APIKey: "ugvfxesz62ycsl42z49c0t1hjexample",
+				fieldname.OrgID:  "YbEXAMPLE",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Files: map[string]sdk.OutputFile{
 					"~/.config/pipedream/config": {
-						Contents: []byte(plugintest.LoadFixture(t, "config")),
+						Contents: []byte(plugintest.LoadFixture(t, "provision")),
 					},
 				},
 			},
@@ -30,14 +30,28 @@ func TestAPIKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
 		"config file": {
 			Files: map[string]string{
-				"~/.config/pipedream/config": plugintest.LoadFixture(t, "config"),
+				"~/.config/pipedream/config": plugintest.LoadFixture(t, "import"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.APIKey: "9cfvvd7bp6099paodoua5shfoexample",
-						fieldname.OrgID:  "b_EXAMPLE",
+						fieldname.APIKey: "ugvfxesz62ycsl42z49c0t1hjexample",
+						fieldname.OrgID:  "YbEXAMPLE",
 					},
+					NameHint: "DEFAULT",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "5puf32rvhkz83c6oj4wpxvaniexample",
+						fieldname.OrgID:  "KVEXAMPLE",
+					},
+					NameHint: "first",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "lgx1amb0qf7mjy6y7nkgfc3x9example",
+					},
+					NameHint: "second",
 				},
 			},
 		},

--- a/plugins/pipedream/api_key_test.go
+++ b/plugins/pipedream/api_key_test.go
@@ -1,0 +1,45 @@
+package pipedream
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"config file": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Key:   "9cfvvd7bp6099paodoua5shfoexample",
+				fieldname.OrgID: "b_EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					"~/.config/pipedream/config": {
+						Contents: []byte(plugintest.LoadFixture(t, "config")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.config/pipedream/config": plugintest.LoadFixture(t, "config"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "9cfvvd7bp6099paodoua5shfoexample",
+						fieldname.OrgID:  "b_EXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/pipedream/pd.go
+++ b/plugins/pipedream/pd.go
@@ -1,0 +1,25 @@
+package pipedream
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func PipedreamCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Pipedream CLI",
+		Runs:    []string{"pd"},
+		DocsURL: sdk.URL("https://pipedream.com/docs/cli/reference/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/pipedream/pd.go
+++ b/plugins/pipedream/pd.go
@@ -15,6 +15,8 @@ func PipedreamCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("-p"),
+			needsauth.NotWhenContainsArgs("--profile"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/pipedream/plugin.go
+++ b/plugins/pipedream/plugin.go
@@ -1,0 +1,22 @@
+package pipedream
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "pipedream",
+		Platform: schema.PlatformInfo{
+			Name:     "Pipedream",
+			Homepage: sdk.URL("https://pipedream.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			PipedreamCLI(),
+		},
+	}
+}

--- a/plugins/pipedream/test-fixtures/config
+++ b/plugins/pipedream/test-fixtures/config
@@ -1,2 +1,0 @@
-api_key = 9cfvvd7bp6099paodoua5shfoexample
-org_id  = b_EXAMPLE

--- a/plugins/pipedream/test-fixtures/config
+++ b/plugins/pipedream/test-fixtures/config
@@ -1,0 +1,2 @@
+api_key = 9cfvvd7bp6099paodoua5shfoexample
+org_id  = b_EXAMPLE

--- a/plugins/pipedream/test-fixtures/import
+++ b/plugins/pipedream/test-fixtures/import
@@ -1,0 +1,9 @@
+api_key = ugvfxesz62ycsl42z49c0t1hjexample
+org_id = YbEXAMPLE
+
+[first]
+api_key = 5puf32rvhkz83c6oj4wpxvaniexample
+org_id = KVEXAMPLE
+
+[second]
+api_key = lgx1amb0qf7mjy6y7nkgfc3x9example

--- a/plugins/pipedream/test-fixtures/provision
+++ b/plugins/pipedream/test-fixtures/provision
@@ -1,0 +1,2 @@
+api_key = ugvfxesz62ycsl42z49c0t1hjexample
+org_id = YbEXAMPLE

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -36,6 +36,7 @@ const (
 	Mode            = sdk.FieldName("Mode")
 	Namespace       = sdk.FieldName("Namespace")
 	OneTimePassword = sdk.FieldName("One-Time Password")
+	OrgID           = sdk.FieldName("Org ID")
 	OrgURL          = sdk.FieldName("Org URL")
 	Organization    = sdk.FieldName("Organization")
 	Password        = sdk.FieldName("Password")
@@ -86,6 +87,7 @@ func ListAll() []sdk.FieldName {
 		Mode,
 		Namespace,
 		OneTimePassword,
+		OrgID,
 		OrgURL,
 		Organization,
 		Password,


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add support for Pipedream CLI. The shell plugin provisions a configuration file at `~/.config/pipedream/config`. The shell plugin also imports the API Key and the Org ID from the same file at the same path, if they exist.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install Pipedream CLI and set up the shell plugin.
- If the config file exists at `~/.config/pipedream/config`, the first time `op plugin init pd` is run, the API Key and Org ID can be imported into 1Password.
- Test with `pd login status`. It should show that the login is successful.

## Changelog

Add support for Pipedream CLI
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

