### PR TITLE
Add Exercism plugin

### DIFF
--- a/plugins/exercism/api_key.go
+++ b/plugins/exercism/api_key.go
@@ -1,0 +1,94 @@
+package exercism
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://exercism.org/docs/using/solving-exercises/working-locally"),
+		ManagementURL: sdk.URL("https://exercism.org/settings/api_cli"),
+		Fields: []schema.CredentialField{
+			{
+				Name: fieldname.URL,
+				MarkdownDescription: `The URL of the Exercism API.`,
+				Secret: false,
+			},
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Exercism.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 37,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name: sdk.FieldName("Directory"),
+				MarkdownDescription: `The path to the workspace directory where the exercises are stored.`,
+				Secret: false,
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			tempFileConfig,
+			provision.AtFixedPath("~/.config/exercism/user.json"),
+		),
+		Importer: importer.TryAll(
+			TryExercismConfigFile(),
+		)}
+}
+
+func TryExercismConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/exercism/user.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.URL == "" || config.APIKey == "" || config.Workspace == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.APIKey: config.APIKey,
+				fieldname.URL: config.URL,
+				sdk.FieldName("Directory"): config.Workspace,
+			},
+		})
+	})
+}
+
+type Config struct {
+	URL string `json:"apibaseurl"`
+	APIKey string `json:"token"`
+	Workspace string `json:"workspace"`
+}
+
+func tempFileConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		URL: in.ItemFields[fieldname.URL],
+		APIKey: in.ItemFields[fieldname.APIKey],
+		Workspace: in.ItemFields[sdk.FieldName("Directory")],
+	}
+
+	contents, err := json.Marshal(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(contents), nil
+}

--- a/plugins/exercism/api_key.go
+++ b/plugins/exercism/api_key.go
@@ -19,9 +19,9 @@ func APIKey() schema.CredentialType {
 		ManagementURL: sdk.URL("https://exercism.org/settings/api_cli"),
 		Fields: []schema.CredentialField{
 			{
-				Name: fieldname.URL,
+				Name:                fieldname.URL,
 				MarkdownDescription: `The URL of the Exercism API.`,
-				Secret: false,
+				Secret:              false,
 			},
 			{
 				Name:                fieldname.APIKey,
@@ -36,9 +36,9 @@ func APIKey() schema.CredentialType {
 				},
 			},
 			{
-				Name: sdk.FieldName("Directory"),
+				Name:                sdk.FieldName("Directory"),
 				MarkdownDescription: `The path to the workspace directory where the exercises are stored.`,
-				Secret: false,
+				Secret:              false,
 			},
 		},
 		DefaultProvisioner: provision.TempFile(
@@ -64,8 +64,8 @@ func TryExercismConfigFile() sdk.Importer {
 
 		out.AddCandidate(sdk.ImportCandidate{
 			Fields: map[sdk.FieldName]string{
-				fieldname.APIKey: config.APIKey,
-				fieldname.URL: config.URL,
+				fieldname.APIKey:           config.APIKey,
+				fieldname.URL:              config.URL,
 				sdk.FieldName("Directory"): config.Workspace,
 			},
 		})
@@ -73,15 +73,15 @@ func TryExercismConfigFile() sdk.Importer {
 }
 
 type Config struct {
-	URL string `json:"apibaseurl"`
-	APIKey string `json:"token"`
+	URL       string `json:"apibaseurl"`
+	APIKey    string `json:"token"`
 	Workspace string `json:"workspace"`
 }
 
 func tempFileConfig(in sdk.ProvisionInput) ([]byte, error) {
 	config := Config{
-		URL: in.ItemFields[fieldname.URL],
-		APIKey: in.ItemFields[fieldname.APIKey],
+		URL:       in.ItemFields[fieldname.URL],
+		APIKey:    in.ItemFields[fieldname.APIKey],
 		Workspace: in.ItemFields[sdk.FieldName("Directory")],
 	}
 

--- a/plugins/exercism/api_key.go
+++ b/plugins/exercism/api_key.go
@@ -28,10 +28,11 @@ func APIKey() schema.CredentialType {
 				MarkdownDescription: "API Key used to authenticate to Exercism.",
 				Secret:              true,
 				Composition: &schema.ValueComposition{
-					Length: 37,
+					Length: 36,
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
+						Specific: []rune{'-'},
 					},
 				},
 			},

--- a/plugins/exercism/api_key.go
+++ b/plugins/exercism/api_key.go
@@ -32,7 +32,7 @@ func APIKey() schema.CredentialType {
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
-						Specific: []rune{'-'},
+						Specific:  []rune{'-'},
 					},
 				},
 			},

--- a/plugins/exercism/api_key_test.go
+++ b/plugins/exercism/api_key_test.go
@@ -1,0 +1,48 @@
+package exercism
+
+import (
+	"strings"
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ 
+				fieldname.URL: "https://api.exercism.io/v1",
+				fieldname.APIKey: "v1o2p80wuf2qhnurrvf8rigro6sp38example",
+				sdk.FieldName("Directory"): "/Users/username/exercism",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					"~/.config/exercism/user.json": {
+						Contents: []byte(strings.Join(strings.Fields(plugintest.LoadFixture(t, "user.json")), "")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.config/exercism/user.json": plugintest.LoadFixture(t, "user.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			 	{
+			 		Fields: map[sdk.FieldName]string{
+						fieldname.URL: "https://api.exercism.io/v1",
+			 			fieldname.APIKey: "v1o2p80wuf2qhnurrvf8rigro6sp38example",
+						sdk.FieldName("Directory"): "/Users/username/exercism",
+			 		},
+			 	},
+			},
+		},
+	})
+}

