### PR TITLE
Add sqitch plugin

### DIFF
--- a/plugins/sqitch/database_credentials.go
+++ b/plugins/sqitch/database_credentials.go
@@ -1,0 +1,31 @@
+package sqitch
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func DatabaseCredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.DatabaseCredentials,
+		DocsURL:       sdk.URL("https://sqitch.org/docs/manual/sqitch-authentication/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password used to authenticate to the target database.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SQITCH_PASSWORD": fieldname.Password,
+}

--- a/plugins/sqitch/database_credentials_test.go
+++ b/plugins/sqitch/database_credentials_test.go
@@ -1,0 +1,41 @@
+package sqitch
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestDatabaseCredentialsProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, DatabaseCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Password: "nBI8u8aF10TvQFfBlMedCDuEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SQITCH_PASSWORD": "nBI8u8aF10TvQFfBlMedCDuEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestDatabaseCredentialsImporter(t *testing.T) {
+	plugintest.TestImporter(t, DatabaseCredentials().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"SQITCH_PASSWORD": "nBI8u8aF10TvQFfBlMedCDuEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Password: "nBI8u8aF10TvQFfBlMedCDuEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/sqitch/plugin.go
+++ b/plugins/sqitch/plugin.go
@@ -1,0 +1,22 @@
+package sqitch
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "sqitch",
+		Platform: schema.PlatformInfo{
+			Name:     "Sqitch",
+			Homepage: sdk.URL("https://sqitch.org"),
+		},
+		Credentials: []schema.CredentialType{
+			DatabaseCredentials(),
+		},
+		Executables: []schema.Executable{
+			Sqitch(),
+		},
+	}
+}

--- a/plugins/sqitch/sqitch.go
+++ b/plugins/sqitch/sqitch.go
@@ -1,0 +1,25 @@
+package sqitch
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func Sqitch() schema.Executable {
+	return schema.Executable{
+		Name:      "Sqitch",
+		Runs:      []string{"sqitch"},
+		DocsURL:   sdk.URL("https://sqitch.org/docs/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Adds a new `sqitch` plugin, for the [Sqitch](https://sqitch.org/) database change management tool, to authenticate a target database with a password.

_Note that this just targets adding a username/password to the environment, and other connection details are left to the `sqitch.conf` file, or to CLI flags. This is because Sqitch supports multiple database engines, and the only cross-engine authentication details that you can provide are the `$SQUITCH_PASSWORD` and `$SQITCH_USERNAME` vars. See [the `sqitch-authentication` docs](https://sqitch.org/docs/manual/sqitch-authentication/) for more detail._ 

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Install Sqitch using appropriate instructions for your platform: https://sqitch.org/download/

Set up (or just have access to) a Postgres database. The database should have a user that requires a password to login (i.e. not locally authenticated). 

_You could also do this for [any of the other DB types supported by Sqitch](https://sqitch.org/docs/manual/sqitch-engine/), but the below instructions assume you're using Postgres._

Create a new working directory and initialise Sqitch:
```sh
mkdir sqitch && cd sqitch
sqitch init my_project --engine pg
```
Your `./sqitch` directory should look as follows:
```
.
├── deploy/
├── revert/
├── verify/
├── sqitch.conf
└── sqitch.plan
```

Edit `sqitch.conf` as follows (substituting `<username>`, `<hostname>` and `<database>` for values from your Postgres database connection):

```apacheconf
[core]
	engine = pg
[engine "pg"]
	target = test
[target "test"]
	uri = db:pg://<username>@<hostname>/<database>
```

Run `sqitch status`. You should be prompted to find the database password in 1Password. After authentication, you should see the following output:

```
# On database test
No changes deployed
```

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Authenticate a database target in the Sqitch database change management tool, using Touch ID and other unlock options with 1Password Shell Plugins.


