### PR TITLE
fix(ci): Use 1Password-bot token for flake update PRs so approval job…

### DIFF
--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -17,7 +17,7 @@ jobs:
       run: nix flake update
     - name: Create signed commit with flake.lock changes
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.OP_BOT_TOKEN }}
         FILE_TO_COMMIT: flake.lock
         COMMIT_BRANCH: automation/update-flake-dependencies
         COMMIT_MESSAGE: "chore(nix): Update Flake dependencies"


### PR DESCRIPTION
… runs

## Overview
<!--  
Provide a high-level description of this change.   
-->

Changes the token used for the flake update CI jobs to use the `1Password-bot` users token, so that the approval job runs and `github-actions[bot]` can apply an approval to the flake.lock update PRs. 

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #459  #456 

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Merge this change, then run a flake.lock update CI job. The PR should be created by 1Password-bot, and github-actions[bot] should provide one approval for it.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Use 1Password-bot instead of github-actions[bot] to run the flake.lock update CI jobs.