--- a/plugins/exercism/api_key_test.go
+++ b/plugins/exercism/api_key_test.go
@@ -3,18 +3,18 @@ package exercism
 import (
 	"strings"
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ 
-				fieldname.URL: "https://api.exercism.io/v1",
-				fieldname.APIKey: "v1o2p80wuf2qhnurrvf8rigro6sp38example",
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.URL:              "https://api.exercism.io/v1",
+				fieldname.APIKey:           "v1o2p80wuf2qhnurrvf8rigro6sp38example",
 				sdk.FieldName("Directory"): "/Users/username/exercism",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -35,13 +35,13 @@ func TestAPIKeyImporter(t *testing.T) {
 				"~/.config/exercism/user.json": plugintest.LoadFixture(t, "user.json"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
-			 	{
-			 		Fields: map[sdk.FieldName]string{
-						fieldname.URL: "https://api.exercism.io/v1",
-			 			fieldname.APIKey: "v1o2p80wuf2qhnurrvf8rigro6sp38example",
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.URL:              "https://api.exercism.io/v1",
+						fieldname.APIKey:           "v1o2p80wuf2qhnurrvf8rigro6sp38example",
 						sdk.FieldName("Directory"): "/Users/username/exercism",
-			 		},
-			 	},
+					},
+				},
 			},
 		},
 	})

