### PR TITLE
Add executable serverless to aws package

### DIFF
--- a/plugins/aws/plugin.go
+++ b/plugins/aws/plugin.go
@@ -18,6 +18,7 @@ func New() schema.Plugin {
 		Executables: []schema.Executable{
 			AWSCLI(),
 			AWSCDKToolkit(),
+			ServerlessCLI(),
 		},
 	}
 }

--- a/plugins/aws/serverless.go
+++ b/plugins/aws/serverless.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ServerlessCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Serverless CLI",
+		Runs:      []string{"serverless"},
+		DocsURL:   sdk.URL("https://www.serverless.com/framework/docs/getting-started"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessKey,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview
Use aws crediential for serverless cli

## Type of change
- [ ] Created a new plugin
- [x ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
Try to deploy your serverless application on AWS
`serverless deploy`


