### PR TITLE
Create Azure CLI plugin

### DIFF
--- a/plugins/azure/az.go
+++ b/plugins/azure/az.go
@@ -1,0 +1,26 @@
+package azure
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func AzureCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Azure CLI",
+		Runs:    []string{"az"},
+		DocsURL: sdk.URL("https://learn.microsoft.com/en-us/cli/azure/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name:        credname.ServicePrincipal,
+				Provisioner: CLIProvisioner{},
+			},
+		},
+	}
+}

--- a/plugins/azure/cli_provisioner.go
+++ b/plugins/azure/cli_provisioner.go
@@ -1,0 +1,55 @@
+package azure
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+type CLIProvisioner struct {
+}
+
+func (p CLIProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	args := []string{
+		"login", "--service-principal",
+		"--user", in.ItemFields[fieldname.ClientID],
+		"--password", in.ItemFields[fieldname.ClientSecret],
+	}
+
+	if tid, ok := in.ItemFields[fieldname.TenantID]; ok {
+		args = append(args, []string{"--tenant", tid}...)
+	}
+
+	cmd := exec.Command("az", args...)
+	err := cmd.Run()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (p CLIProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	cmd := exec.Command("az", "logout")
+	err := cmd.Run()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (p CLIProvisioner) Description() string {
+	return "Log into Azure using a service principal"
+}
+
+func ExecuteSilently[input interface{}, output interface{}, e error](f func(input) (output, e)) func(input) (output, e) {
+	return func(i input) (output, e) {
+		log.SetOutput(io.Discard)
+		defer log.SetOutput(os.Stderr)
+		return f(i)
+	}
+}

--- a/plugins/azure/plugin.go
+++ b/plugins/azure/plugin.go
@@ -1,0 +1,22 @@
+package azure
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "azure",
+		Platform: schema.PlatformInfo{
+			Name:     "Azure",
+			Homepage: sdk.URL("https://azure.com"),
+		},
+		Credentials: []schema.CredentialType{
+			ServicePrincipal(),
+		},
+		Executables: []schema.Executable{
+			AzureCLI(),
+		},
+	}
+}

--- a/plugins/azure/service_principal.go
+++ b/plugins/azure/service_principal.go
@@ -1,0 +1,72 @@
+package azure
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func ServicePrincipal() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.ServicePrincipal,
+		DocsURL:       sdk.URL("https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-service-principal"),
+		ManagementURL: sdk.URL("https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.ClientID,
+				MarkdownDescription: "Application (client) ID of the service principal.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Length: 36,
+					Charset: schema.Charset{
+						// Client IDs are lowercased UUIDs.
+						Lowercase: true,
+						Digits:    true,
+						Specific:  []rune{'-'},
+					},
+				},
+			},
+			{
+				Name:                fieldname.ClientSecret,
+				MarkdownDescription: "Secret created for the service principal.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 40,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.TenantID,
+				MarkdownDescription: "Tenant ID which will be authenticated to.",
+				Secret:              false,
+				Optional:            true,
+				Composition: &schema.ValueComposition{
+					Length: 36,
+					Charset: schema.Charset{
+						// Tenant IDs are lowercased UUIDs.
+						Lowercase: true,
+						Digits:    true,
+						Specific:  []rune{'-'},
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"AZURE_CLIENT_ID":     fieldname.ClientID,
+	"AZURE_CLIENT_SECRET": fieldname.ClientSecret,
+	"AZURE_TENANT_ID":     fieldname.TenantID,
+}

--- a/plugins/azure/service_principal_test.go
+++ b/plugins/azure/service_principal_test.go
@@ -1,0 +1,49 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestServicePrincipalProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, ServicePrincipal().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.ClientID:     "6a768b1b-8eee-40e9-81b9-c0bca485f33e",
+				fieldname.ClientSecret: "T.L8Q~IhftYnbzhuCADzkfIRZ9p8e5kiyjSR4cjb",
+				fieldname.TenantID:     "83f25d69-e104-45ba-8939-4d9103b03b3c",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"AZURE_CLIENT_ID":     "6a768b1b-8eee-40e9-81b9-c0bca485f33e",
+					"AZURE_CLIENT_SECRET": "T.L8Q~IhftYnbzhuCADzkfIRZ9p8e5kiyjSR4cjb",
+					"AZURE_TENANT_ID":     "83f25d69-e104-45ba-8939-4d9103b03b3c",
+				},
+			},
+		},
+	})
+}
+
+func TestServicePrincipalImporter(t *testing.T) {
+	plugintest.TestImporter(t, ServicePrincipal().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"AZURE_CLIENT_ID":     "f3593130-88fe-4f93-95c5-1c62d2d56a36",
+				"AZURE_CLIENT_SECRET": "51U8Q~tqPdbkcxgYChTSie9br1_gIgHh2ZeWKcHX",
+				"AZURE_TENANT_ID":     "a16c4485-bc84-41a3-90f4-b00498389c06",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.ClientID:     "f3593130-88fe-4f93-95c5-1c62d2d56a36",
+						fieldname.ClientSecret: "51U8Q~tqPdbkcxgYChTSie9br1_gIgHh2ZeWKcHX",
+						fieldname.TenantID:     "a16c4485-bc84-41a3-90f4-b00498389c06",
+					},
+				},
+			},
+		},
+	})
+}

