### PR TITLE
Remove tickbox for Hashnode submissions in PR review

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,7 +57,5 @@ The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment vari
 For more examples, have a look over 1Password CLI's past release notes: 
 https://app-updates.agilebits.com/product_history/CLI2
 -->  
-## Additional information
 
-- [ ] Check this box if this is a [Hashnode Hackathon](https://hashnode.com/hackathons/1password) submission
 


### PR DESCRIPTION
Reverts 1Password/shell-plugins#320

As the hackathon ended June 30th, this tickbox is not required anymore.