### PR TITLE
plugins/aiven: add plugin for aiven-client

### DIFF
--- a/plugins/aiven/access_token.go
+++ b/plugins/aiven/access_token.go
@@ -1,0 +1,86 @@
+package aiven
+
+import (
+	"context"
+	"os"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://docs.aiven.io/docs/tools/cli"),
+		ManagementURL: sdk.URL("https://console.aiven.io/profile/tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.AccessToken,
+				MarkdownDescription: "Token used to authenticate to Aiven.io.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 392,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   false,
+						Specific:  []rune{43, 47, 61}, // "+", "/" and "="
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryAivenCredentialsFileFromEnv(),
+			TryAivenCredentialsFile(),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"AIVEN_AUTH_TOKEN": fieldname.AccessToken, // https://github.com/aiven/aiven-client/blob/02765178014d5d9ded0eeec6e234606dab9f2c60/aiven/client/envdefault.py#L15
+}
+
+func TryAivenCredentialsFile() sdk.Importer {
+	// aiven-credentials.json is written to ~/.config/aiven/ on Linux and OSX
+	// https://github.com/aiven/aiven-client/tree/main?tab=readme-ov-file#authenticate-logins-and-tokens
+	return tryFromCredentialsFile("~/.config/aiven/aiven-credentials.json")
+}
+func TryAivenCredentialsFileFromEnv() sdk.Importer {
+	// or can be loaded from env.AIVEN_CREDENTIALS_FILE
+	// we don't have to check if the path is valid here, or that the env actually returned
+	// a value. The tryFromCredendialsFile will do validation of path etc
+	credentialsPath := os.Getenv("AIVEN_CREDENTIALS_FILE")
+	return tryFromCredentialsFile(credentialsPath)
+}
+
+func tryFromCredentialsFile(filePath string) sdk.Importer {
+	return importer.TryFile(filePath, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config AivenCredentialsConfig
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.AuthToken == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.AccessToken: config.AuthToken,
+			},
+		})
+	})
+}
+
+type AivenCredentialsConfig struct {
+	AuthToken string `json:"auth_token"`
+	UserEmail string `json:"user_email"`
+}