--- a/sdk/schema/credname/names.go
+++ b/sdk/schema/credname/names.go
@@ -22,6 +22,7 @@ const (
 	PersonalAccessToken  = sdk.CredentialName("Personal Access Token")
 	RegistryCredentials  = sdk.CredentialName("Registry Credentials")
 	SecretKey            = sdk.CredentialName("Secret Key")
+	ServicePrincipal     = sdk.CredentialName("Service Principal")
 	UserLogin            = sdk.CredentialName("User Login")
 )
 
@@ -45,6 +46,7 @@ func ListAll() []sdk.CredentialName {
 		PersonalAccessToken,
 		RegistryCredentials,
 		SecretKey,
+		ServicePrincipal,
 		UserLogin,
 	}
 }

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -22,6 +22,7 @@ const (
 	Authtoken       = sdk.FieldName("Authtoken")
 	Cert            = sdk.FieldName("Cert")
 	Certificate     = sdk.FieldName("Certificate")
+	ClientID        = sdk.FieldName("Client ID")
 	ClientSecret    = sdk.FieldName("Client Secret")
 	ClientToken     = sdk.FieldName("Client Token")
 	Credential      = sdk.FieldName("Credential")
@@ -51,6 +52,7 @@ const (
 	Secret          = sdk.FieldName("Secret")
 	SecretAccessKey = sdk.FieldName("Secret Access Key")
 	Subdomain       = sdk.FieldName("Subdomain")
+	TenantID        = sdk.FieldName("Tenant ID")
 	Token           = sdk.FieldName("Token")
 	URL             = sdk.FieldName("URL")
 	User            = sdk.FieldName("User")
@@ -78,6 +80,7 @@ func ListAll() []sdk.FieldName {
 		Authtoken,
 		Cert,
 		Certificate,
+		ClientID,
 		ClientSecret,
 		ClientToken,
 		Credential,
@@ -105,6 +108,7 @@ func ListAll() []sdk.FieldName {
 		Region,
 		Secret,
 		SecretAccessKey,
+		TenantID,
 		Token,
 		URL,
 		User,


### PR DESCRIPTION
## Overview
Create a new plugin for Azure CLI.

Sadly the az cli doesn't support environment variables for login, so this plugin runs `az login` and `az logout` to resolve this issue.

The plugin uses an [Entra ID Service Principal](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-service-principal) for authentication which needs to be created and granted permissions to the Azure subscription(s).

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

None

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

`az group list`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Authenticate the Azure CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The Azure plugin can be correctly initialized with a default credential, using `op plugin az init`.
The Azure plugin will check for the `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID` environment variables and attempts to import credentials from them.
