### PR TITLE
Add support for Contentful CLI

### DIFF
--- a/plugins/contentful/contentful.go
+++ b/plugins/contentful/contentful.go
@@ -1,0 +1,25 @@
+package contentful
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ContentfulCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Contentful CLI",
+		Runs:    []string{"contentful"},
+		DocsURL: sdk.URL("https://www.contentful.com/developers/docs/tutorials/cli/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/contentful/personal_access_token.go
+++ b/plugins/contentful/personal_access_token.go
@@ -1,0 +1,81 @@
+package contentful
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.PersonalAccessToken,
+		DocsURL: sdk.URL("https://www.contentful.com/developers/docs/references/content-management-api/#/reference/personal-access-tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Personal Access Token used to authenticate to Contentful.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 49,
+					Prefix: "CFPAT-",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			contentfulConfig,
+			provision.AtFixedPath("~/.contentfulrc.json"),
+		),
+		Importer: importer.TryAll(
+			TryContentfulConfigFile(),
+		)}
+}
+
+func TryContentfulConfigFile() sdk.Importer {
+	return importer.TryFile("~/.contentfulrc.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.ManagementToken == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token: config.ManagementToken,
+			},
+		})
+	})
+}
+
+type Config struct {
+	ManagementToken     string `json:"managementToken"`
+	ActiveEnvironmentId string `json:"activeEnvironmentId"`
+	Host                string `json:"host"`
+}
+
+func contentfulConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		ManagementToken:     in.ItemFields[fieldname.Token],
+		ActiveEnvironmentId: "master",
+		Host:                "api.contentful.com",
+	}
+	contents, err := json.MarshalIndent(&config, "", "	")
+	if err != nil {
+		return nil, err
+	}
+	return []byte(contents), nil
+}

--- a/plugins/contentful/personal_access_token_test.go
+++ b/plugins/contentful/personal_access_token_test.go
@@ -1,0 +1,41 @@
+package contentful
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "lDoY0qLbGt9Se8K71O42xI3y6XPxNSfFop4cjHHq1CEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"CONTENTFUL_TOKEN": "lDoY0qLbGt9Se8K71O42xI3y6XPxNSfFop4cjHHq1CEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.contentfulrc.json": plugintest.LoadFixture(t, "contentfulrc.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Key: "CFPAT-XArJuIgiqjflHUGePPYbILIKOUzdFv2jTJMNEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/contentful/plugin.go
+++ b/plugins/contentful/plugin.go
@@ -1,0 +1,22 @@
+package contentful
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "contentful",
+		Platform: schema.PlatformInfo{
+			Name:     "Contentful",
+			Homepage: sdk.URL("https://contentful.com"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			ContentfulCLI(),
+		},
+	}
+}

--- a/plugins/contentful/test-fixtures/contentfulrc.json
+++ b/plugins/contentful/test-fixtures/contentfulrc.json
@@ -1,0 +1,5 @@
+{
+    "managementToken": "CFPAT-XArJuIgiqjflHUGePPYbILIKOUzdFv2jTJMNEXAMPLE",
+    "activeEnvironmentId": "master",
+    "host": "api.contentful.com"
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add support for Contentful CLI. The shell plugin provisions a configuration file at `~/.contentfulrc.json`. The shell plugin also imports the Contentful token from the same file at the same path, if it exists.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install Contentful CLI and set up shell plugin.
- Future queries of `contentful` should provision the token at `~/.contentfulrc.json` and use it for authentication.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Add support for Contentful CLI.

## Additional information

- [x] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission

