### PR TITLE
Add support for Todoist CLI

### DIFF
--- a/plugins/todoist/api_token.go
+++ b/plugins/todoist/api_token.go
@@ -68,7 +68,7 @@ func todoistConfig(in sdk.ProvisionInput) ([]byte, error) {
 	config := Config{
 		Token: in.ItemFields[fieldname.Token],
 	}
-	contents, err := json.MarshalIndent(&config, "", "  ")
+	contents, err := json.Marshal(&config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/todoist/api_token.go
+++ b/plugins/todoist/api_token.go
@@ -1,0 +1,76 @@
+package todoist
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://todoist.com/help/articles/8048880904476"),
+		ManagementURL: sdk.URL("https://todoist.com/app/settings/integrations/developer"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "API Token used to authenticate to Todoist.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 40,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			todoistConfig,
+			provision.AtFixedPath("~/.config/todoist/config.json"),
+		),
+		Importer: importer.TryAll(
+			TryTodoistConfigFile(),
+		)}
+}
+
+func TryTodoistConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/todoist/config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.Token == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token: config.Token,
+			},
+		})
+	})
+}
+
+type Config struct {
+	Token string `json:"token"`
+}
+
+func todoistConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		Token: in.ItemFields[fieldname.Token],
+	}
+	contents, err := json.MarshalIndent(&config, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return []byte(contents), nil
+}

--- a/plugins/todoist/api_token_test.go
+++ b/plugins/todoist/api_token_test.go
@@ -1,0 +1,45 @@
+package todoist
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"config file": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "dbq9y65uguqrk4ognfhdiwcc0zx34z20pexample",
+			},
+			CommandLine: []string{"todoist"},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"todoist"},
+				Files: map[string]sdk.OutputFile{
+					"~/.config/todoist/config.json": {
+						Contents: []byte(plugintest.LoadFixture(t, "config.json")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.config/todoist/config.json": plugintest.LoadFixture(t, "config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "dbq9y65uguqrk4ognfhdiwcc0zx34z20pexample",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/todoist/plugin.go
+++ b/plugins/todoist/plugin.go
@@ -1,0 +1,22 @@
+package todoist
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "todoist",
+		Platform: schema.PlatformInfo{
+			Name:     "Todoist",
+			Homepage: sdk.URL("https://todoist.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIToken(),
+		},
+		Executables: []schema.Executable{
+			TodoistCLI(),
+		},
+	}
+}

--- a/plugins/todoist/test-fixtures/config.json
+++ b/plugins/todoist/test-fixtures/config.json
@@ -1,0 +1,3 @@
+{
+  "token": "dbq9y65uguqrk4ognfhdiwcc0zx34z20pexample"
+}

--- a/plugins/todoist/test-fixtures/config.json
+++ b/plugins/todoist/test-fixtures/config.json
@@ -1,3 +1,1 @@
-{
-  "token": "dbq9y65uguqrk4ognfhdiwcc0zx34z20pexample"
-}
+{"token":"dbq9y65uguqrk4ognfhdiwcc0zx34z20pexample"}

--- a/plugins/todoist/todoist.go
+++ b/plugins/todoist/todoist.go
@@ -1,0 +1,25 @@
+package todoist
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func TodoistCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Todoist CLI",
+		Runs:    []string{"todoist"},
+		DocsURL: sdk.URL("https://github.com/sachaos/todoist"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIToken,
+			},
+		},
+	}
+}

--- a/plugins/todoist/todoist.go
+++ b/plugins/todoist/todoist.go
@@ -14,7 +14,6 @@ func TodoistCLI() schema.Executable {
 		DocsURL: sdk.URL("https://github.com/sachaos/todoist"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
-			needsauth.NotWithoutArgs(),
 		),
 		Uses: []schema.CredentialUsage{
 			{


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add support for Todoist CLI. The shell plugin provisions a configuration file at `~/.config/todoist/config.json`. The shell plugin also imports the Todoist token from the same file at the same path, if it exists.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install Todoist CLI and set up shell plugin.
- Run `op plugin init todoist` to import the token from `~/.config/todoist/config.json`
- The next time `todoist` commands are run, the shell plugin provisions the token to the same file path.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Add support for Todoist CLI.

## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

