### PR TITLE
Adding Enterprise Support to github shell plugin

### DIFF
--- a/plugins/github/gh.go
+++ b/plugins/github/gh.go
@@ -21,6 +21,9 @@ func GitHubCLI() schema.Executable {
 			{
 				Name: credname.PersonalAccessToken,
 			},
+			{
+				Name: credname.EnterprisePersonalAccessToken,
+			},
 		},
 	}
 }

--- a/plugins/github/personal_access_token.go
+++ b/plugins/github/personal_access_token.go
@@ -64,7 +64,9 @@ func PersonalAccessToken() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"GITHUB_TOKEN": fieldname.Token,
+	"GH_TOKEN": fieldname.Token,
+	"GH_ENTERPRISE_TOKEN": fieldname.Token,
+        "GH_HOST": fieldname.Host,
 }
 
 type Config struct {

--- a/plugins/github/personal_access_token.go
+++ b/plugins/github/personal_access_token.go
@@ -32,24 +32,11 @@ func PersonalAccessToken() schema.CredentialType {
 					},
 				},
 			},
-			{
-				Name:                fieldname.Host,
-				MarkdownDescription: "The GitHub host to authenticate to. Defaults to 'github.com'.",
-				Optional:            true,
-			},
 		},
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
 			importer.TryAllEnvVars(fieldname.Token, "GH_TOKEN", "GITHUB_PAT"),
-			importer.TryEnvVarPair(map[string]sdk.FieldName{
-				"GH_HOST":             fieldname.Host,
-				"GH_ENTERPRISE_TOKEN": fieldname.Token,
-			}),
-			importer.TryEnvVarPair(map[string]sdk.FieldName{
-				"GH_HOST":                 fieldname.Host,
-				"GITHUB_ENTERPRISE_TOKEN": fieldname.Token,
-			}),
 			importer.TryEnvVarPair(map[string]sdk.FieldName{
 				"GH_HOST":  fieldname.Host,
 				"GH_TOKEN": fieldname.Token,
@@ -65,8 +52,54 @@ func PersonalAccessToken() schema.CredentialType {
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"GH_TOKEN": fieldname.Token,
+}
+
+func EnterprisePersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.EnterprisePersonalAccessToken,
+		DocsURL:       sdk.URL("https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"),
+                ManagementURL: nil, // TODO: Add management URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Enterprise GitHub.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 40,
+					Prefix: "ghp_",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "The GitHub Enterprise host to authenticate to.",
+				Optional:            false,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnterpriseEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnterpriseEnvVarMapping),
+			importer.TryAllEnvVars(fieldname.Token),
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"GH_HOST":             fieldname.Host,
+				"GH_ENTERPRISE_TOKEN": fieldname.Token,
+			}),
+			importer.TryEnvVarPair(map[string]sdk.FieldName{
+				"GH_HOST":                 fieldname.Host,
+				"GITHUB_ENTERPRISE_TOKEN": fieldname.Token,
+			}),
+			TryEnterpriseGitHubConfigFile(),
+		),
+	}
+}
+
+var defaultEnterpriseEnvVarMapping = map[string]sdk.FieldName{
 	"GH_ENTERPRISE_TOKEN": fieldname.Token,
-        "GH_HOST": fieldname.Host,
+	"GH_HOST": fieldname.Host,
 }
 
 type Config struct {
@@ -90,9 +123,37 @@ func TryGitHubConfigFile() sdk.Importer {
 				}
 
 				if host != "github.com" {
+                                        continue
+				}
+
+				out.AddCandidate(candidate)
+			}
+		}
+	})
+}
+
+func TryEnterpriseGitHubConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/gh/hosts.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config map[string]Config
+		if err := contents.ToYAML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for host, values := range config {
+			if strings.HasPrefix(values.Token, "ghp_") {
+				candidate := sdk.ImportCandidate{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: values.Token,
+					},
+				}
+
+				if host != "github.com" {
 					candidate.NameHint = host
 					candidate.Fields[fieldname.Host] = host
-				}
+				} else {
+                                        continue
+                                }
 
 				out.AddCandidate(candidate)
 			}

