### PR TITLE
Add pgcli plugin

### DIFF
--- a/plugins/pgcli/database_credentials.go
+++ b/plugins/pgcli/database_credentials.go
@@ -1,0 +1,52 @@
+package pgcli
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func DatabaseCredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.DatabaseCredentials,
+		DocsURL: sdk.URL("https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "Postgres host to connect to.",
+			},
+			{
+				Name:                fieldname.Port,
+				MarkdownDescription: "Port used to connect to Postgres.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.User,
+				MarkdownDescription: "Postgres user to authenticate as.",
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password used to authenticate to Postgres.",
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Database,
+				MarkdownDescription: "Database name to connect to. Defaults to the name of the authenticated user.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"PGHOST":     fieldname.Host,
+	"PGPORT":     fieldname.Port,
+	"PGUSER":     fieldname.User,
+	"PGPASSWORD": fieldname.Password,
+	"PGDATABASE": fieldname.Database,
+}

--- a/plugins/pgcli/database_credentials_test.go
+++ b/plugins/pgcli/database_credentials_test.go
@@ -1,0 +1,57 @@
+package pgcli
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestDatabaseCredentialsImporter(t *testing.T) {
+	plugintest.TestImporter(t, DatabaseCredentials().Importer, map[string]plugintest.ImportCase{
+		"default": {
+			Environment: map[string]string{
+				"PGHOST":     "localhost",
+				"PGPORT":     "5432",
+				"PGUSER":     "root",
+				"PGPASSWORD": "123456",
+				"PGDATABASE": "test",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:     "localhost",
+						fieldname.Port:     "5432",
+						fieldname.User:     "root",
+						fieldname.Password: "123456",
+						fieldname.Database: "test",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestDatabaseCredentialsProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, DatabaseCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Host:     "localhost",
+				fieldname.Port:     "5432",
+				fieldname.User:     "root",
+				fieldname.Password: "123456",
+				fieldname.Database: "test",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"PGHOST":     "localhost",
+					"PGPORT":     "5432",
+					"PGUSER":     "root",
+					"PGPASSWORD": "123456",
+					"PGDATABASE": "test",
+				},
+			},
+		},
+	})
+}

--- a/plugins/pgcli/pgcli.go
+++ b/plugins/pgcli/pgcli.go
@@ -1,0 +1,22 @@
+package pgcli
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func PostgreSQLCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "pgcli",
+		Runs:      []string{"pgcli"},
+		DocsURL:   sdk.URL("https://www.pgcli.com/docs"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}

--- a/plugins/pgcli/plugin.go
+++ b/plugins/pgcli/plugin.go
@@ -1,0 +1,22 @@
+package pgcli
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "pgcli",
+		Platform: schema.PlatformInfo{
+			Name:     "PostgreSQL",
+			Homepage: sdk.URL("https://pgcli.com"),
+		},
+		Credentials: []schema.CredentialType{
+			DatabaseCredentials(),
+		},
+		Executables: []schema.Executable{
+			PostgreSQLCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

This PR adds a new plugin for the pgcli executable. pgcli is a more modern alternative to psql (which is already supported in a built-in plugin). This plugin was heavily copied from psql, since pgcli is mostly compatible with psql.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Same way as testing psql, but installing pgcli and using the pgcli plugin.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Add pgcli plugin
