### PR TITLE
MonogoDB CLI (mongosh) provider

### DIFF
--- a/plugins/mongosh/database_credentials.go
+++ b/plugins/mongosh/database_credentials.go
@@ -1,0 +1,77 @@
+package mongosh
+
+import (
+	"context"
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func DatabaseCredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.DatabaseCredentials,
+		DocsURL: sdk.URL("https://www.mongodb.com/docs/mongodb-shell/connect/#connect-with-ldap"),
+		//ManagementURL: sdk.URL("https://console.mongosh.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "MongoDB host to connect to.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Port,
+				MarkdownDescription: "Port used to connect to MongoDB.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Username,
+				MarkdownDescription: "MongoDB user to authenticate as.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password used to authenticate to MongoDB.",
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Database,
+				MarkdownDescription: "Database name or URL to connect to.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: mongoshProvisioner{},
+	}
+}
+
+type mongoshProvisioner struct{}
+
+func (m mongoshProvisioner) Description() string {
+	return "mongosh cli provisioner"
+}
+
+func (m mongoshProvisioner) Provision(ctx context.Context, input sdk.ProvisionInput, output *sdk.ProvisionOutput) {
+	if username, ok := input.ItemFields[fieldname.Username]; ok {
+		output.AddArgs("--username", username)
+	}
+
+	if password, ok := input.ItemFields[fieldname.Password]; ok {
+		output.AddArgs("--password", password)
+	}
+
+	if host, ok := input.ItemFields[fieldname.Host]; ok {
+		output.AddArgs("--host", host)
+	}
+
+	if port, ok := input.ItemFields[fieldname.Port]; ok {
+		output.AddArgs("--port", port)
+	}
+
+	if db, ok := input.ItemFields[fieldname.Database]; ok {
+		output.AddArgs(db)
+	}
+}
+
+func (m mongoshProvisioner) Deprovision(ctx context.Context, input sdk.DeprovisionInput, output *sdk.DeprovisionOutput) {
+	// No-op
+}

--- a/plugins/mongosh/database_credentials_test.go
+++ b/plugins/mongosh/database_credentials_test.go
@@ -1,0 +1,26 @@
+package mongosh
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestUserLoginProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, DatabaseCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Username: "aexample",
+				fieldname.Password: "apassword",
+				fieldname.Host:     "example.org",
+				fieldname.Port:     "2121",
+				fieldname.Database: "example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"--username", "aexample", "--password", "apassword", "--host", "example.org", "--port", "2121", "example"},
+			},
+		},
+	})
+}

--- a/plugins/mongosh/mongosh.go
+++ b/plugins/mongosh/mongosh.go
@@ -1,0 +1,22 @@
+package mongosh
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func MongoDBShellCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "MongoDB Shell CLI",
+		Runs:      []string{"mongosh"},
+		DocsURL:   sdk.URL("https://mongosh.com/docs/cli"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}

--- a/plugins/mongosh/plugin.go
+++ b/plugins/mongosh/plugin.go
@@ -1,0 +1,22 @@
+package mongosh
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "mongosh",
+		Platform: schema.PlatformInfo{
+			Name:     "MongoDB Shell",
+			Homepage: sdk.URL("https://mongosh.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			DatabaseCredentials(),
+		},
+		Executables: []schema.Executable{
+			MongoDBShellCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
This provider takes a bunch of optional arguments/fields. The most important one is "database". That can be used for either specifying just a database name in conjuction with the other arguments/fields, or to supply a MongoDB connection string
(e.g. `mongodb+srv://username:password@example.org:27017/database?options`).

I generally use a username, password, and a connection string without username and password in it.

I modeled after the mysql and postgres providers.

## Type of change

- [X] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
```
op init plugin mongosh
op plugin run -- mongosh
```

## Changelog
Authenticate the MongoDB CLI using Touch ID and other unlock options with 1Password Shell Plugins.
