### PR TITLE
Add support for Kaggle CLI

### DIFF
--- a/plugins/kaggle/api_token.go
+++ b/plugins/kaggle/api_token.go
@@ -1,0 +1,51 @@
+package kaggle
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://www.kaggle.com/docs/api"),
+		ManagementURL: sdk.URL("https://www.kaggle.com/settings/account"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "API Token used to authenticate to Kaggle.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 32,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Username,
+				MarkdownDescription: "Username to authenticate to Kaggle.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"KAGGLE_TOKEN":    fieldname.Token,
+	"KAGGLE_USERNAME": fieldname.Username,
+}

--- a/plugins/kaggle/api_token.go
+++ b/plugins/kaggle/api_token.go
@@ -32,7 +32,7 @@ func APIToken() schema.CredentialType {
 			{
 				Name:                fieldname.Username,
 				MarkdownDescription: "Username to authenticate to Kaggle.",
-				Secret:              true,
+				Secret:              false,
 				Composition: &schema.ValueComposition{
 					Charset: schema.Charset{
 						Lowercase: true,

--- a/plugins/kaggle/api_token.go
+++ b/plugins/kaggle/api_token.go
@@ -46,6 +46,6 @@ func APIToken() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"KAGGLE_TOKEN":    fieldname.Token,
+	"KAGGLE_KEY":      fieldname.Token,
 	"KAGGLE_USERNAME": fieldname.Username,
 }

--- a/plugins/kaggle/api_token.go
+++ b/plugins/kaggle/api_token.go
@@ -1,6 +1,8 @@
 package kaggle
 
 import (
+	"context"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -42,10 +44,38 @@ func APIToken() schema.CredentialType {
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryKaggleConfigFile("~/.kaggle/kaggle.json"),
 		)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"KAGGLE_KEY":      fieldname.Token,
 	"KAGGLE_USERNAME": fieldname.Username,
+}
+
+func TryKaggleConfigFile(path string) sdk.Importer {
+	return importer.TryFile(path, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.Token == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token:    config.Token,
+				fieldname.Username: config.Username,
+			},
+			NameHint: importer.SanitizeNameHint(config.Username),
+		})
+	})
+}
+
+type Config struct {
+	Username string `json:"username"`
+	Token    string `json:"key"`
 }

--- a/plugins/kaggle/api_token_test.go
+++ b/plugins/kaggle/api_token_test.go
@@ -17,7 +17,7 @@ func TestAPITokenProvisioner(t *testing.T) {
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"KAGGLE_TOKEN":    "z2pifkruzgbb17plmz2gux21fexample",
+					"KAGGLE_KEY":      "z2pifkruzgbb17plmz2gux21fexample",
 					"KAGGLE_USERNAME": "username",
 				},
 			},

--- a/plugins/kaggle/api_token_test.go
+++ b/plugins/kaggle/api_token_test.go
@@ -1,0 +1,26 @@
+package kaggle
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token:    "z2pifkruzgbb17plmz2gux21fexample",
+				fieldname.Username: "username",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"KAGGLE_TOKEN":    "z2pifkruzgbb17plmz2gux21fexample",
+					"KAGGLE_USERNAME": "username",
+				},
+			},
+		},
+	})
+}

--- a/plugins/kaggle/api_token_test.go
+++ b/plugins/kaggle/api_token_test.go
@@ -24,3 +24,36 @@ func TestAPITokenProvisioner(t *testing.T) {
 		},
 	})
 }
+
+func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"KAGGLE_KEY":      "z2pifkruzgbb17plmz2gux21fexample",
+				"KAGGLE_USERNAME": "username",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:    "z2pifkruzgbb17plmz2gux21fexample",
+						fieldname.Username: "username",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files: map[string]string{
+				"~/.kaggle/kaggle.json": plugintest.LoadFixture(t, "config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:    "z2pifkruzgbb17plmz2gux21fexample",
+						fieldname.Username: "username",
+					},
+					NameHint: "username",
+				},
+			},
+		},
+	})
+}

--- a/plugins/kaggle/kaggle.go
+++ b/plugins/kaggle/kaggle.go
@@ -1,0 +1,25 @@
+package kaggle
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func KaggleCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Kaggle CLI",
+		Runs:    []string{"kaggle"},
+		DocsURL: sdk.URL("https://github.com/Kaggle/kaggle-api"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIToken,
+			},
+		},
+	}
+}

--- a/plugins/kaggle/plugin.go
+++ b/plugins/kaggle/plugin.go
@@ -1,0 +1,22 @@
+package kaggle
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "kaggle",
+		Platform: schema.PlatformInfo{
+			Name:     "Kaggle",
+			Homepage: sdk.URL("https://kaggle.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIToken(),
+		},
+		Executables: []schema.Executable{
+			KaggleCLI(),
+		},
+	}
+}

--- a/plugins/kaggle/test-fixtures/config.json
+++ b/plugins/kaggle/test-fixtures/config.json
@@ -1,0 +1,1 @@
+{"username":"username","key":"z2pifkruzgbb17plmz2gux21fexample"}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add support for Kaggle CLI. Kaggle CLI supports environment variables KAGGLE_KEY and KAGGLE_USERNAME

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install [Kaggle CLI](https://github.com/Kaggle/kaggle-api) and set up shell plugin.
- Run `op plugin init kaggle` to configure username and [Kaggle API Key](https://www.kaggle.com/settings/account).
- Future queries should use these credentials.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Add support for Kaggle.

## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