--- a/plugins/aiven/access_token_test.go
+++ b/plugins/aiven/access_token_test.go
@@ -1,0 +1,53 @@
+package aiven
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.AccessToken: "/TKopDBC2nHPi1TTa4kMakmTC3m+bHoC2UIUOvEjUTJeC/WxjnpsCqlrmR8VXgSx/hJUUQ8jnd+6gylz8RtnUYovkiiDq9pP/y54SNmqa1AMvR1AnYXevuvUWupZBDujRYkjyQvdu+QsUPtGOppmKc7ymZa1otRqGlFdVu5jhh3/7j8RcxsM4z0WdUSCRnBt3lL3nNRQE5diRE8xbkWBfUCZu1kY6XSzDQcrTko6AvkLY3wdvbfLfENL/l2pp6WmNVsftW5XjxihjL1O+9Klg1wuYxko40CcseL8W3up7HcCSVtgVZSMHjF9LQMLcmd0U9CVpngGY/fcM89MO0Wz4BzNXDyhhxx4ox+LdgriSm13p0o5hF6pVwSFRHxlVEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"AIVEN_AUTH_TOKEN": "/TKopDBC2nHPi1TTa4kMakmTC3m+bHoC2UIUOvEjUTJeC/WxjnpsCqlrmR8VXgSx/hJUUQ8jnd+6gylz8RtnUYovkiiDq9pP/y54SNmqa1AMvR1AnYXevuvUWupZBDujRYkjyQvdu+QsUPtGOppmKc7ymZa1otRqGlFdVu5jhh3/7j8RcxsM4z0WdUSCRnBt3lL3nNRQE5diRE8xbkWBfUCZu1kY6XSzDQcrTko6AvkLY3wdvbfLfENL/l2pp6WmNVsftW5XjxihjL1O+9Klg1wuYxko40CcseL8W3up7HcCSVtgVZSMHjF9LQMLcmd0U9CVpngGY/fcM89MO0Wz4BzNXDyhhxx4ox+LdgriSm13p0o5hF6pVwSFRHxlVEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"AIVEN_AUTH_TOKEN": "/TKopDBC2nHPi1TTa4kMakmTC3m+bHoC2UIUOvEjUTJeC/WxjnpsCqlrmR8VXgSx/hJUUQ8jnd+6gylz8RtnUYovkiiDq9pP/y54SNmqa1AMvR1AnYXevuvUWupZBDujRYkjyQvdu+QsUPtGOppmKc7ymZa1otRqGlFdVu5jhh3/7j8RcxsM4z0WdUSCRnBt3lL3nNRQE5diRE8xbkWBfUCZu1kY6XSzDQcrTko6AvkLY3wdvbfLfENL/l2pp6WmNVsftW5XjxihjL1O+9Klg1wuYxko40CcseL8W3up7HcCSVtgVZSMHjF9LQMLcmd0U9CVpngGY/fcM89MO0Wz4BzNXDyhhxx4ox+LdgriSm13p0o5hF6pVwSFRHxlVEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.AccessToken: "/TKopDBC2nHPi1TTa4kMakmTC3m+bHoC2UIUOvEjUTJeC/WxjnpsCqlrmR8VXgSx/hJUUQ8jnd+6gylz8RtnUYovkiiDq9pP/y54SNmqa1AMvR1AnYXevuvUWupZBDujRYkjyQvdu+QsUPtGOppmKc7ymZa1otRqGlFdVu5jhh3/7j8RcxsM4z0WdUSCRnBt3lL3nNRQE5diRE8xbkWBfUCZu1kY6XSzDQcrTko6AvkLY3wdvbfLfENL/l2pp6WmNVsftW5XjxihjL1O+9Klg1wuYxko40CcseL8W3up7HcCSVtgVZSMHjF9LQMLcmd0U9CVpngGY/fcM89MO0Wz4BzNXDyhhxx4ox+LdgriSm13p0o5hF6pVwSFRHxlVEXAMPLE",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files: map[string]string{
+				"~/.config/aiven/aiven-credentials.json": plugintest.LoadFixture(t, "aiven-credentials.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.AccessToken: "/EXAMPLE/WxjnpsCqlrmR8VXgSx/hJUUQ8jnd+6gylz8RtnUYovkiiDhh3/7j8RcxsM4z0WdUSCRnBt3lL3nNRQE5diRE8xbkWBfUCZu1kY6XSzDQcrTko6AvkLY3wdvbfLfENL/l2pp6WmNVsftW5XjxihjL1O+9Klg1wuYxko40CcseL8W3up7EXAMPLE=",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/aiven/avn.go
+++ b/plugins/aiven/avn.go
@@ -1,0 +1,26 @@
+package aiven
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func AivenCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "aiven-client",
+		Runs:    []string{"avn"},
+		DocsURL: sdk.URL("https://docs.aiven.io/docs/tools/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("user", "login"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/plugins/aiven/plugin.go
+++ b/plugins/aiven/plugin.go
@@ -1,0 +1,22 @@
+package aiven
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "aiven",
+		Platform: schema.PlatformInfo{
+			Name:     "Aiven.io",
+			Homepage: sdk.URL("https://aiven.io"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			AivenCLI(),
+		},
+	}
+}

--- a/plugins/aiven/test-fixtures/aiven-credentials.json
+++ b/plugins/aiven/test-fixtures/aiven-credentials.json
@@ -1,0 +1,4 @@
+{
+    "auth_token": "/EXAMPLE/WxjnpsCqlrmR8VXgSx/hJUUQ8jnd+6gylz8RtnUYovkiiDhh3/7j8RcxsM4z0WdUSCRnBt3lL3nNRQE5diRE8xbkWBfUCZu1kY6XSzDQcrTko6AvkLY3wdvbfLfENL/l2pp6WmNVsftW5XjxihjL1O+9Klg1wuYxko40CcseL8W3up7EXAMPLE=",
+    "user_email": "first.last@aiven.io"
+}


### PR DESCRIPTION
## Overview
Adds support for the [aiven-client](https://github.com/aiven/aiven-client/tree/main) (avn) for https://aiven.io


## Type of change
- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

## How To Test

* `avn user login` to generate an `~/.config/aiven/aiven-credentials.json` file if you don't have an existing one
* `avn user info`
* init the plugin
* remove `~/.config/aiven/aiven-credentials.json`
* `avn user info`
    * compare and see that the user info is the same as before using the plugin

## Changelog
Authenticate the Aiven-Client CLI using Touch ID and other unlock options with 1Password Shell Plugins.



