### PR TITLE
Add support for Axiom CLI

### DIFF
--- a/plugins/axiom/axiom.go
+++ b/plugins/axiom/axiom.go
@@ -1,0 +1,25 @@
+package axiom
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func AxiomCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Axiom CLI",
+		Runs:    []string{"axiom"},
+		DocsURL: sdk.URL("https://axiom.com/docs/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/axiom/axiom.go
+++ b/plugins/axiom/axiom.go
@@ -11,7 +11,7 @@ func AxiomCLI() schema.Executable {
 	return schema.Executable{
 		Name:    "Axiom CLI",
 		Runs:    []string{"axiom"},
-		DocsURL: sdk.URL("https://axiom.com/docs/cli"),
+		DocsURL: sdk.URL("https://axiom.co/docs/reference/cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/axiom/personal_access_token.go
+++ b/plugins/axiom/personal_access_token.go
@@ -30,9 +30,8 @@ func PersonalAccessToken() schema.CredentialType {
 			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
-		Importer: importer.TryAll(
-			importer.TryEnvVarPair(defaultEnvVarMapping),
-		)}
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{

--- a/plugins/axiom/personal_access_token.go
+++ b/plugins/axiom/personal_access_token.go
@@ -1,0 +1,40 @@
+package axiom
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAccessToken,
+		DocsURL:       sdk.URL("https://axiom.co/docs/restapi/token#creating-personal-token"),
+		ManagementURL: sdk.URL("https://app.axiom.co/settings/profile"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Axiom.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 41,
+					Prefix: "xapt-",
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"AXIOM_TOKEN": fieldname.Token,
+}

--- a/plugins/axiom/personal_access_token.go
+++ b/plugins/axiom/personal_access_token.go
@@ -28,6 +28,30 @@ func PersonalAccessToken() schema.CredentialType {
 					},
 				},
 			},
+			{
+				Name:                fieldname.Organization,
+				MarkdownDescription: "The organization ID of the organization the access token is valid for. Only valid for Axiom Cloud.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+						Specific:  []rune{'-'},
+					},
+				},
+			},
+			{
+				Name:                fieldname.Deployment,
+				MarkdownDescription: "Deployment to use.",
+				Secret:              false,
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
@@ -35,5 +59,7 @@ func PersonalAccessToken() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"AXIOM_TOKEN": fieldname.Token,
+	"AXIOM_TOKEN":      fieldname.Token,
+	"AXIOM_ORG_ID":     fieldname.Organization,
+	"AXIOM_DEPLOYMENT": fieldname.Deployment,
 }

--- a/plugins/axiom/personal_access_token.go
+++ b/plugins/axiom/personal_access_token.go
@@ -21,7 +21,6 @@ func PersonalAccessToken() schema.CredentialType {
 				Secret:              true,
 				Composition: &schema.ValueComposition{
 					Length: 41,
-					Prefix: "xapt-",
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,

--- a/plugins/axiom/personal_access_token_test.go
+++ b/plugins/axiom/personal_access_token_test.go
@@ -1,0 +1,41 @@
+package axiom
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "xapt-wovexreez0qf7zvkn935na41cudk2example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"AXIOM_TOKEN": "xapt-wovexreez0qf7zvkn935na41cudk2example",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"AXIOM_TOKEN": "xapt-wovexreez0qf7zvkn935na41cudk2example",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "xapt-wovexreez0qf7zvkn935na41cudk2example",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/axiom/personal_access_token_test.go
+++ b/plugins/axiom/personal_access_token_test.go
@@ -12,11 +12,15 @@ func TestPersonalAccessTokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.Token: "xapt-wovexreez0qf7zvkn935na41cudk2example",
+				fieldname.Token:        "xapt-wovexreez0qf7zvkn935na41cudk2example",
+				fieldname.Organization: "example",
+				fieldname.Deployment:   "cloud",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"AXIOM_TOKEN": "xapt-wovexreez0qf7zvkn935na41cudk2example",
+					"AXIOM_TOKEN":      "xapt-wovexreez0qf7zvkn935na41cudk2example",
+					"AXIOM_ORG_ID":     "example",
+					"AXIOM_DEPLOYMENT": "cloud",
 				},
 			},
 		},
@@ -27,12 +31,16 @@ func TestPersonalAccessTokenImporter(t *testing.T) {
 	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
 		"environment": {
 			Environment: map[string]string{
-				"AXIOM_TOKEN": "xapt-wovexreez0qf7zvkn935na41cudk2example",
+				"AXIOM_TOKEN":      "xapt-wovexreez0qf7zvkn935na41cudk2example",
+				"AXIOM_ORG_ID":     "example",
+				"AXIOM_DEPLOYMENT": "cloud",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Token: "xapt-wovexreez0qf7zvkn935na41cudk2example",
+						fieldname.Token:        "xapt-wovexreez0qf7zvkn935na41cudk2example",
+						fieldname.Organization: "example",
+						fieldname.Deployment:   "cloud",
 					},
 				},
 			},

--- a/plugins/axiom/plugin.go
+++ b/plugins/axiom/plugin.go
@@ -1,0 +1,22 @@
+package axiom
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "axiom",
+		Platform: schema.PlatformInfo{
+			Name:     "Axiom",
+			Homepage: sdk.URL("https://axiom.co"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			AxiomCLI(),
+		},
+	}
+}

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -27,6 +27,7 @@ const (
 	Credentials     = sdk.FieldName("Credentials")
 	Database        = sdk.FieldName("Database")
 	DefaultRegion   = sdk.FieldName("Default Region")
+	Deployment      = sdk.FieldName("Deployment")
 	Email           = sdk.FieldName("Email")
 	Endpoint        = sdk.FieldName("Endpoint")
 	Host            = sdk.FieldName("Host")
@@ -78,6 +79,7 @@ func ListAll() []sdk.FieldName {
 		Credentials,
 		Database,
 		DefaultRegion,
+		Deployment,
 		Endpoint,
 		Host,
 		HostAddress,


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add support for Axiom CLI. The CLI has support for environment variable AXIOM_TOKEN which can be used for authentication.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install Axiom CLI and set up shell plugin.
- Run `op plugin init axiom`
- Future queries should set AXIOM_TOKEN and use it for authentication.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Add support for Axiom CLI.

## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

