### PR TITLE
Troubleshoot local shell plugin hanging

### DIFF
--- a/plugins/fooctl/credentials.go
+++ b/plugins/fooctl/credentials.go
@@ -1,0 +1,117 @@
+package fooctl
+
+import (
+	"context"
+	"fmt"
+
+	"os"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func ConfigPath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "~/.fooctl/credentials"
+	}
+	return homeDir + "/.fooctl/credentials"
+}
+
+func Credentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.Credentials,
+		DocsURL:       sdk.URL("https://localhost/fooctl-cli"),
+		ManagementURL: sdk.URL("https://localhost/fooctl-cli"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKeyID,
+				AlternativeNames:    []string{"UUID"},
+				MarkdownDescription: "UUID used to authenticate to fooctl.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 36,
+					Charset: schema.Charset{
+						Uppercase: false,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.APIKey,
+				AlternativeNames:    []string{"Token"},
+				MarkdownDescription: "Token used to authenticate to fooctl.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 44,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			fooctlConfig,
+			provision.AtFixedPath(ConfigPath()),
+		),
+		Importer: importer.TryAll(
+			TryFooctlConfigFile(),
+		)}
+}
+
+func fooctlConfig(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		UUID:  in.ItemFields[fieldname.APIKeyID],
+		Token: in.ItemFields[fieldname.APIKey],
+	}
+
+	contents := fmt.Sprintf("UUID = \"%s\"\nToken = \"%s\"", config.UUID, config.Token)
+	return []byte(contents), nil
+}
+
+func TryFooctlConfigFile() sdk.Importer {
+	return importer.TryFile(ConfigPath(), func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		configFile, err := contents.ToINI()
+
+		if err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for _, section := range configFile.Sections() {
+			added := false
+			fields := make(map[sdk.FieldName]string)
+
+			addFieldIfPresent := func(key sdk.FieldName, value string) {
+				if value != "" {
+					fields[key] = value
+					added = true
+				}
+			}
+
+			addFieldIfPresent(fieldname.APIKeyID, section.Key("UUID").String())
+			addFieldIfPresent(fieldname.APIKey, section.Key("Token").String())
+
+			if added {
+				out.AddCandidate(sdk.ImportCandidate{
+					Fields:   fields,
+					NameHint: importer.SanitizeNameHint(section.Name()),
+				})
+			}
+		}
+	})
+}
+
+type Config struct {
+	UUID  string `ini:"UUID"`
+	Token string `ini:"Token"`
+}

--- a/plugins/fooctl/fooctl.go
+++ b/plugins/fooctl/fooctl.go
@@ -1,0 +1,27 @@
+package fooctl
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func FooctlCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Fooctl CLI",
+		Runs:    []string{"fooctl"},
+		DocsURL: sdk.URL("https://localhost/fooctl-cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			// needsauth.NotWhenContainsArgs("configure"),
+			// needsauth.NotWhenContainsArgs("daemon"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.Credentials,
+			},
+		},
+	}
+}

--- a/plugins/fooctl/plugin.go
+++ b/plugins/fooctl/plugin.go
@@ -1,0 +1,22 @@
+package fooctl
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "fooctl",
+		Platform: schema.PlatformInfo{
+			Name:     "Fooctl",
+			Homepage: sdk.URL("https://localhost/fooctl-cli"),
+		},
+		Credentials: []schema.CredentialType{
+			Credentials(),
+		},
+		Executables: []schema.Executable{
+			FooctlCLI(),
+		},
+	}
+}


### PR DESCRIPTION
Hey, I'm after a bit of help please? I use a local dev CLI tool called `fooctl`, it simplifies my interactions with cloud resources. To use `fooctl`, I must provide a credentials file at `~/.fooctl/credentials`. The credentials file expects a `UUID` and `Token` (I guess in the `ini` format, e.g. `UUID = "4191234b-foo5-4bar-af3f-3d8266111d8b"`).

I followed the [tutorial](https://developer.1password.com/docs/cli/shell-plugins/contribute), but I'm getting stuck - literally. 

My plugin validates & builds fine. It's also successfully looking for & importing the `UUID` and `Token` in 1Password when a credentials file already exists. 

However, it hangs when using any `fooctl` commands with an arg.

I'm running this on macOS `14.4.1 (23E224)` from `~/dev/shell-plugins`.

This is what happens when I run `footctl` without any args, works as expected:

```
% fooctl                                        
################################################################################
# WARNING: 'fooctl' is not from the official registry.                         #
# Only proceed if you are the developer of 'fooctl'.                           #
# Otherwise, delete the file at /Users/me/.config/op/plugins/local/fooctl.     #
################################################################################
Fooctl is a tool to ease working with applications, projects and infrastructure

Usage:
  fooctl [command]

... omitted help text

```

Now to use `fooctl`, I need to use the `daemon `command (which requires the credentials file):

```
% fooctl daemon                                                         
################################################################################
# WARNING: 'fooctl' is not from the official registry.                         #
# Only proceed if you are the developer of 'fooctl'.                           #
# Otherwise, delete the file at /Users/me/.config/op/plugins/local/fooctl.     #
################################################################################

... the command hangs
... ~/.fooctl/credentials is created but trying to open that also hangs

```

Interestingly, if I run `fooctl configure` (I thought I could avoid doing this as this is what the shell plugin creates), it gets a bit further. It automagically suggests `Defaults` using credentials that were imported into 1Password, creates the credentials file which I can open & see correct contents... but then hangs:

```
% fooctl configure
################################################################################
# WARNING: 'fooctl' is not from the official registry.                         #
# Only proceed if you are the developer of 'fooctl'.                           #
# Otherwise, delete the file at /Users/me/.config/op/plugins/local/fooctl.     #
################################################################################
To proceed with configuration you will need to either generate new credentials
or re-use an existing one that is still valid i.e. hasn't expired or hasn't been
revoked). To manage or view your credentials, visit:
https://localhost/fooctl-cli

Detected existing credentials, they are available as defaults.

What is your UUID?
Enter a value (Default is 5eae7028-1698-4045-9521-21580b4cddf1): 

What is your Token?
Enter a value (Default is sL+****): 

... the command hangs
... ~/.fooctl/credentials is created, can be opened & contains the correct credentials

```

Can you spot anything wrong in the code, or suggest ways to troubleshoot this?