### PR TITLE
Fix signed commits CI job

### DIFF
--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,5 +1,5 @@
 name: Check signed commits in PR 
-on: pull_request
+on: pull_request_target
 
 jobs:
   build:

--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -9,8 +9,5 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
       - name: Check signed commits in PR
         uses: 1Password/check-signed-commits-action@main

--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,5 +1,5 @@
 name: Check signed commits in PR 
-on: pull_request_target
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check signed commits in PR
-        uses: 1Password/check-signed-commits-action@v1
+        uses: 1Password/check-signed-commits-action@main


### PR DESCRIPTION
The job was previously ran on "pull_request_target". This runs the job on the base branch (i.e. the `main` branch of the
 1password/shell-plugins repo). Since we want to know if commits are signed on all the commits to be merged (i.e. also on the fork), I have changed this job to run on the merge commit instead.

### Relevant documentation
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

Note that the usage example of https://github.com/1Password/check-signed-commits-action also recommends running on the "pull_reqeusts" event.

### Use Cases
See https://github.com/1Password/shell-plugins/pull/332 where we run into this in practice. The job is passed, but commits aren't signed.