### PR TITLE
Adding Shopify CLI plugin

### DIFF
--- a/plugins/shopify/cli_token.go
+++ b/plugins/shopify/cli_token.go
@@ -1,0 +1,70 @@
+package shopify
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func CLIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.CLIToken,
+		DocsURL:       sdk.URL("https://shopify.com/docs/cli_token"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.shopify.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Shopify.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 69,
+					Prefix: "atkn_", // TODO: Check if this is correct
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryShopifyConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SHOPIFY_TOKEN": fieldname.Token, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the CLI Token in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryShopifyConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.Token == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.Token: config.Token,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	Token string
+// }

--- a/plugins/shopify/cli_token.go
+++ b/plugins/shopify/cli_token.go
@@ -1,8 +1,6 @@
 package shopify
 
 import (
-	"context"
-
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -14,8 +12,8 @@ import (
 func CLIToken() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.CLIToken,
-		DocsURL:       sdk.URL("https://shopify.com/docs/cli_token"), // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://console.shopify.com/user/security/tokens"), // TODO: Replace with actual URL
+		DocsURL:       sdk.URL("https://shopify.dev/docs/apps/tools/cli/ci-cd#step-2-generate-a-cli-authentication-token"),
+		ManagementURL: sdk.URL("https://partners.shopify.com/"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,
@@ -23,7 +21,7 @@ func CLIToken() schema.CredentialType {
 				Secret:              true,
 				Composition: &schema.ValueComposition{
 					Length: 69,
-					Prefix: "atkn_", // TODO: Check if this is correct
+					Prefix: "atkn_",
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
@@ -34,37 +32,9 @@ func CLIToken() schema.CredentialType {
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
-			TryShopifyConfigFile(),
 		)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"SHOPIFY_TOKEN": fieldname.Token, // TODO: Check if this is correct
+	"SHOPIFY_TOKEN": fieldname.Token,
 }
-
-// TODO: Check if the platform stores the CLI Token in a local config file, and if so,
-// implement the function below to add support for importing it.
-func TryShopifyConfigFile() sdk.Importer {
-	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
-		// var config Config
-		// if err := contents.ToYAML(&config); err != nil {
-		// 	out.AddError(err)
-		// 	return
-		// }
-
-		// if config.Token == "" {
-		// 	return
-		// }
-
-		// out.AddCandidate(sdk.ImportCandidate{
-		// 	Fields: map[sdk.FieldName]string{
-		// 		fieldname.Token: config.Token,
-		// 	},
-		// })
-	})
-}
-
-// TODO: Implement the config file schema
-// type Config struct {
-//	Token string
-// }

--- a/plugins/shopify/cli_token_test.go
+++ b/plugins/shopify/cli_token_test.go
@@ -2,16 +2,16 @@ package shopify
 
 import (
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func TestCLITokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, CLIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+			ItemFields: map[sdk.FieldName]string{
 				fieldname.Token: "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -26,7 +26,7 @@ func TestCLITokenProvisioner(t *testing.T) {
 func TestCLITokenImporter(t *testing.T) {
 	plugintest.TestImporter(t, CLIToken().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
+			Environment: map[string]string{
 				"SHOPIFY_TOKEN": "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
@@ -35,20 +35,6 @@ func TestCLITokenImporter(t *testing.T) {
 						fieldname.Token: "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
 					},
 				},
-			},
-		},
-		// TODO: If you implemented a config file importer, add a test file example in shopify/test-fixtures
-		// and fill the necessary details in the test template below.
-		"config file": {
-			Files: map[string]string{
-				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
-			},
-			ExpectedCandidates: []sdk.ImportCandidate{
-			// 	{
-			// 		Fields: map[sdk.FieldName]string{
-			// 			fieldname.Token: "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
-			// 		},
-			// 	},
 			},
 		},
 	})

--- a/plugins/shopify/cli_token_test.go
+++ b/plugins/shopify/cli_token_test.go
@@ -1,0 +1,55 @@
+package shopify
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestCLITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, CLIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SHOPIFY_TOKEN": "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
+				},
+			},
+		},
+	})
+}
+
+func TestCLITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, CLIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"SHOPIFY_TOKEN": "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in shopify/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "atkn_0mgpyi6brmpxduriv7ukpp9r3lcjgsld7357svtw5fey5vlyriyauwxhgexample",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/shopify/plugin.go
+++ b/plugins/shopify/plugin.go
@@ -1,0 +1,22 @@
+package shopify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "shopify",
+		Platform: schema.PlatformInfo{
+			Name:     "Shopify",
+			Homepage: sdk.URL("https://shopify.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			CLIToken(),
+		},
+		Executables: []schema.Executable{
+			ShopifyCLI(),
+		},
+	}
+}

--- a/plugins/shopify/shopify.go
+++ b/plugins/shopify/shopify.go
@@ -1,0 +1,25 @@
+package shopify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ShopifyCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Shopify CLI",
+		Runs:    []string{"shopify"},
+		DocsURL: sdk.URL("https://github.com/shopify/cli#readme"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.CLIToken,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Adding a shell-plugin for the Shopify CLI.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [X] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #201

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

`shopify theme dev`


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Adds the Shopify CLI plugin.



