### PR TITLE
Add file importer for cachix plugin

### DIFF
--- a/plugins/cachix/auth_token.go
+++ b/plugins/cachix/auth_token.go
@@ -1,6 +1,9 @@
 package cachix
 
 import (
+	"context"
+	"strings"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -33,9 +36,41 @@ func AuthToken() schema.CredentialType {
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryCachixConfigFile(),
 		)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"CACHIX_AUTH_TOKEN": fieldname.Token,
+}
+
+func TryCachixConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/cachix/cachix.dhall", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var token string
+
+		fileString := contents.ToString()
+		// The dhall config file contains a single block with variables inside
+		fileString = strings.Trim(fileString, "{}")
+		// Remove spaces to make parsing simpler
+		fileString = strings.Join(strings.Fields(fileString), "")
+		// There should be 3 fields: authToken, hostname, binaryCaches
+		keyVals := strings.SplitN(fileString, ",", 3)
+
+		for i := range keyVals {
+			kvPair := strings.Split(keyVals[i], "=")
+			if len(kvPair) != 2 {
+				continue
+			}
+			kvPair[1] = strings.Trim(kvPair[1], "\"")
+			if strings.Contains(kvPair[0], "authToken") {
+				token = kvPair[1]
+			}
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token: token,
+			},
+		})
+	})
 }

--- a/plugins/cachix/auth_token.go
+++ b/plugins/cachix/auth_token.go
@@ -54,7 +54,7 @@ func TryCachixConfigFile() sdk.Importer {
 		// Remove spaces to make parsing simpler
 		fileString = strings.Join(strings.Fields(fileString), "")
 		// There should be 3 fields: authToken, hostname, binaryCaches
-		keyVals := strings.SplitN(fileString, ",", 3)
+		keyVals := strings.Split(fileString, ",")
 
 		for i := range keyVals {
 			kvPair := strings.Split(keyVals[i], "=")

--- a/plugins/cachix/auth_token.go
+++ b/plugins/cachix/auth_token.go
@@ -53,7 +53,7 @@ func TryCachixConfigFile() sdk.Importer {
 		fileString = strings.Trim(fileString, "{}")
 		// Remove spaces to make parsing simpler
 		fileString = strings.Join(strings.Fields(fileString), "")
-		// There should be 3 fields: authToken, hostname, binaryCaches
+		// Split fields into separate strings
 		keyVals := strings.Split(fileString, ",")
 
 		for i := range keyVals {

--- a/plugins/cachix/auth_token_test.go
+++ b/plugins/cachix/auth_token_test.go
@@ -34,6 +34,18 @@ func TestAuthTokenImporter(t *testing.T) {
 				},
 			},
 		},
+		"Cache config file": {
+			Files: map[string]string{
+				"~/.config/cachix/cachix.dhall": plugintest.LoadFixture(t, "cachix.dhall"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI3OGRlOTA4Yi03MjhiLTRiMjUtODA1Yi1hNTRjODIxMWQ1ZjMiLCJzY29wZXMiOiJ0eCJ9.A0XjByVJtp2Di0Ui7M5KjiG1OinYW8PwVKRw5N4YETE",
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/plugins/cachix/test-fixtures/cachix.dhall
+++ b/plugins/cachix/test-fixtures/cachix.dhall
@@ -1,0 +1,5 @@
+{ authToken =
+    "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI3OGRlOTA4Yi03MjhiLTRiMjUtODA1Yi1hNTRjODIxMWQ1ZjMiLCJzY29wZXMiOiJ0eCJ9.A0XjByVJtp2Di0Ui7M5KjiG1OinYW8PwVKRw5N4YETE"
+, hostname = "https://cachix.org"
+, binaryCaches = [] : List { name : Text, secretKey : Text }
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Adds a file importer for the Cachix plugin. The file is stored at `~/.config/cachix/cachix.dhall` and is generated from a terminal command. To avoid bringing in a third-party dependency, the file contents are processed as a string, rather than using a dhall parser.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #111 

## How To Test

When running `op plugin init cachix`, you should now see the option to import credentials using the specified file.



## Changelog

The Cachix plugin now checks for the `~/.config/cachix/cachix.dhall` file and attempts to import an auth token using the specified file.


