### PR TITLE
Add support for ipinfo CLI

### DIFF
--- a/plugins/ipinfo/access_token.go
+++ b/plugins/ipinfo/access_token.go
@@ -1,0 +1,84 @@
+package ipinfo
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessToken,
+		DocsURL:       nil,
+		ManagementURL: sdk.URL("https://ipinfo.io/account/token"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.AccessToken,
+				MarkdownDescription: "Access Token used to authenticate to IPinfo.io.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 14,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			ipinfoConfig,
+			provision.AtFixedPath("~/Library/Application Support/ipinfo/config.json"),
+		),
+		Importer: importer.TryAll(
+			TryIpinfoConfigFile("~/Library/Application Support/ipinfo/config.json"),
+		)}
+}
+
+func TryIpinfoConfigFile(path string) sdk.Importer {
+	return importer.TryFile(
+		path,
+		func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+			var config Config
+			if err := contents.ToJSON(&config); err != nil {
+				out.AddError(err)
+				return
+			}
+
+			if config.Token == "" {
+				return
+			}
+
+			out.AddCandidate(
+				sdk.ImportCandidate{
+					Fields: map[sdk.FieldName]string{
+						fieldname.AccessToken: config.Token,
+					},
+				},
+			)
+		},
+	)
+}
+
+type Config struct {
+	CacheEnabled bool   `json:"cache_enabled"`
+	Token        string `json:"token"`
+}
+
+func ipinfoConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		CacheEnabled: false,
+		Token:        in.ItemFields[fieldname.AccessToken],
+	}
+	contents, err := json.Marshal(&config)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(contents), nil
+}

--- a/plugins/ipinfo/access_token_test.go
+++ b/plugins/ipinfo/access_token_test.go
@@ -1,0 +1,43 @@
+package ipinfo
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.AccessToken: "OYjuTe0EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					"~/Library/Application Support/ipinfo/config.json": {
+						Contents: []byte(plugintest.LoadFixture(t, "config.json")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/Library/Application Support/ipinfo/config.json": plugintest.LoadFixture(t, "config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.AccessToken: "OYjuTe0EXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/ipinfo/ipinfo.go
+++ b/plugins/ipinfo/ipinfo.go
@@ -1,0 +1,25 @@
+package ipinfo
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func IPinfoCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "IPinfo.io CLI",
+		Runs:    []string{"ipinfo"},
+		DocsURL: sdk.URL("https://github.com/ipinfo/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/plugins/ipinfo/plugin.go
+++ b/plugins/ipinfo/plugin.go
@@ -1,0 +1,22 @@
+package ipinfo
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "ipinfo",
+		Platform: schema.PlatformInfo{
+			Name:     "IPinfo.io",
+			Homepage: sdk.URL("https://ipinfo.io"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			IPinfoCLI(),
+		},
+	}
+}

--- a/plugins/ipinfo/test-fixtures/config.json
+++ b/plugins/ipinfo/test-fixtures/config.json
@@ -1,0 +1,1 @@
+{"cache_enabled":false,"token":"OYjuTe0EXAMPLE"}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add support for ipinfo CLI. The shell plugin provisions a configuration file at `~/Library/Application\ Support/ipinfo/config.json`. The shell plugin also imports the Token from the same file at the same path, if it exists.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install ipinfo CLI and set up shell plugin.
- Run a bulk query like `ipinfo bulk 8.8.8.0-8.8.8.255 1.1.1.0/30 123.123.123.123` and it'll use the token for queries. Bulk queries cannot be run without a token.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Add support for ipinfo CLI.

## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

