### PR TITLE
Initial Commit for SSH Plugin

### DIFF
--- a/plugins/ssh/plugin.go
+++ b/plugins/ssh/plugin.go
@@ -1,0 +1,22 @@
+package ssh
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "ssh",
+		Platform: schema.PlatformInfo{
+			Name:     "SSH",
+			Homepage: sdk.URL("https://www.openssh.com"),
+		},
+		Credentials: []schema.CredentialType{
+			UserLogin(),
+		},
+		Executables: []schema.Executable{
+			SSHCLI(),
+		},
+	}
+}

--- a/plugins/ssh/sshpass.go
+++ b/plugins/ssh/sshpass.go
@@ -1,0 +1,24 @@
+package ssh
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func SSHCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "SSH CLI",
+		Runs:    []string{"sshpass"},
+		DocsURL: sdk.URL("https://linux.die.net/man/1/sshpass"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.UserLogin,
+			},
+		},
+	}
+}

--- a/plugins/ssh/user_login.go
+++ b/plugins/ssh/user_login.go
@@ -1,0 +1,51 @@
+package ssh
+
+import (
+	"context"
+	"github.com/1Password/shell-plugins/sdk/importer"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func UserLogin() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.UserLogin,
+		DocsURL: sdk.URL("https://linux.die.net/man/1/sshpass"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Host,
+				AlternativeNames:    []string{fieldname.HostAddress.String(), fieldname.URL.String()},
+				MarkdownDescription: "SSH Host to connect to.",
+			},
+			{
+				Name:                fieldname.Username,
+				MarkdownDescription: "User to authenticate as.",
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password used to authenticate.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: sshProvisioner{},
+		Importer:           importer.NoOp(),
+	}
+}
+
+type sshProvisioner struct{}
+
+func (s sshProvisioner) Description() string {
+	return "SSH password provisioner"
+}
+
+func (s sshProvisioner) Provision(_ context.Context, input sdk.ProvisionInput, output *sdk.ProvisionOutput) {
+	output.AddArgs("-p", input.ItemFields[fieldname.Password],
+		"ssh", input.ItemFields[fieldname.Username]+"@"+input.ItemFields[fieldname.Host])
+}
+
+func (s sshProvisioner) Deprovision(_ context.Context, _ sdk.DeprovisionInput, _ *sdk.DeprovisionOutput) {
+	// no-op
+}

--- a/plugins/ssh/user_login_test.go
+++ b/plugins/ssh/user_login_test.go
@@ -1,0 +1,24 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestUserLoginProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, UserLogin().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Password: "zhexample",
+				fieldname.Username: "user",
+				fieldname.Host:     "192.168.1.20",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"-p", "zhexample", "ssh", "user@192.168.1.20"},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Create a plugin to fetch Passwords from 1Password in password-based SSH Authentication   



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #348
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Created a new Plugin for SSH password-based Authentication.
