### PR TITLE
Add support for Crowdin CLI

### DIFF
--- a/plugins/crowdin/access_token.go
+++ b/plugins/crowdin/access_token.go
@@ -58,6 +58,6 @@ func AccessToken() schema.CredentialType {
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"CROWDIN_PERSONAL_TOKEN": fieldname.Token,
-	"CROWDIN_PROJECT_ID":     fieldname.OrgID,
+	"CROWDIN_PROJECT_ID":     fieldname.ProjectID,
 	"CROWDIN_BASE_URL":       fieldname.HostAddress,
 }

--- a/plugins/crowdin/access_token.go
+++ b/plugins/crowdin/access_token.go
@@ -1,0 +1,54 @@
+package crowdin
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.AccessToken,
+		DocsURL: sdk.URL("https://developer.crowdin.com/configuration-file/#api-credentials-from-environment-variables"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Crowdin.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 80,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.ProjectID,
+				MarkdownDescription: "Project ID used to authenticate to Crowdin.",
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Digits: true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.HostAddress,
+				MarkdownDescription: "Base URL (for Crowdin Enterprise)",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"CROWDIN_PERSONAL_TOKEN": fieldname.Token,
+	"CROWDIN_PROJECT_ID":     fieldname.OrgID,
+	"CROWDIN_BASE_URL":       fieldname.HostAddress,
+}

--- a/plugins/crowdin/access_token.go
+++ b/plugins/crowdin/access_token.go
@@ -40,6 +40,15 @@ func AccessToken() schema.CredentialType {
 				Name:                fieldname.HostAddress,
 				MarkdownDescription: "Base URL (for Crowdin Enterprise)",
 				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Lowercase: true,
+						Uppercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+					Prefix: "https://",
+				},
 			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),

--- a/plugins/crowdin/access_token.go
+++ b/plugins/crowdin/access_token.go
@@ -11,15 +11,15 @@ import (
 
 func AccessToken() schema.CredentialType {
 	return schema.CredentialType{
-		Name:    credname.AccessToken,
-		DocsURL: sdk.URL("https://developer.crowdin.com/configuration-file/#api-credentials-from-environment-variables"),
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://developer.crowdin.com/configuration-file/#api-credentials-from-environment-variables"),
+		ManagementURL: sdk.URL("https://crowdin.com/settings#api-key"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,
 				MarkdownDescription: "Token used to authenticate to Crowdin.",
 				Secret:              true,
 				Composition: &schema.ValueComposition{
-					Length: 80,
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,

--- a/plugins/crowdin/access_token_test.go
+++ b/plugins/crowdin/access_token_test.go
@@ -13,7 +13,7 @@ func TestAccessTokenProvisioner(t *testing.T) {
 		"default": {
 			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
 				fieldname.Token:       "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
-				fieldname.OrgID:       "123",
+				fieldname.ProjectID:   "123",
 				fieldname.HostAddress: "https://testOrg.crowdin.com",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -39,7 +39,7 @@ func TestAccessTokenImporter(t *testing.T) {
 				{
 					Fields: map[sdk.FieldName]string{
 						fieldname.Token:       "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
-						fieldname.OrgID:       "123",
+						fieldname.ProjectID:   "123",
 						fieldname.HostAddress: "https://testOrg.crowdin.com",
 					},
 				},

--- a/plugins/crowdin/access_token_test.go
+++ b/plugins/crowdin/access_token_test.go
@@ -1,0 +1,49 @@
+package crowdin
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token:       "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
+				fieldname.OrgID:       "123",
+				fieldname.HostAddress: "https://testOrg.crowdin.com",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"CROWDIN_PERSONAL_TOKEN": "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
+					"CROWDIN_PROJECT_ID":     "123",
+					"CROWDIN_BASE_URL":       "https://testOrg.crowdin.com",
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"CROWDIN_PERSONAL_TOKEN": "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
+				"CROWDIN_PROJECT_ID":     "123",
+				"CROWDIN_BASE_URL":       "https://testOrg.crowdin.com",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:       "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
+						fieldname.OrgID:       "123",
+						fieldname.HostAddress: "https://testOrg.crowdin.com",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/crowdin/access_token_test.go
+++ b/plugins/crowdin/access_token_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccessTokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+			ItemFields: map[sdk.FieldName]string{
 				fieldname.Token:       "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
 				fieldname.ProjectID:   "123",
 				fieldname.HostAddress: "https://testOrg.crowdin.com",
@@ -30,7 +30,7 @@ func TestAccessTokenProvisioner(t *testing.T) {
 func TestAccessTokenImporter(t *testing.T) {
 	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
+			Environment: map[string]string{
 				"CROWDIN_PERSONAL_TOKEN": "pt2sk1g1nqfervdjk8av8r88wvjsprzzck4vws97n5r7fn8ad0l3pe45k09fecy152ra6c8sgexample",
 				"CROWDIN_PROJECT_ID":     "123",
 				"CROWDIN_BASE_URL":       "https://testOrg.crowdin.com",

--- a/plugins/crowdin/crowdin.go
+++ b/plugins/crowdin/crowdin.go
@@ -1,0 +1,26 @@
+package crowdin
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func CrowdinCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Crowdin CLI",
+		Runs:    []string{"crowdin"},
+		DocsURL: sdk.URL("https://crowdin.github.io/crowdin-cli/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("init"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/plugins/crowdin/plugin.go
+++ b/plugins/crowdin/plugin.go
@@ -1,0 +1,22 @@
+package crowdin
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "crowdin",
+		Platform: schema.PlatformInfo{
+			Name:     "Crowdin",
+			Homepage: sdk.URL("https://crowdin.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			CrowdinCLI(),
+		},
+	}
+}

--- a/plugins/crowdin/plugin.go
+++ b/plugins/crowdin/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "crowdin",
 		Platform: schema.PlatformInfo{
 			Name:     "Crowdin",
-			Homepage: sdk.URL("https://crowdin.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://crowdin.com"),
 		},
 		Credentials: []schema.CredentialType{
 			AccessToken(),

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -43,6 +43,7 @@ const (
 	Port            = sdk.FieldName("Port")
 	PublicKey       = sdk.FieldName("Public Key")
 	PrivateKey      = sdk.FieldName("Private Key")
+	ProjectID       = sdk.FieldName("Project ID")
 	Region          = sdk.FieldName("Region")
 	Secret          = sdk.FieldName("Secret")
 	SecretAccessKey = sdk.FieldName("Secret Access Key")
@@ -94,6 +95,7 @@ func ListAll() []sdk.FieldName {
 		Port,
 		PublicKey,
 		PrivateKey,
+		ProjectID,
 		Region,
 		Secret,
 		SecretAccessKey,


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Add support for the [Crowdin CLI](https://crowdin.github.io/crowdin-cli/)


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

When inside of a Crowdin project with a `crowdin.yml` file, run a command such as `crowdin list branches`


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Authenticate the Crowdin CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The Crowdin plugin can be initialized with a Crowdin Personal Token, an optional Project ID, and a Base URL (for Crowdin Enterprise) using `op plugin init crowdin`. Please see the [Crowdin documentation](https://developer.crowdin.com/configuration-file/#api-credentials-from-environment-variables) to ensure your project is set up to authenticate via environment variables.

