### PR TITLE
cdk.go: support --profile flag by adding missing provisioner

### DIFF
--- a/plugins/aws/cdk.go
+++ b/plugins/aws/cdk.go
@@ -18,7 +18,8 @@ func AWSCDKToolkit() schema.Executable {
 		),
 		Uses: []schema.CredentialUsage{
 			{
-				Name: credname.AccessKey,
+				Name:        credname.AccessKey,
+				Provisioner: CLIProvisioner{},
 			},
 		},
 	}


### PR DESCRIPTION
## Overview
Fixes the _cdk_ plugin not handling the `--profile` flag correctly when a profile is using role assumption. Now it matches  the expected behavior of the _aws_ plugin's `--profile` flag and the `AWS_PROFILE` environment variable.

## Type of change
- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test

If you have an existing CDK stack, you can confirm that using a profile to assume a role used for deployments.
```shell
cd $YOUR_CDK_DIR
cdk diff --profile cdk-stack-admin
```

Example `~/.aws/config` file. Swap out with names and numbers from your account
```ini
[default]

[profile cdk-stack-admin]
source_profile=default
role_arn=arn:aws:iam::<AWS_ACC_NUM>:role/<CDK_ADMIN_ROLE>
role_session_name=cdk-stack-admin
```

Without the patch, the _cdk_ will encounter the error below and fail
```
Need to perform AWS calls for account <AWS_ACC_NUM>, but no credentials have been configured
```

## Changelog

AWS CDK Plugin now supports AWS Profiles that assume a role, when specified by the `--plugin` flag.


