### PR TITLE
Create wireguard wg-quick plugin

### DIFF
--- a/plugins/wireguard/access_config.go
+++ b/plugins/wireguard/access_config.go
@@ -1,0 +1,119 @@
+package wireguard
+
+import (
+	"context"
+	"fmt"
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessConfig() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.AccessConfig,
+		DocsURL: sdk.URL("https://www.wireguard.com/quickstart/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.PrivateKey,
+				MarkdownDescription: "Private Key of your client.",
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Address,
+				MarkdownDescription: "VPN IP address of your client.",
+				Secret:              false,
+			},
+			{
+				Name:                fieldname.PublicKey,
+				MarkdownDescription: "Public Key of the Peer.",
+				Secret:              false,
+			},
+			{
+				Name:                fieldname.Endpoint,
+				MarkdownDescription: "Endpoint address of the Peer.",
+				Secret:              false,
+			},
+			{
+				Name:                fieldname.AllowedIPs,
+				MarkdownDescription: "Allowed IPs of the Peer.",
+				Secret:              false,
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			wgConfig,
+			provision.Filename("wg0.conf"),
+			provision.AddArgs("{{ .Path }}"),
+		),
+		Importer: importer.TryAll(
+			TryWireguardVPNConfigFile("/etc/wireguard/wg0.conf"),
+		)}
+}
+
+func wgConfig(in sdk.ProvisionInput) ([]byte, error) {
+	content := "[Interface]\n"
+
+	if privateKey, ok := in.ItemFields[fieldname.PrivateKey]; ok {
+		content += configFileEntry("PrivateKey", privateKey)
+	}
+
+	if address, ok := in.ItemFields[fieldname.Address]; ok {
+		content += configFileEntry("Address", address)
+	}
+
+	content = content + "\n"
+	content = content + "[Peer]\n"
+
+	if publicKey, ok := in.ItemFields[fieldname.PublicKey]; ok {
+		content += configFileEntry("PublicKey", publicKey)
+	}
+
+	if endpoint, ok := in.ItemFields[fieldname.Endpoint]; ok {
+		content += configFileEntry("Endpoint", endpoint)
+	}
+
+	if allowedIPs, ok := in.ItemFields[fieldname.AllowedIPs]; ok {
+		content += configFileEntry("AllowedIPs", allowedIPs)
+	}
+
+	return []byte(content), nil
+}
+
+func configFileEntry(key string, value string) string {
+	return fmt.Sprintf("%s = %s\n", key, value)
+}
+
+func TryWireguardVPNConfigFile(path string) sdk.Importer {
+	return importer.TryFile(path, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		configFile, err := contents.ToINI()
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		fields := make(map[sdk.FieldName]string)
+		for _, section := range configFile.Sections() {
+			if section.HasKey("PrivateKey") && section.Key("PrivateKey").Value() != "" {
+				fields[fieldname.PrivateKey] = section.Key("PrivateKey").Value()
+			}
+			if section.HasKey("Address") && section.Key("Address").Value() != "" {
+				fields[fieldname.Address] = section.Key("Address").Value()
+			}
+			if section.HasKey("PublicKey") && section.Key("PublicKey").Value() != "" {
+				fields[fieldname.PublicKey] = section.Key("PublicKey").Value()
+			}
+			if section.HasKey("Endpoint") && section.Key("Endpoint").Value() != "" {
+				fields[fieldname.Endpoint] = section.Key("Endpoint").Value()
+			}
+			if section.HasKey("AllowedIPs") && section.Key("AllowedIPs").Value() != "" {
+				fields[fieldname.AllowedIPs] = section.Key("AllowedIPs").Value()
+			}
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: fields,
+		})
+	})
+}

