### PR TITLE
fix(ci): Run `check-flake` on Pull Requests

### DIFF
--- a/.github/workflows/check-flake.yml
+++ b/.github/workflows/check-flake.yml
@@ -1,6 +1,9 @@
 name: Check Nix flake
 on:
-  pull_request:
+  pull_request_target:
+    paths:
+      - '*.nix'
+      - flake.lock
   push:
     branches:
       - main

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -33,5 +33,5 @@ jobs:
               --field content=@<(base64 -i $FILE_TO_COMMIT) \
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
-            gh pr create --title "[automation]: Update Flake dependencies" --body "This is an automated PR to update \`flake.lock\`" --reviewer mrjones2014 --base main --head $COMMIT_BRANCH
+            gh pr create --title "[automation]: Update Flake dependencies" --body "This is an automated PR to update \`flake.lock\`" --reviewer mrjones2014 --reviewer AndyTitu --base main --head $COMMIT_BRANCH
           fi


### PR DESCRIPTION

## Overview
<!--  
Provide a high-level description of this change.   
-->

Updates the `check-flake` CI job to run on PRs that change any `*.nix` files or `flake.lock`, also adds @AndyTitu as a default reviewer for the automated `flake.lock` update PRs.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Let's merge this before #445, then merge main into #445 and make sure CI runs there

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Run `check-flake` CI job on PRs where any `*.nix` files or `flake.lock` are changed
