### PR TITLE
fix(ci): Update existing flake.lock PR if it exists already

### DIFF
--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -13,20 +13,28 @@ jobs:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: DeterminateSystems/magic-nix-cache-action@main
-    - name: update flake.lock
-      run: nix flake update
-    - name: Create signed commit with flake.lock changes
+    - name: Update flake.lock and create signed commit with flake.lock changes
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FILE_TO_COMMIT: flake.lock
         COMMIT_BRANCH: automation/update-flake-dependencies
         COMMIT_MESSAGE: "chore(nix): Update Flake dependencies"
       run: |
+          # fetch remote state
+          git fetch
+          # if branch exists on remote already
+          if git checkout "$COMMIT_BRANCH" > /dev/null 2>&1; then
+            # pull changes
+            git pull
+          else
+            # otherwise, create the branch and push it to remote
+            git checkout -b "$COMMIT_BRANCH"
+            git push -u origin "$COMMIT_BRANCH"
+          fi
+          # update flake.lock
+          nix flake update
           # make sure something actually changed first, if not, no updates required
           if [[ `git status --porcelain` ]]; then
-            # create the branch on the remote
-            git branch "$COMMIT_BRANCH"
-            git push -u origin "$COMMIT_BRANCH"
             # commit via the GitHub API so we get automatic commit signing
             gh api --method PUT /repos/1Password/shell-plugins/contents/$FILE_TO_COMMIT \
               --field message="$COMMIT_MESSAGE" \


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

If a `flake.lock` automated PR already exists and hasn't been merged by the time a new job runs to create a new PR, it updates the existing PR instead of trying to create a new PR and failing because the branch already exists.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #467 

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Read the changed bash script and ensure it makes sense. You can also test out the logic locally on a test repo. The thinking in the first few lines (the first `if` block) is:

- If the branch already exists on remote, checkout and pull before trying to update `flake.lock` (this is to ensure we can push new changes, e.g. a commit exists on remote that we don't have locally)
- Otherwise, create the branch and push the empty branch to remote
- _Then_ run `nix flake update`, which now runs on the latest version of the file from the branch
- Push the changes to the branch
    - If the branch already existed and had a PR for it, pushing new commits to the branch will update the existing PR

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Update `flake.lock` CI automation to update existing PR if there is one.