--- a/plugins/exercism/api_key_test.go
+++ b/plugins/exercism/api_key_test.go
@@ -38,7 +38,7 @@ func TestAPIKeyImporter(t *testing.T) {
 				{
 					Fields: map[sdk.FieldName]string{
 						fieldname.URL:              "https://api.exercism.org/v1",
-						fieldname.APIKey:           "v1o2p80wuf2qhnurrvf8rigro6sp38example",
+						fieldname.APIKey:           "1ge7a536-9d1c-4a26-9ww3-3d423example",
 						sdk.FieldName("Directory"): "/Users/username/exercism",
 					},
 				},

--- a/plugins/exercism/api_key_test.go
+++ b/plugins/exercism/api_key_test.go
@@ -14,7 +14,7 @@ func TestAPIKeyProvisioner(t *testing.T) {
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.URL:              "https://api.exercism.io/v1",
-				fieldname.APIKey:           "v1o2p80wuf2qhnurrvf8rigro6sp38example",
+				fieldname.APIKey:           "1ge7a536-9d1c-4a26-9ww3-3d423example",
 				sdk.FieldName("Directory"): "/Users/username/exercism",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{

--- a/plugins/exercism/api_key_test.go
+++ b/plugins/exercism/api_key_test.go
@@ -13,7 +13,7 @@ func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.URL:              "https://api.exercism.io/v1",
+				fieldname.URL:              "https://api.exercism.org/v1",
 				fieldname.APIKey:           "1ge7a536-9d1c-4a26-9ww3-3d423example",
 				sdk.FieldName("Directory"): "/Users/username/exercism",
 			},
@@ -37,7 +37,7 @@ func TestAPIKeyImporter(t *testing.T) {
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.URL:              "https://api.exercism.io/v1",
+						fieldname.URL:              "https://api.exercism.org/v1",
 						fieldname.APIKey:           "v1o2p80wuf2qhnurrvf8rigro6sp38example",
 						sdk.FieldName("Directory"): "/Users/username/exercism",
 					},

--- a/plugins/exercism/exercism.go
+++ b/plugins/exercism/exercism.go
@@ -1,0 +1,25 @@
+package exercism
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ExercismCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Exercism CLI", 
+		Runs:      []string{"exercism"},
+		DocsURL:   sdk.URL("https://exercism.org/docs/using/solving-exercises/working-locally"), 
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/exercism/exercism.go
+++ b/plugins/exercism/exercism.go
@@ -9,9 +9,9 @@ import (
 
 func ExercismCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Exercism CLI", 
-		Runs:      []string{"exercism"},
-		DocsURL:   sdk.URL("https://exercism.org/docs/using/solving-exercises/working-locally"), 
+		Name:    "Exercism CLI",
+		Runs:    []string{"exercism"},
+		DocsURL: sdk.URL("https://exercism.org/docs/using/solving-exercises/working-locally"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/exercism/exercism.go
+++ b/plugins/exercism/exercism.go
@@ -15,6 +15,7 @@ func ExercismCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("completion", "upgrade", "workspace", "troubleshoot"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/exercism/plugin.go
+++ b/plugins/exercism/plugin.go
@@ -1,0 +1,22 @@
+package exercism
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "exercism",
+		Platform: schema.PlatformInfo{
+			Name:     "Exercism",
+			Homepage: sdk.URL("https://exercism.org"), 
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			ExercismCLI(),
+		},
+	}
+}

--- a/plugins/exercism/plugin.go
+++ b/plugins/exercism/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "exercism",
 		Platform: schema.PlatformInfo{
 			Name:     "Exercism",
-			Homepage: sdk.URL("https://exercism.org"), 
+			Homepage: sdk.URL("https://exercism.org"),
 		},
 		Credentials: []schema.CredentialType{
 			APIKey(),

--- a/plugins/exercism/test-fixtures/user.json
+++ b/plugins/exercism/test-fixtures/user.json
@@ -1,0 +1,5 @@
+{
+	"apibaseurl":"https://api.exercism.io/v1",
+	"token":"v1o2p80wuf2qhnurrvf8rigro6sp38example",
+	"workspace":"/Users/username/exercism"
+}

--- a/plugins/exercism/test-fixtures/user.json
+++ b/plugins/exercism/test-fixtures/user.json
@@ -1,5 +1,5 @@
 {
-	"apibaseurl":"https://api.exercism.io/v1",
+	"apibaseurl":"https://api.exercism.org/v1",
 	"token":"v1o2p80wuf2qhnurrvf8rigro6sp38example",
 	"workspace":"/Users/username/exercism"
 }

--- a/plugins/exercism/test-fixtures/user.json
+++ b/plugins/exercism/test-fixtures/user.json
@@ -1,5 +1,5 @@
 {
 	"apibaseurl":"https://api.exercism.org/v1",
-	"token":"v1o2p80wuf2qhnurrvf8rigro6sp38example",
+	"token":"1ge7a536-9d1c-4a26-9ww3-3d423example",
 	"workspace":"/Users/username/exercism"
 }


### PR DESCRIPTION
## Overview
Adds a plugin for the Exercism CLI. A config file at `~/.config/exercism/user.json` is provisioned/imported. This file contains a URL to the Exercism API, an API key, and a directory in which the user's Exercism workspace is located.


## Type of change
- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience


## Related Issue(s)
* Resolves: #142 


## How To Test
Run any exercism command other than help or version.
E.g., `exercism download --track=cpp --exercise=armstrong-numbers`


## Changelog
The user can now use the Exercism plugin to authenticate to the Exercism CLI.


