### PR TITLE
New plugin for CVE Services API

### DIFF
--- a/plugins/cvelib/api_key.go
+++ b/plugins/cvelib/api_key.go
@@ -1,0 +1,49 @@
+package cvelib
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://github.com/RedHatProductSecurity/cvelib"),
+		ManagementURL: sdk.URL("https://vulnogram.github.io/cve5/#cvePortal"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.User,
+				MarkdownDescription: "User to authenticate to CVE Services API (CVE user).",
+			},
+			{
+				Name:                fieldname.Organization,
+				MarkdownDescription: "Organization to authenticate to CVE Services API (CNA short name).",
+			},
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to CVE Services API (CNA API key).",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 36,
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"CVE_USER": fieldname.User,
+	"CVE_ORG": fieldname.Organization,
+	"CVE_API_KEY": fieldname.APIKey,
+}

--- a/plugins/cvelib/cve.go
+++ b/plugins/cvelib/cve.go
@@ -1,0 +1,25 @@
+package cvelib
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func CVEServicesAPICLI() schema.Executable {
+	return schema.Executable{
+		Name:      "CVE Services API CLI",
+		Runs:      []string{"cve"},
+		DocsURL:   sdk.URL("https://github.com/RedHatProductSecurity/cvelib"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/cvelib/plugin.go
+++ b/plugins/cvelib/plugin.go
@@ -1,0 +1,22 @@
+package cvelib
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "cvelib",
+		Platform: schema.PlatformInfo{
+			Name:     "CVE Services",
+			Homepage: sdk.URL("https://www.cve.org/AllResources/CveServices"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			CVEServicesAPICLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
The CVE Services API allows CVE Numbering Authorities (CNAs) to reserve, publish, and manage CVE IDs.  This plugin sets the environment variables required to use the reference cvelib implementation of the API.

See also:
https://www.cve.org/AllResources/CveServices
https://github.com/RedHatProductSecurity/cvelib
https://vulnogram.github.io/cve5/#cvePortal

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
The CVE Services API can only be used by CNAs.  Assuming you are a CNA (or a CNA can provide you with a test user), you can test authentication with `cve ping`.


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

New CLI plugin for the CVE Services API.