### PR TITLE
Optional package

### DIFF
--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -21,6 +21,7 @@ in {
   options = {
     programs._1password-shell-plugins = {
       enable = mkEnableOption "1Password Shell Plugins";
+      package = mkPackageOption pkgs "_1password" { };
       plugins = mkOption {
         type = types.listOf types.package;
         default = [ ];
@@ -62,7 +63,7 @@ in {
       name = package;
       value = "op plugin run -- ${package}";
     }) pkg-exe-names);
-    packages = [ pkgs._1password ] ++ cfg.plugins;
+    packages = [ cfg.package ] ++ cfg.plugins;
   in mkIf cfg.enable (mkMerge [
     ({
       programs = {

--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -21,7 +21,7 @@ in {
   options = {
     programs._1password-shell-plugins = {
       enable = mkEnableOption "1Password Shell Plugins";
-      package = mkPackageOption pkgs "_1password" { };
+      package = mkPackageOption pkgs "_1password-cli" { nullable = true; };
       plugins = mkOption {
         type = types.listOf types.package;
         default = [ ];
@@ -63,7 +63,7 @@ in {
       name = package;
       value = "op plugin run -- ${package}";
     }) pkg-exe-names);
-    packages = [ cfg.package ] ++ cfg.plugins;
+    packages = lib.optional (cfg.package != null) cfg.package ++ cfg.plugins;
   in mkIf cfg.enable (mkMerge [
     ({
       programs = {


### PR DESCRIPTION
## Overview

1Password CLI requires setting the group of the executable to `onepassword-cli`. This isn't possible when home-manager is installed in standalone mode (e.g. Ubuntu or other distributions). Opting out of installing the 1Password CLI
with nix allows using the system-wide installation (e.g. via apt).

This change also allows changing the package. It's beneficial when nixpkgs-unstable is mapped to `pkgs.unstable` via an overlay.

This is **not** breaking, the current behavior remains as is.

## Type of change
Improved experience for nix users.

## How To Test
Opting out of installing the package:
```nix
{
    imports = [ inputs._1password-shell-plugins.hmModules.default ];
    programs._1password-shell-plugins = {
      enable = true;
      package = null;
      plugins = with pkgs; [ gh awscli2 cachix ];
    };
}
```

Changing the package:
```nix
{
    imports = [ inputs._1password-shell-plugins.hmModules.default ];
    programs._1password-shell-plugins = {
      enable = true;
      package = pkgs.unstable._1password-cli;
      plugins = with pkgs; [ gh awscli2 cachix ];
    };
}
```

## Changelog

Allow nix users to change the `_1password-cli` package like in home-manager modules or allow opting out from installing the package by setting it to `null`.