### PR TITLE
Add Shodan Command-Line Interface Plugin

### DIFF
--- a/plugins/shodan/api_key.go
+++ b/plugins/shodan/api_key.go
@@ -1,0 +1,70 @@
+package shodan
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://shodan.com/docs/api_key"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.shodan.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Shodan.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 32,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryShodanConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SHODAN_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the API Key in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryShodanConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.APIKey == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.APIKey: config.APIKey,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	APIKey string
+// }

--- a/plugins/shodan/api_key_test.go
+++ b/plugins/shodan/api_key_test.go
@@ -1,0 +1,55 @@
+package shodan
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.APIKey: "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SHODAN_API_KEY": "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"SHODAN_API_KEY": "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in shodan/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/shodan/api_key_test.go
+++ b/plugins/shodan/api_key_test.go
@@ -11,12 +11,12 @@ import (
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+			ItemFields: map[sdk.FieldName]string{
 				fieldname.APIKey: "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
-				Environment: map[string]string{
-					"SHODAN_API_KEY": "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
+				Files: map[string]sdk.OutputFile{
+					"~/.config/shodan/api_key": {Contents: []byte("ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE")},
 				},
 			},
 		},
@@ -25,9 +25,9 @@ func TestAPIKeyProvisioner(t *testing.T) {
 
 func TestAPIKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
-		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
-				"SHODAN_API_KEY": "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
+		"config file": {
+			Files: map[string]string{
+				"~/.config/shodan/api_key": plugintest.LoadFixture(t, "api_key"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
@@ -35,20 +35,6 @@ func TestAPIKeyImporter(t *testing.T) {
 						fieldname.APIKey: "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
 					},
 				},
-			},
-		},
-		// TODO: If you implemented a config file importer, add a test file example in shodan/test-fixtures
-		// and fill the necessary details in the test template below.
-		"config file": {
-			Files: map[string]string{
-				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
-			},
-			ExpectedCandidates: []sdk.ImportCandidate{
-			// 	{
-			// 		Fields: map[sdk.FieldName]string{
-			// 			fieldname.Token: "ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE",
-			// 		},
-			// 	},
 			},
 		},
 	})

--- a/plugins/shodan/plugin.go
+++ b/plugins/shodan/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "shodan",
 		Platform: schema.PlatformInfo{
 			Name:     "Shodan",
-			Homepage: sdk.URL("https://shodan.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://www.shodan.io"),
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),

--- a/plugins/shodan/plugin.go
+++ b/plugins/shodan/plugin.go
@@ -1,0 +1,22 @@
+package shodan
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "shodan",
+		Platform: schema.PlatformInfo{
+			Name:     "Shodan",
+			Homepage: sdk.URL("https://shodan.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			ShodanCLI(),
+		},
+	}
+}

--- a/plugins/shodan/shodan.go
+++ b/plugins/shodan/shodan.go
@@ -1,0 +1,25 @@
+package shodan
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ShodanCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Shodan CLI", // TODO: Check if this is correct
+		Runs:      []string{"shodan"},
+		DocsURL:   sdk.URL("https://shodan.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/shodan/shodan.go
+++ b/plugins/shodan/shodan.go
@@ -9,9 +9,9 @@ import (
 
 func ShodanCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Shodan CLI", // TODO: Check if this is correct
+		Name:      "Shodan Command-Line Interface",
 		Runs:      []string{"shodan"},
-		DocsURL:   sdk.URL("https://shodan.com/docs/cli"), // TODO: Replace with actual URL
+		DocsURL:   sdk.URL("https://cli.shodan.io"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/shodan/test-fixtures/api_key
+++ b/plugins/shodan/test-fixtures/api_key
@@ -1,0 +1,1 @@
+ddXfzwQOIjTaaxGMzcxXYR6Q0EXAMPLE


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add Plugin for Shodan Command-Line Interface.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

- Install Shodan CLI with pip
- Run `op plugin init shodan`
- Run `shodan info`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Authenticate the Shodan Command-Line Interface using Touch ID and other unlock options with 1Password Shell Plugins.

