### PR TITLE
Add `make registry.json` command 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Auto-generated with `make registry`
 plugins/plugins.go
 
+# Auto-generated with `make registry.json`
+plugins/registry.json
+
 # GoLand
 .idea
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ registry:
 validate: registry
 	go run cmd/contrib/main.go $@
 
+registry.json: registry
+	go run cmd/contrib/main.go $@
+
 $(plugins_dir):
 	mkdir -p $(plugins_dir)
 	chmod 700 $(plugins_dir)

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -634,5 +634,5 @@ func generateRegistryJSON() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join("plugins", "plugins.json"), b, 0600)
+	return os.WriteFile(filepath.Join("plugins", "registry.json"), b, 0600)
 }

--- a/cmd/contrib/main.go
+++ b/cmd/contrib/main.go
@@ -77,6 +77,14 @@ func main() {
 		}
 		return
 	}
+
+	if command == "registry.json" {
+		err := generateRegistryJSON()
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
 }
 
 func isPluginCommand(command string) (isPluginCommand bool, pluginName string, pluginCommand string) {
@@ -619,4 +627,12 @@ func transformCredentialName(ans any) (newAns any) {
 	}
 
 	return ans
+}
+
+func generateRegistryJSON() error {
+	b, err := plugins.RegistryJSON()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join("plugins", "plugins.json"), b, 0600)
 }

--- a/plugins/registry.go
+++ b/plugins/registry.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
@@ -13,21 +12,13 @@ var registry = []schema.Plugin{}
 
 func RegistryJSON() ([]byte, error) {
 	var listToJSON []schema.Plugin
-
 	// Only include plugins that contain at least one credential.
 	for _, p := range List() {
 		if len(p.Credentials) > 0 {
 			listToJSON = append(listToJSON, p)
 		}
 	}
-	timedRegistry := struct {
-		Plugins   []schema.Plugin `json:"registry"`
-		Timestamp time.Time       `json:"timestamp"`
-	}{
-		Plugins:   listToJSON,
-		Timestamp: time.Now(),
-	}
-	return json.MarshalIndent(timedRegistry, "", "\t")
+	return json.MarshalIndent(listToJSON, "", "\t")
 }
 
 func List() []schema.Plugin {

--- a/plugins/registry.go
+++ b/plugins/registry.go
@@ -1,13 +1,34 @@
 package plugins
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
 var registry = []schema.Plugin{}
+
+func RegistryJSON() ([]byte, error) {
+	var listToJSON []schema.Plugin
+
+	// Only include plugins that contain at least one credential.
+	for _, p := range List() {
+		if len(p.Credentials) > 0 {
+			listToJSON = append(listToJSON, p)
+		}
+	}
+	timedRegistry := struct {
+		Plugins   []schema.Plugin `json:"registry"`
+		Timestamp time.Time       `json:"timestamp"`
+	}{
+		Plugins:   listToJSON,
+		Timestamp: time.Now(),
+	}
+	return json.MarshalIndent(timedRegistry, "", "\t")
+}
 
 func List() []schema.Plugin {
 	list := make([]schema.Plugin, len(registry))

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -125,7 +125,7 @@ func (p Plugin) MarshalJSON() ([]byte, error) {
 	}
 	plugin := struct {
 		PlatformName  string `json:"platform_name"`
-		ManagementURL string `json:"management_url"`
+		ManagementURL string `json:"management_url,omitempty"`
 	}{
 		PlatformName: p.Platform.Name,
 		ManagementURL: func() string {

--- a/sdk/schema/plugin.go
+++ b/sdk/schema/plugin.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 )
@@ -116,4 +117,24 @@ func (p Plugin) DeepValidate() []ValidationReport {
 	}
 
 	return reports
+}
+
+func (p Plugin) MarshalJSON() ([]byte, error) {
+	if len(p.Credentials) == 0 {
+		return nil, nil
+	}
+	plugin := struct {
+		PlatformName  string `json:"platform_name"`
+		ManagementURL string `json:"management_url"`
+	}{
+		PlatformName: p.Platform.Name,
+		ManagementURL: func() string {
+			if p.Credentials[0].ManagementURL != nil {
+				return p.Credentials[0].ManagementURL.String()
+			} else {
+				return ""
+			}
+		}(),
+	}
+	return json.Marshal(plugin)
 }


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

This PR adds a `make registry.json` command, generating a json-formatted registry.

For the time being, this will be used as configuration for the Shell Plugins banners that OPH renders for Shell Plugins items. However, this can also serve as boilerplate for more complex configuration that can be built on top of this repo.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [X] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Run `make registry.json`
