### PR TITLE
Add job to locally lint changes before pushing to remote

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,4 +43,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # version of golangci-lint to use
+          # Version should stay in sync with version used for local linting (lint job in Makefile).
           version: v1.50.1

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ $(plugins_dir):
 test:
 	go test ./...
 
+lint:
+	# Version used should stay in sync with version in CI (.github/workflows/test.yaml).
+	docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.50.1 golangci-lint run
+
 %/remove-local: beta-notice
 	$(eval plugin := $(firstword $(subst /, ,$@)))
 	rm -f ~/.op/plugins/local/$(plugin)


### PR DESCRIPTION
## Overview

You can now check if your code passes the lint rules by running `make lint` locally.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## How To Test

1. Run `make lint`.
2. That's it :tada:


## Changelog

This is an internal change (i.e. not to be included in CLI release notes).

Change: You can now check if your code passes the lint rules by running `make lint` locally.


