### PR TITLE
update(postgresql): add support for 'pgcli'

### DIFF
--- a/plugins/postgresql/pgcli.go
+++ b/plugins/postgresql/pgcli.go
@@ -1,0 +1,22 @@
+package postgresql
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func Pgcli() schema.Executable {
+	return schema.Executable{
+		Name:      "pgcli",
+		Runs:      []string{"pgcli"},
+		DocsURL:   sdk.URL("https://pgcli.com/docs"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}

--- a/plugins/postgresql/plugin.go
+++ b/plugins/postgresql/plugin.go
@@ -19,6 +19,7 @@ func New() schema.Plugin {
 			Psql(),
 			Pg_dump(),
 			Pg_restore(),
+			Pgcli(),
 		},
 	}
 }


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Add support support for `pgcli` as alternative cli client for PostgreSQL.
Pgcli is a rich, postgres client with syntax highlighting, smart completion and multiline support.

More info about pgcli: https://www.pgcli.com/

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Since pgcli can use the same environment variables as psql it can be used as a psql replacement:
```shell
op plugin run -- pgcli
```
or we can configure it if psql is not already configured:
```shell
op plugin init pgcli
```


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
PostgreSQL plugin now also supports `pgcli` as an alternative to psql.

