### PR TITLE
Add NPM plugin

### DIFF
--- a/plugins/npm/access_token.go
+++ b/plugins/npm/access_token.go
@@ -68,6 +68,8 @@ func configFile(in sdk.ProvisionInput) ([]byte, error) {
 	}
 	if host, ok := in.ItemFields[fieldname.Host]; ok && host != "" {
 		contents += "//" + strings.Trim(host, "/") + "/:"
+	} else {
+		contents += "//registry.npmjs.org/:"
 	}
 
 	contents += "_authToken="

--- a/plugins/npm/access_token.go
+++ b/plugins/npm/access_token.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"path/filepath"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -12,7 +14,6 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 	"gopkg.in/ini.v1"
-	"path/filepath"
 )
 
 func AccessToken() schema.CredentialType {
@@ -35,8 +36,23 @@ func AccessToken() schema.CredentialType {
 					},
 				},
 			},
+			{
+				Name:                fieldname.Organization,
+				MarkdownDescription: "The organization the access token is scoped for.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "The registry host for the npm packages.",
+				Optional:            true,
+			},
 		},
-		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		DefaultProvisioner: provision.TempFile(configFile,
+			provision.Filename(".npmrc"),
+			provision.AddArgs(
+				"--userconfig", "{{ .Path }}",
+			),
+		),
 		Importer: importer.TryAll(
 			TryNPMConfigFile(""),
 			TryGlobalNPMConfigFile("NPM_CONFIG_USERCONFIG", "~"),
@@ -44,8 +60,23 @@ func AccessToken() schema.CredentialType {
 	}
 }
 
