### PR TITLE
run terraform plugin for all terraform state commands (not just `stat…

### DIFF
--- a/plugins/terraform/terraform.go
+++ b/plugins/terraform/terraform.go
@@ -27,7 +27,7 @@ func TerraformCLI() schema.Executable {
 				NeedsAuth: needsauth.IfAny(
 					needsauth.ForCommand("refresh"),
 					needsauth.ForCommand("init"),
-					needsauth.ForCommand("state", "list"),
+					needsauth.ForCommand("state"),
 					needsauth.ForCommand("plan"),
 					needsauth.ForCommand("apply"),
 					needsauth.ForCommand("destroy"),


### PR DESCRIPTION
## Overview
This PR makes sure the terraform plugin is run for all `terraform state` commands.

## Type of change
- [ ] Created a new plugin
- [X] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
* Resolves: #
* Relates: #

## How To Test
Run `terraform state show '<any terraform resource id in your state>' or `terraform state pull|push`.

## Changelog
The terraform plugin now kicks in on all `terraform state` subcommands, not just `terraform state list`.