### PR TITLE
Update developer Slack invitation link to the one we control

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: "💬 Chat with us on Slack"
-    url: https://join.slack.com/t/1password-devs/shared_invite/zt-1z0rd7lro-fx4LPkQwUF89~PzpDGPe1A
+    url: https://developer.1password.com/joinslack
     about: Chat with us about shell plugins in our Developer Slack workspace.
   - name: "❓ General 1Password questions"
     url: https://1password.community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ No documentation work is required on your end. If your plugin is accepted, a tec
 If you need help, found a bug, or have an idea for an awesome plugin that you'd like to discuss with us first, you can reach out to us here:
 
 * Create an [issue](https://github.com/1Password/shell-plugins/issues) in this repo.
-* Join the [Developer Slack workspace](https://join.slack.com/t/1password-devs/shared_invite/zt-1z0rd7lro-fx4LPkQwUF89~PzpDGPe1A).
+* Join the [Developer Slack workspace](https://developer.1password.com/joinslack).
 
 ## 📣 Contributions Beta Notice
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ make new-plugin
 
 Still not sure where or how to begin? We're happy to help! You can:
 - Book a free [pairing session](https://calendly.com/d/grs-x2h-pmb/1password-shell-plugins-pairing-session) with one of our developers
-- Join the [Developer Slack workspace](https://join.slack.com/t/1password-devs/shared_invite/zt-1z0rd7lro-fx4LPkQwUF89~PzpDGPe1A), and ask us any questions there
+- Join the [Developer Slack workspace](https://developer.1password.com/joinslack), and ask us any questions there
 
 ## 💙 Community & Support
 
 - File an [issue](https://github.com/1Password/shell-plugins/issues/new/choose) for bugs and feature requests
-- Join the [Developer Slack workspace](https://join.slack.com/t/1password-devs/shared_invite/zt-1z0rd7lro-fx4LPkQwUF89~PzpDGPe1A)
+- Join the [Developer Slack workspace](https://developer.1password.com/joinslack)
 - Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/)


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

We now have a Slack invitation link for the developer Slack on a domain we control. This PR updates the links:

- Old link: https://join.slack.com/t/1password-devs/shared_invite/zt-1z0rd7lro-fx4LPkQwUF89~PzpDGPe1A
- New link: https://developer.1password.com/joinslack

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Visit the new link
- See that it offers a sign up flow and verify that any domain can be used for the sign up.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Update developer Slack invitation link to the one we control