### PR TITLE
Feat: Add redli CLI plugin

### DIFF
--- a/plugins/redli/database_credentials.go
+++ b/plugins/redli/database_credentials.go
@@ -1,0 +1,141 @@
+package redli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+const (
+	fnUri      = sdk.FieldName("Uri")
+	fnProtocol = sdk.FieldName("Protocol")
+	fnHost     = sdk.FieldName("Server")
+	fnPort     = sdk.FieldName("Port")
+	fnUsername = sdk.FieldName("Username")
+	fnPassword = sdk.FieldName("Password")
+	fnDb       = sdk.FieldName("Database")
+)
+
+func DatabaseCredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name: credname.DatabaseCredentials,
+		Fields: []schema.CredentialField{
+			{
+				Name:                fnUri,
+				MarkdownDescription: "URI to connect to host",
+				Secret:              true,
+				Optional:            true,
+			},
+			{
+				Name:                fnProtocol,
+				MarkdownDescription: "Protocol to use when connecting",
+				Secret:              false,
+				Optional:            true,
+			},
+			{
+				Name:                fnHost,
+				MarkdownDescription: "Host to connect to",
+				Secret:              false,
+				Optional:            true,
+			},
+			{
+				Name:                fnPort,
+				MarkdownDescription: "Port to connect to",
+				Secret:              false,
+				Optional:            true,
+			},
+			{
+				Name:                fnDb,
+				MarkdownDescription: "DB to connect to",
+				Secret:              false,
+				Optional:            true,
+			},
+			{
+				Name:                fnUsername,
+				MarkdownDescription: "Username to use when connecting to host",
+				Secret:              true,
+				Optional:            true,
+			},
+			{
+				Name:                fnPassword,
+				MarkdownDescription: "Password to use when connecting to host",
+				Secret:              true,
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: commandLineProvisioner{},
+	}
+}
+
+type commandLineProvisioner struct{}
+
+func (p commandLineProvisioner) Description() string {
+	return ""
+}
+
+func (p commandLineProvisioner) Provision(ctx context.Context, input sdk.ProvisionInput, output *sdk.ProvisionOutput) {
+	foundArgs := make(map[string]bool)
+	for _, arg := range output.CommandLine {
+		if strings.HasPrefix(arg, "-") {
+			foundArgs[arg] = true
+		}
+	}
+
+	if foundArgs["-u"] {
+		return
+	}
+
+	if uri, ok := input.ItemFields[fnUri]; ok {
+		output.AddArgs("-u", uri)
+		return
+	}
+
+	var (
+		protocol = input.ItemFields[fnProtocol]
+		host     = input.ItemFields[fnHost]
+		port     = input.ItemFields[fnPort]
+		username = input.ItemFields[fnUsername]
+		password = input.ItemFields[fnPassword]
+		db       = input.ItemFields[fnDb]
+	)
+
+	if _, ok := foundArgs["-h"]; !ok {
+		if _, ok := foundArgs["--host"]; !ok {
+			output.AddArgs("-h", host)
+		}
+	}
+
+	if _, ok := foundArgs["-p"]; !ok {
+		if _, ok := foundArgs["--port"]; !ok {
+			output.AddArgs("-p", port)
+		}
+	}
+
+	if _, ok := foundArgs["-r"]; !ok {
+		if _, ok := foundArgs["--redisuser"]; !ok {
+			output.AddArgs("-r", username)
+		}
+	}
+
+	if _, ok := foundArgs["-a"]; !ok {
+		if _, ok := foundArgs["--auth"]; !ok {
+			output.AddArgs("-a", password)
+		}
+	}
+
+	if _, ok := foundArgs["--tls"]; !ok {
+		if protocol == "rediss" {
+			output.AddArgs("--tls")
+		}
+	}
+
+	if _, ok := foundArgs["-n"]; !ok {
+		output.AddArgs("-n", db)
+	}
+}
+
+func (p commandLineProvisioner) Deprovision(ctx context.Context, input sdk.DeprovisionInput, output *sdk.DeprovisionOutput) {
+}

--- a/plugins/redli/database_credentials_test.go
+++ b/plugins/redli/database_credentials_test.go
@@ -1,0 +1,70 @@
+package redli
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+)
+
+func TestDatabaseCredentialsProvisioner(t *testing.T) {
+	const (
+		insecureProtocol = "redis"
+		secureProtocol   = "rediss"
+		host             = "Host"
+		port             = "Port"
+		username         = "Username"
+		password         = "Password"
+		db               = "Db"
+		uri              = username + ":" + password + "@" + host + ":" + port
+	)
+	plugintest.TestProvisioner(t, DatabaseCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"using uri": {
+			ItemFields: map[sdk.FieldName]string{
+				fnUri: uri,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"-u", uri},
+			},
+		},
+		"using args (secure)": {
+			ItemFields: map[sdk.FieldName]string{
+				fnProtocol: secureProtocol,
+				fnHost:     host,
+				fnPort:     port,
+				fnUsername: username,
+				fnPassword: password,
+				fnDb:       db,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{
+					"-h", host,
+					"-p", port,
+					"-r", username,
+					"-a", password,
+					"--tls",
+					"-n", db,
+				},
+			},
+		},
+		"using args (not secure)": {
+			ItemFields: map[sdk.FieldName]string{
+				fnProtocol: insecureProtocol,
+				fnHost:     host,
+				fnPort:     port,
+				fnUsername: username,
+				fnPassword: password,
+				fnDb:       db,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{
+					"-h", host,
+					"-p", port,
+					"-r", username,
+					"-a", password,
+					"-n", db,
+				},
+			},
+		},
+	})
+}

--- a/plugins/redli/plugin.go
+++ b/plugins/redli/plugin.go
@@ -1,0 +1,22 @@
+package redli
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "redli",
+		Platform: schema.PlatformInfo{
+			Name:     "Redli",
+			Homepage: sdk.URL("https://github.com/IBM-Cloud/redli"),
+		},
+		Credentials: []schema.CredentialType{
+			DatabaseCredentials(),
+		},
+		Executables: []schema.Executable{
+			RedliCLI(),
+		},
+	}
+}

--- a/plugins/redli/redli.go
+++ b/plugins/redli/redli.go
@@ -1,0 +1,24 @@
+package redli
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func RedliCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Redli CLI",
+		Runs:    []string{"redli"},
+		DocsURL: sdk.URL("https://github.com/IBM-Cloud/redli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview
Added support for Redis CLI tool [redli](https://github.com/IBM-Cloud/redli) by IBM

## Type of change
- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
1. Prepare a Redis instance (Only one required)
  a. Via docker: `docker run --rm -it --name=redis -p 6379:6379 redis`
  b. Via system installation: `redis-server`
  c. Via a 3rd party service like [Upstash](https://upstash.com/)
2. Create new Database item in 1Password
  a. Set type to `Redis` (Optional)
  b. Save connection information (Only one required)
    1. Add a `uri` field containing the connection string in the following format `redis://[<USERNAME>[:<PASSWORD>]]@<HOST>[:<PORT>]`
    2. Add `server`, `port`, `database`(if unknown leave at 0), `username`(Optional), `password`(Optional) and `protocol`(`rediss` for secure connections, `redis` for non-secure connections)
3. Install `redli`
  a. Instructions available here: https://github.com/IBM-Cloud/redli
4. Configure the plugin: `op plugin init -- redli`
5. Validate connection works by running `redli` via the 1Password plugin

## Changelog
- Added support for Redis CLI tool [redli](https://github.com/IBM-Cloud/redli) by IBM