--- a/plugins/wireguard/access_config_test.go
+++ b/plugins/wireguard/access_config_test.go
@@ -1,0 +1,53 @@
+package wireguard
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAccessConfigProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessConfig().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.PrivateKey: "wvCwch6elBhsYAFlhXPj8bFEXAMPLE",
+				fieldname.Address:    "10.0.0.2/32",
+				fieldname.PublicKey:  "wvCwch6elBhsYAFlhXPj8bFEXAMPLE",
+				fieldname.Endpoint:   "test.example.com:51820",
+				fieldname.AllowedIPs: "10.0.0.0/8",
+			},
+			CommandLine: []string{"wg-quick"},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"wg-quick", "/tmp/wg0.conf"},
+				Files: map[string]sdk.OutputFile{
+					"/tmp/wg0.conf": {
+						Contents: []byte(plugintest.LoadFixture(t, "wg0.conf")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccessConfigImporter(t *testing.T) {
+	expectedFields := map[sdk.FieldName]string{
+		fieldname.PrivateKey: "wvCwch6elBhsYAFlhXPj8bFEXAMPLE",
+		fieldname.Address:    "10.0.0.2/32",
+		fieldname.PublicKey:  "wvCwch6elBhsYAFlhXPj8bFEXAMPLE",
+		fieldname.Endpoint:   "test.example.com:51820",
+		fieldname.AllowedIPs: "10.0.0.0/8",
+	}
+
+	plugintest.TestImporter(t, AccessConfig().Importer, map[string]plugintest.ImportCase{
+		"wireguard config file": {
+			Files: map[string]string{
+				"/etc/wireguard/wg0.conf": plugintest.LoadFixture(t, "wg0.conf"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{Fields: expectedFields},
+			},
+		},
+	})
+}

--- a/plugins/wireguard/plugin.go
+++ b/plugins/wireguard/plugin.go
@@ -1,0 +1,22 @@
+package wireguard
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "wireguard",
+		Platform: schema.PlatformInfo{
+			Name:     "Wireguard VPN",
+			Homepage: sdk.URL("https://wireguard.com"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessConfig(),
+		},
+		Executables: []schema.Executable{
+			WireguardVPNCLI(),
+		},
+	}
+}

--- a/plugins/wireguard/test-fixtures/wg0.conf
+++ b/plugins/wireguard/test-fixtures/wg0.conf
@@ -1,0 +1,8 @@
+[Interface]
+PrivateKey = wvCwch6elBhsYAFlhXPj8bFEXAMPLE
+Address = 10.0.0.2/32
+
+[Peer]
+PublicKey = wvCwch6elBhsYAFlhXPj8bFEXAMPLE
+Endpoint = test.example.com:51820
+AllowedIPs = 10.0.0.0/8

--- a/plugins/wireguard/wg_quick.go
+++ b/plugins/wireguard/wg_quick.go
@@ -1,0 +1,25 @@
+package wireguard
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func WireguardVPNCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Wireguard VPN Quick CLI",
+		Runs:    []string{"wg-quick"},
+		DocsURL: sdk.URL("https://www.wireguard.com/quickstart/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessConfig,
+			},
+		},
+	}
+}

--- a/sdk/schema/credname/names.go
+++ b/sdk/schema/credname/names.go
@@ -23,6 +23,7 @@ const (
 	RegistryCredentials  = sdk.CredentialName("Registry Credentials")
 	SecretKey            = sdk.CredentialName("Secret Key")
 	UserLogin            = sdk.CredentialName("User Login")
+	AccessConfig         = sdk.CredentialName("Access Config")
 )
 
 func ListAll() []sdk.CredentialName {
@@ -46,5 +47,6 @@ func ListAll() []sdk.CredentialName {
 		RegistryCredentials,
 		SecretKey,
 		UserLogin,
+		AccessConfig,
 	}
 }

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -57,6 +57,7 @@ const (
 	UserAccessToken = sdk.FieldName("User Access Token")
 	Username        = sdk.FieldName("Username")
 	Website         = sdk.FieldName("Website")
+	AllowedIPs      = sdk.FieldName("Allowed IPs")
 )
 
 func ListAll() []sdk.FieldName {
@@ -110,5 +111,6 @@ func ListAll() []sdk.FieldName {
 		User,
 		Username,
 		Website,
+		AllowedIPs,
 	}
 }


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
I've created a plugin for wg-quick to use the configurations out of 1password instead of the standard config path.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
Example command: 

Without plugin: 

`wg quick up wg0`

With plugin:

`wg-quick up`

No Interface name is needed cause the plugin will handle it with the credential


## Changelog
Enable secure authentication for wg-quick using 1Password Shell Plugins, ensuring proper initialization with default credentials via op plugin init and support for importing credentials from the specified standard wireguard config file e.g. "/etc/wireguard/wg0.conf"