-var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"NPM_CONFIG_//registry.npmjs.org/:_authToken": fieldname.Token,
+func configFile(in sdk.ProvisionInput) ([]byte, error) {
+	contents := ""
+
+	if org, ok := in.ItemFields[fieldname.Organization]; ok && org != "" {
+		contents += "@" + strings.Trim(org, "@") + ":"
+	}
+	if host, ok := in.ItemFields[fieldname.Host]; ok && host != "" {
+		contents += "//" + strings.Trim(host, "/") + "/:"
+	}
+
+	contents += "_authToken="
+
+	if token, ok := in.ItemFields[fieldname.Token]; ok {
+		contents += token
+	}
+
+	return []byte(contents), nil
 }
 
 func TryGlobalNPMConfigFile(env string, defaultPath string) sdk.Importer {
@@ -74,10 +105,27 @@ func TryNPMConfigFile(path string) sdk.Importer {
 		for _, key := range section.Keys() {
 			if strings.Contains(key.Name(), "_authToken") {
 
+				keyParts := strings.Split(key.Name(), ":")
+
+				registry := ""
+				scope := ""
+				hint := ""
+				if len(keyParts) == 2 {
+					registry = strings.Trim(keyParts[0], "/")
+					hint = registry
+				} else if len(keyParts) == 3 {
+					registry = strings.Trim(keyParts[1], "/")
+					scope = strings.Trim(keyParts[0], "@")
+					hint = "@" + scope + ":" + registry
+				}
+
 				out.AddCandidate(sdk.ImportCandidate{
 					Fields: map[sdk.FieldName]string{
-						fieldname.Token: key.Value(),
+						fieldname.Token:        key.Value(),
+						fieldname.Host:         registry,
+						fieldname.Organization: scope,
 					},
+					NameHint: importer.SanitizeNameHint(hint),
 				})
 			}
 		}

--- a/plugins/npm/access_token.go
+++ b/plugins/npm/access_token.go
@@ -1,0 +1,68 @@
+package npm
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://docs.npmjs.com/creating-and-viewing-access-tokens"),
+		ManagementURL: sdk.URL("https://www.npmjs.com/settings/<username>/tokens/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to NPM.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 36,
+					Prefix: "npm_",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"NPM_CONFIG_//registry.npmjs.org/:_authToken": fieldname.Token,
+}
+
+// TODO: Check if the platform stores the Access Token in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryNPMConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.Token == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.Token: config.Token,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	Token string
+// }

--- a/plugins/npm/access_token_test.go
+++ b/plugins/npm/access_token_test.go
@@ -1,0 +1,55 @@
+package npm
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NPM_TOKEN": "npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"NPM_TOKEN": "npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in npm/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/npm/npm.go
+++ b/plugins/npm/npm.go
@@ -1,0 +1,20 @@
+package npm
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func NPMCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "NPM CLI",
+		Runs:    []string{"npm"},
+		DocsURL: sdk.URL("https://docs.npmjs.com/cli"),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/plugins/npm/npm.go
+++ b/plugins/npm/npm.go
@@ -2,6 +2,7 @@ package npm
 
 import (
 	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
 	"github.com/1Password/shell-plugins/sdk/schema"
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
@@ -11,6 +12,30 @@ func NPMCLI() schema.Executable {
 		Name:    "NPM CLI",
 		Runs:    []string{"npm"},
 		DocsURL: sdk.URL("https://docs.npmjs.com/cli"),
+		NeedsAuth: needsauth.IfAll(
+			// not a complete list of commands that don't
+			// need auth, but probably the main ones
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWhenContainsArgs("init"),
+			needsauth.NotWhenContainsArgs("?"),
+			needsauth.NotWhenContainsArgs("config"),
+			needsauth.NotWhenContainsArgs("help-search"),
+			needsauth.NotWhenContainsArgs("login"),
+			needsauth.NotWhenContainsArgs("logout"),
+			needsauth.NotWhenContainsArgs("prune"),
+			needsauth.NotWhenContainsArgs("shrinkwrap"),
+			needsauth.NotWhenContainsArgs("start"),
+			needsauth.NotWhenContainsArgs("run-script"),
+			needsauth.NotWhenContainsArgs("run"),
+			needsauth.NotWhenContainsArgs("rum"),
+			needsauth.NotWhenContainsArgs("urn"),
+			needsauth.NotWhenContainsArgs("uninstall"),
+			needsauth.NotWhenContainsArgs("unlink"),
+			needsauth.NotWhenContainsArgs("remove"),
+			needsauth.NotWhenContainsArgs("rm"),
+			needsauth.NotWhenContainsArgs("r"),
+			needsauth.NotWhenContainsArgs("un"),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.AccessToken,

--- a/plugins/npm/plugin.go
+++ b/plugins/npm/plugin.go
@@ -1,0 +1,22 @@
+package npm
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "npm",
+		Platform: schema.PlatformInfo{
+			Name:     "NPM",
+			Homepage: sdk.URL("https://npmjs.com"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			NPMCLI(),
+		},
+	}
+}

--- a/plugins/npm/test-fixtures/.npmrc-custom-registry
+++ b/plugins/npm/test-fixtures/.npmrc-custom-registry
@@ -1,0 +1,1 @@
+//my.registry.com/:_authToken=npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE

--- a/plugins/npm/test-fixtures/.npmrc-default-registry
+++ b/plugins/npm/test-fixtures/.npmrc-default-registry
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE

--- a/plugins/npm/test-fixtures/.npmrc-scoped
+++ b/plugins/npm/test-fixtures/.npmrc-scoped
@@ -1,0 +1,1 @@
+@op://my.registry.com/:_authToken=npm_4F1h0xp0lBn0XvZ4RGfpnpoawECBMEXAMPLE


### PR DESCRIPTION
## Overview
This is a second attempt at creating an NPM plugin, following https://github.com/1Password/shell-plugins/pull/168. 

Currently, this plugin supports:
- Importing existing project and user config files
- Multiple registries and scopes

It does not yet support:
- MFA
- importing global and builtin config files

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
- `npm login` to generate an `.npmrc` file if you don't have an existing one
- init the plugin
- remove your `.npmrc` file from your home folder
- `npm whoami`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the NPM CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Authenticate the NPM CLI using Touch ID and other unlock options with 1Password Shell Plugins.
