### PR TITLE
fix(nix): Update flake.nix to configure Shell Plugins as functions vs. aliases

### DIFF
--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -54,28 +54,55 @@ in {
     pkg-exe-names = map getExeName cfg.plugins;
     # Explanation:
     # Map over `cfg.plugins` (the value of the `plugins` option provided by the user)
-    # and for each package specified, get the executable name, then create a shell alias
+    # and for each package specified, get the executable name, then create a shell function
     # of the form:
-    # `alias {pkg}="op plugin run -- {pkg}"`
+    #
+    # For Bash and Zsh:
+    # ```
+    #   {pkg}() {
+    #     op plugin run -- {pkg};
+    #   }
+    # ```
+    #
+    # And for Fish:
+    # ```
+    #  function {pkg} --wraps {pkg}
+    #    op plugin run -- {pkg}
+    #  end
+    # ```
     # where `{pkg}` is the executable name of the package
-    aliases = listToAttrs (map (package: {
-      name = package;
-      value = "op plugin run -- ${package}";
-    }) pkg-exe-names);
+    posixFunctions = map (package: ''
+      ${package}() {
+        op plugin run -- ${package};
+      }
+    '') pkg-exe-names;
+    fishFunctions = map (package: ''
+      function ${package} --wraps "${package}" --description "1Password Shell Plugin for ${package}"
+        op plugin run -- ${package}
+      end
+    '') pkg-exe-names;
     packages = [ pkgs._1password ] ++ cfg.plugins;
   in mkIf cfg.enable (mkMerge [
     ({
-      programs = {
-        bash.shellAliases = aliases;
-        zsh.shellAliases = aliases;
-        fish.shellAliases = aliases;
-      };
+      # for Fish its the same option path between NixOS vs. home-manager
+      fish.interactiveShellInit = strings.concatStringsSep "\n" fishFunctions;
     } // optionalAttrs is-home-manager {
+      programs = {
+        # for the Bash and Zsh home-manager modules,
+        # the initExtra option is equivalent to Fish's interactiveShellInit
+        bash.initExtra = strings.concatStringsSep "\n" posixFunctions;
+        zsh.initExtra = strings.concatStringsSep "\n" posixFunctions;
+      };
       home = {
         inherit packages;
         sessionVariables = { OP_PLUGINS_SOURCED = "1"; };
       };
     } // optionalAttrs (!is-home-manager) {
+      programs = {
+        bash.interactiveShellInit =
+          strings.concatStringsSep "\n" posixFunctions;
+        zsh.interactiveShellInit = strings.concatStringsSep "\n" posixFunctions;
+      };
       environment = {
         systemPackages = packages;
         variables = { OP_PLUGINS_SOURCED = "1"; };


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Users of the Nix Flake will now have Shell Plugins wired up as shell functions instead of shell aliases. This results in a better tab completion experience.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Relates: #433  (Resolves for Nix Flake users but not others)

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

1. However you consume the flake (e.g. as an input to your own flake) update the URL to `git+file:///path/to/local/shell-plugins` (replacing the file path as appropriate for your own system)˜
2. Rebuild your Nix configuration
3. Restart your shell
4. Check that Shell Plugins still work

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Update Nix Flake to configure Shell Plugins as shell functions instead of aliases for better tab completion.