### PR TITLE
nomad: Init nomad plugin

### DIFF
--- a/plugins/nomad/auth_token.go
+++ b/plugins/nomad/auth_token.go
@@ -1,0 +1,55 @@
+package nomad
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AuthToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AuthToken,
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to HashiCorp Nomad.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 36,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Address,
+				MarkdownDescription: "Address of the HashiCorp Nomad Server",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryHashiCorpNomadConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"NOMAD_TOKEN":   fieldname.Token,
+	"NOMAD_ADDRESS": fieldname.Address,
+}
+
+// TODO: Check if the platform stores the Auth Token in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryHashiCorpNomadConfigFile() sdk.Importer {
+	return importer.NoOp()
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	Token string
+// }

--- a/plugins/nomad/auth_token_test.go
+++ b/plugins/nomad/auth_token_test.go
@@ -1,0 +1,45 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAuthTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AuthToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "zwlwp719xssnxwvt3bq1rahafxsn0example",
+				fieldname.Address: "http://localhost:4646",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NOMAD_TOKEN": "zwlwp719xssnxwvt3bq1rahafxsn0example",
+					"NOMAD_ADDR": "http://localhost:4646",
+				},
+			},
+		},
+	})
+}
+
+func TestAuthTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AuthToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"NOMAD_TOKEN": "zwlwp719xssnxwvt3bq1rahafxsn0example",
+				"NOMAD_ADDR": "http://nomad.example.com",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "zwlwp719xssnxwvt3bq1rahafxsn0example",
+						fieldname.Address: "http://nomad.example.com",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/nomad/nomad.go
+++ b/plugins/nomad/nomad.go
@@ -1,0 +1,25 @@
+package nomad
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func HashiCorpNomadCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "HashiCorp Nomad CLI",
+		Runs:      []string{"nomad"},
+		DocsURL:   sdk.URL("https://developer.hashicorp.com/nomad/docs/commands"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AuthToken,
+			},
+		},
+	}
+}

--- a/plugins/nomad/plugin.go
+++ b/plugins/nomad/plugin.go
@@ -1,0 +1,22 @@
+package nomad
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "nomad",
+		Platform: schema.PlatformInfo{
+			Name:     "HashiCorp Nomad",
+			Homepage: sdk.URL("https://nomad.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			AuthToken(),
+		},
+		Executables: []schema.Executable{
+			HashiCorpNomadCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
This PR adds support for the `nomad` CLI to allow pulling the `NOMAD_ADDR` and `NOMAD_TOKEN` Environment variables from a 1Password vault item.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [X] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

None

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
nomad job status


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Authenticate to an HashiCorp Nomad cluster with a Nomad ACL token stored in 1Password.

