### PR TITLE
chore(ci): Auto-add one approval to automated flake.lock PRs

### DIFF
--- a/.github/workflows/approve-flake-lock-prs.yml
+++ b/.github/workflows/approve-flake-lock-prs.yml
@@ -4,13 +4,23 @@
 name: Approve flake.lock PRs (still require 1 human approval)
 permissions:
   pull-requests: write
+on:
+  pull_request_target:
+    paths:
+      - 'flake.lock' # only run if flake.lock has changed
 jobs:
   approve-flake-lock-prs:
     runs-on: ubuntu-latest
     if: github.actor == 'github-actions[bot]' && github.event.pull_request.labels.*.name == 'flake.lock automation'
     steps:
       - name: Approve flake.lock PRs (still requires 1 human approval)
-        run: gh pr review --approve "$PR_URL"
+        run: |
+          # only run if only exactly 1 file is changed;
+          # this combined with the `paths:` filter on the job itself
+          # ensures that the PR changes ONLY flake.lock and no other files
+          if [[ "$(git diff --name-only HEAD..origin/main | wc -l)" = 1 ]]; then
+            gh pr review --approve "$PR_URL"
+          end
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/approve-flake-lock-prs.yml
+++ b/.github/workflows/approve-flake-lock-prs.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'github-actions[bot]' && github.event.pull_request.labels.*.name == 'flake.lock automation'
     steps:
+      - uses: actions/checkout@v4
       - name: Approve flake.lock PRs (still requires 1 human approval)
         run: |
           # only run if only exactly 1 file is changed;

--- a/.github/workflows/approve-flake-lock-prs.yml
+++ b/.github/workflows/approve-flake-lock-prs.yml
@@ -1,0 +1,16 @@
+# This job applies one approval automatically to the automated `flake.lock` PRs
+# This helps us keep up with the weekly automated PRs, but still requires at least 1
+# human manual approval.
+name: Approve flake.lock PRs (still require 1 human approval)
+permissions:
+  pull-requests: write
+jobs:
+  approve-flake-lock-prs:
+    runs-on: ubuntu-latest
+    if: github.actor == 'github-actions[bot]' && github.event.pull_request.labels.*.name == 'flake.lock automation'
+    steps:
+      - name: Approve flake.lock PRs (still requires 1 human approval)
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -33,5 +33,10 @@ jobs:
               --field content=@<(base64 -i $FILE_TO_COMMIT) \
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
-            gh pr create --title "[automation]: Update Flake dependencies" --body "This is an automated PR to update \`flake.lock\`" --reviewer mrjones2014 --reviewer AndyTitu --base main --head $COMMIT_BRANCH
+            gh pr create --title "[automation]: Update Flake dependencies" \
+              --body "This is an automated PR to update \`flake.lock\`" \
+              --label "flake.lock automation" \
+              --reviewer mrjones2014 \
+              --reviewer AndyTitu \
+              --base main --head $COMMIT_BRANCH
           fi


### PR DESCRIPTION
## Overview

Makes the `github-actions[bot]` automatically approve its own automated `flake.lock` update PRs. The PRs will still require 1 manual human approval, but only requiring 1 human approval helps us keep up with it, and there is reduced risk with these PRs vs. dependabot PRs for example, since we're only pulling in `flake-utils` and `nixpkgs` which are already screened by their respective maintainers.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #452 

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

TODO I'm not sure how exactly to test this other than merging it to main and running a new flake.lock automation job to see if this applies correctly to it. @AndyTitu any ideas?

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Update flake.lock automation to reduce maintenance burden.
