### PR TITLE
Prepend arg for defaults-file

### DIFF
--- a/sdk/provision/file_provisioner.go
+++ b/sdk/provision/file_provisioner.go
@@ -159,7 +159,7 @@ func (p FileProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, o
 			argsResolved[i] = result.String()
 		}
 
-		out.AddArgs(argsResolved...)
+		out.PrependArgs(argsResolved...)
 	}
 }
 

--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"slices"
 	"time"
 )
 
@@ -105,6 +106,11 @@ func (out *ProvisionOutput) AddEnvVar(name string, value string) {
 // AddArgs can be used to add additional arguments to the command line of the provision output.
 func (out *ProvisionOutput) AddArgs(args ...string) {
 	out.CommandLine = append(out.CommandLine, args...)
+}
+
+// PrependArgs can be used to insert additional arguments at the beginning of the command line of the provision output.
+func (out *ProvisionOutput) PrependArgs(args ...string) {
+	out.CommandLine = slices.Insert(out.CommandLine, 1, args...)
 }
 
 // AddSecretFile can be used to add a file containing secrets to the provision output.


### PR DESCRIPTION


## Overview
The `mysql` CLI depends on the `--defaults-file=foo` argument being the *very first* argument.  This change provides a new 'PrependArgs' method and uses it for the `mysql` plugin.

From the `mysql` CLI help text:
```
The following groups are read: mysql client
The following options may be given as the first argument:
--print-defaults        Print the program argument list and exit.
--no-defaults           Don't read default options from any option file,
                        except for login file.
--defaults-file=#       Only read default options from the given file #.
--defaults-extra-file=# Read this file after the global files are read.
--defaults-group-suffix=#
                        Also read groups with concat(group, suffix)
--login-path=#          Read this path from the login file.
```

## Type of change

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

* Resolves: #406

## How To Test

Build the plugin locally and run `op plugin run mysql -- --host=foo` using a credential with no `host` field.  Before this PR, it results in the error: `mysql: [ERROR] unknown variable 'defaults-file=...` because the MySQL treats unknown arguments in the form `--variable-name=foo` as MySQL configuration variable. After the PR, additional command-line arguments are appended after `--defaults-file` that is injected by the `mysql` plugin.

<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
- The `mysql` CLI depends on the `--defaults-file=foo` argument being the very first argument


