### PR TITLE
Add Docker plugin

### DIFF
--- a/plugins/docker/credentials.go
+++ b/plugins/docker/credentials.go
@@ -1,0 +1,89 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func Credentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.Credentials,
+		DocsURL:       sdk.URL("https://docs.docker.com/engine/reference/commandline/login"),
+		ManagementURL: sdk.URL("https://hub.docker.com/settings/security"),
+		Fields: []schema.CredentialField{
+			{
+				Name: fieldname.Username,
+				MarkdownDescription: "Username used in Docker registries.",
+				Secret: false,
+			},
+			{
+				Name:                fieldname.Secret,
+				AlternativeNames: []string{fieldname.Password.String(), fieldname.AccessToken.String()},
+				MarkdownDescription: "Password or access token used to authenticate to a Docker registry.",
+				Secret:              true,
+			},
+			{
+				Name: fieldname.Host,
+				MarkdownDescription: "URL of the Docker registry server.",
+				Optional: true, // Defaults to Docker Hub registry
+				Secret: false,
+			},
+		},
+		DefaultProvisioner: dockerProvisioner{},
+		Importer: importer.TryAll(
+			TryDockerConfigFile(),
+		)}
+}
+
+func TryDockerConfigFile() sdk.Importer {
+	// The config file likely points to a keychain, but might hold the plaintext credentials.
+	return importer.TryFile("~/.docker/config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		 var config Config
+		 if err := contents.ToJSON(&config); err != nil {
+		 	out.AddError(err)
+		 	return
+		 }
+
+		 if config.Username == "" || config.Secret == "" {
+		 	return
+		 }
+
+		 out.AddCandidate(sdk.ImportCandidate{
+		 	Fields: map[sdk.FieldName]string{
+		 		fieldname.Username: config.Username,
+				fieldname.Secret: config.Secret,
+				fieldname.Host: config.ServerUrl,
+		 	},
+		 })
+	})
+}
+
+type dockerProvisioner struct{}
+
+func (p dockerProvisioner) Description() string {
+	return "Docker login credentials provisioner"
+}
+
+func (p dockerProvisioner) Provision(ctx context.Context, input sdk.ProvisionInput, output *sdk.ProvisionOutput) {
+	if registry := input.ItemFields[fieldname.Host]; registry != "" {
+		output.AddArgs(registry)
+	}
+	// Docker will emit a warning that using --password is insecure, as it in unaware that the password is not being
+	// typed in manually on the command line
+	output.AddArgs("--username", input.ItemFields[fieldname.Username], "--password", input.ItemFields[fieldname.Secret])
+}
+
+func (p dockerProvisioner) Deprovision(ctx context.Context, input sdk.DeprovisionInput, output *sdk.DeprovisionOutput) {
+	// No-op: nothing to delete
+}
+
+type Config struct {
+	Username string `json:"Username"`
+	Secret string `json:"Secret"`
+	ServerUrl string `json:"ServerURL"`
+}

--- a/plugins/docker/credentials_test.go
+++ b/plugins/docker/credentials_test.go
@@ -1,0 +1,59 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestCredentialsProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, Credentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Username: "david",
+				fieldname.Secret: "passw0rd1",
+				fieldname.Host: "https://index.docker.io/v1",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{
+					"https://index.docker.io/v1", "--username", "david", "--password", "passw0rd1" ,
+				},
+			},
+		},
+	})
+}
+
+func TestCredentialsImporter(t *testing.T) {
+	plugintest.TestImporter(t, Credentials().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.docker/config.json": plugintest.LoadFixture(t, "config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			 	{
+			 		Fields: map[sdk.FieldName]string{
+			 			fieldname.Username: "david",
+						fieldname.Secret: "passw0rd1",
+						fieldname.Host: "https://index.docker.io/v1",
+			 		},
+			 	},
+			},
+		},
+		"no url config file" : {
+			Files: map[string]string{
+				"~/.docker/config.json": plugintest.LoadFixture(t, "no_url_config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			 	{
+			 		Fields: map[sdk.FieldName]string{
+			 			fieldname.Username: "user123",
+						fieldname.Secret: "passw0rd2",
+						fieldname.Host: "",
+			 		},
+			 	},
+			},
+		},
+	})
+}

--- a/plugins/docker/docker.go
+++ b/plugins/docker/docker.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func DockerCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Docker CLI",
+		Runs:      []string{"docker"},
+		DocsURL:   sdk.URL("https://docs.docker.com/engine/reference/commandline/docker/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.ForCommand("login"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.Credentials,
+				Provisioner: dockerProvisioner{},
+			},
+		},
+	}
+}

--- a/plugins/docker/plugin.go
+++ b/plugins/docker/plugin.go
@@ -1,0 +1,22 @@
+package docker
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "docker",
+		Platform: schema.PlatformInfo{
+			Name:     "Docker",
+			Homepage: sdk.URL("https://docker.com"),
+		},
+		Credentials: []schema.CredentialType{
+			Credentials(),
+		},
+		Executables: []schema.Executable{
+			DockerCLI(),
+		},
+	}
+}

--- a/plugins/docker/test-fixtures/config.json
+++ b/plugins/docker/test-fixtures/config.json
@@ -1,0 +1,5 @@
+{
+	"ServerURL": "https://index.docker.io/v1",
+	"Username": "david",
+	"Secret": "passw0rd1"
+}

--- a/plugins/docker/test-fixtures/no_url_config.json
+++ b/plugins/docker/test-fixtures/no_url_config.json
@@ -1,0 +1,4 @@
+{
+	"Username": "user123",
+	"Secret":"passw0rd2"
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Adds a plugin to authenticate the Docker CLI using a username and secret (a password or an access token).

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #114 

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
docker login


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Authenticate to a Docker registry using Touch ID and other unlock options with 1Password Shell Plugins.

