### PR TITLE
feat: add `age` plugin

### DIFF
--- a/plugins/age/age.go
+++ b/plugins/age/age.go
@@ -1,0 +1,26 @@
+package age
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func AgeCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Age CLI",
+		Runs:    []string{"age"},
+		DocsURL: sdk.URL("https://age-encryption.org"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("encrypt", "recipient", "armor"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.SecretKey,
+			},
+		},
+	}
+}

--- a/plugins/age/plugin.go
+++ b/plugins/age/plugin.go
@@ -1,0 +1,22 @@
+package age
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "age",
+		Platform: schema.PlatformInfo{
+			Name:     "Age",
+			Homepage: sdk.URL("https://age-encryption.org/"),
+		},
+		Credentials: []schema.CredentialType{
+			PrivateKey(),
+		},
+		Executables: []schema.Executable{
+			AgeCLI(),
+		},
+	}
+}

--- a/plugins/age/private_key.go
+++ b/plugins/age/private_key.go
@@ -1,0 +1,32 @@
+package age
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PrivateKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.SecretKey,
+		DocsURL: sdk.URL("https://age-encryption.org/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.PrivateKey,
+				MarkdownDescription: "Age Private key",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 80,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: PrivateKeyProvisioner{},
+	}
+}

--- a/plugins/age/private_key_provisioner.go
+++ b/plugins/age/private_key_provisioner.go
@@ -1,0 +1,50 @@
+package age
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"slices"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+type PrivateKeyProvisioner struct {
+}
+
+func (p PrivateKeyProvisioner) Provision(_ context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	privateKey := in.ItemFields[fieldname.PrivateKey]
+
+	fileName, err := randomFilename()
+	if err != nil {
+		out.AddError(fmt.Errorf("generating random file name: %s", err))
+		return
+	}
+
+	secretFilePath := in.FromTempDir(fileName)
+	out.AddSecretFile(secretFilePath, []byte(privateKey))
+
+	editedCommandLine := slices.Insert(out.CommandLine, 1, "--identity", secretFilePath)
+
+	if editedCommandLine != nil {
+		out.CommandLine = editedCommandLine
+	}
+}
+
+func (p PrivateKeyProvisioner) Deprovision(_ context.Context, _ sdk.DeprovisionInput, _ *sdk.DeprovisionOutput) {
+	// Nothing to do here: environment variables get wiped automatically when the process exits.
+}
+
+func (p PrivateKeyProvisioner) Description() string {
+	return "Provision age secret key"
+}
+
+func randomFilename() (string, error) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Adds support for using [age](https://github.com/FiloSottile/age) encryption tool private keys from 1Password


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
If you already have an `age` private key, create a new item in 1Password with a field named: `Private Key`
You can now use `age` to decrypt a file without passing the `--identity` argument
Example:
```shell
age --decrypt test.txt.enc
```

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