--- a/plugins/github/plugin.go
+++ b/plugins/github/plugin.go
@@ -14,6 +14,7 @@ func New() schema.Plugin {
 		},
 		Credentials: []schema.CredentialType{
 			PersonalAccessToken(),
+			EnterprisePersonalAccessToken(),
 		},
 		Executables: []schema.Executable{
 			GitHubCLI(),

--- a/sdk/schema/credname/names.go
+++ b/sdk/schema/credname/names.go
@@ -4,25 +4,26 @@ import "github.com/1Password/shell-plugins/sdk"
 
 // Credential type names.
 const (
-	APIClientCredentials = sdk.CredentialName("API Client Credentials")
-	APIKey               = sdk.CredentialName("API Key")
-	APIToken             = sdk.CredentialName("API Token")
-	AccessKey            = sdk.CredentialName("Access Key")
-	AccessToken          = sdk.CredentialName("Access Token")
-	AppPassword          = sdk.CredentialName("App Password")
-	AppToken             = sdk.CredentialName("App Token")
-	AuthToken            = sdk.CredentialName("Auth Token")
-	CLIToken             = sdk.CredentialName("CLI Token")
-	Credential           = sdk.CredentialName("Credential")
-	Credentials          = sdk.CredentialName("Credentials")
-	DatabaseCredentials  = sdk.CredentialName("Database Credentials")
-	DeployKey            = sdk.CredentialName("Deploy Key")
-	LoginDetails         = sdk.CredentialName("Login Details")
-	PersonalAPIToken     = sdk.CredentialName("Personal API Token")
-	PersonalAccessToken  = sdk.CredentialName("Personal Access Token")
-	RegistryCredentials  = sdk.CredentialName("Registry Credentials")
-	SecretKey            = sdk.CredentialName("Secret Key")
-	UserLogin            = sdk.CredentialName("User Login")
+	APIClientCredentials           = sdk.CredentialName("API Client Credentials")
+	APIKey                         = sdk.CredentialName("API Key")
+	APIToken                       = sdk.CredentialName("API Token")
+	AccessKey                      = sdk.CredentialName("Access Key")
+	AccessToken                    = sdk.CredentialName("Access Token")
+	AppPassword                    = sdk.CredentialName("App Password")
+	AppToken                       = sdk.CredentialName("App Token")
+	AuthToken                      = sdk.CredentialName("Auth Token")
+	CLIToken                       = sdk.CredentialName("CLI Token")
+	Credential                     = sdk.CredentialName("Credential")
+	Credentials                    = sdk.CredentialName("Credentials")
+	DatabaseCredentials            = sdk.CredentialName("Database Credentials")
+	DeployKey                      = sdk.CredentialName("Deploy Key")
+	EnterprisePersonalAccessToken  = sdk.CredentialName("Enterprise Personal Access Token")
+	LoginDetails                   = sdk.CredentialName("Login Details")
+	PersonalAPIToken               = sdk.CredentialName("Personal API Token")
+	PersonalAccessToken            = sdk.CredentialName("Personal Access Token")
+	RegistryCredentials            = sdk.CredentialName("Registry Credentials")
+	SecretKey                      = sdk.CredentialName("Secret Key")
+	UserLogin                      = sdk.CredentialName("User Login")
 )
 
 func ListAll() []sdk.CredentialName {
@@ -40,6 +41,7 @@ func ListAll() []sdk.CredentialName {
 		Credentials,
 		DatabaseCredentials,
 		DeployKey,
+		EnterprisePersonalAccessToken,
 		LoginDetails,
 		PersonalAPIToken,
 		PersonalAccessToken,


### PR DESCRIPTION
- Fixes for github enterprise tokens
- WIP: add enterprise support to gh

## Overview
<!--  
Provide a high-level description of this change.   
-->
Adding Support for Github Enterprise Tokens as they are separated from Github Tokens


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [X] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Allow users to authenticate to an Github Enterprise Server
