### PR TITLE
feat: add zsh plugin

### DIFF
--- a/1password.plugin.zsh
+++ b/1password.plugin.zsh
@@ -1,0 +1,10 @@
+# make sure you execute this *after* asdf or other version managers are loaded
+if (( $+commands[op] )); then
+  eval "$(op completion zsh)"
+  compdef _op op
+  
+  # load plugins configuration
+  if [[ -f ~/.config/op/plugins.sh ]]; then
+    source ~/.config/op/plugins.sh
+  fi
+fi


### PR DESCRIPTION
## Overview
Users can load all of the required shell config with:

`zinit load 1Password/shell-plugins`

## Type of change

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
NA

## How To Test
Use the load command above

## Changelog
Add zsh plugin for completion and plugin aliases


