### PR TITLE
feat: Create plugin for Railway CLI

### DIFF
--- a/plugins/railway/api_token.go
+++ b/plugins/railway/api_token.go
@@ -1,0 +1,70 @@
+package railway
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://railway.com/docs/api_token"), // TODO: Replace with actual URL
+		ManagementURL: sdk.URL("https://console.railway.com/user/security/tokens"), // TODO: Replace with actual URL
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Railway.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 36,
+					Prefix: "aa7b1a4b-7bb3-", // TODO: Check if this is correct
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryRailwayConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"RAILWAY_TOKEN": fieldname.Token, // TODO: Check if this is correct
+}
+
+// TODO: Check if the platform stores the API Token in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryRailwayConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		// var config Config
+		// if err := contents.ToYAML(&config); err != nil {
+		// 	out.AddError(err)
+		// 	return
+		// }
+
+		// if config.Token == "" {
+		// 	return
+		// }
+
+		// out.AddCandidate(sdk.ImportCandidate{
+		// 	Fields: map[sdk.FieldName]string{
+		// 		fieldname.Token: config.Token,
+		// 	},
+		// })
+	})
+}
+
+// TODO: Implement the config file schema
+// type Config struct {
+//	Token string
+// }

--- a/plugins/railway/api_token.go
+++ b/plugins/railway/api_token.go
@@ -1,8 +1,6 @@
 package railway
 
 import (
-	"context"
-
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -14,8 +12,8 @@ import (
 func APIToken() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIToken,
-		DocsURL:       sdk.URL("https://railway.com/docs/api_token"), // TODO: Replace with actual URL
-		ManagementURL: sdk.URL("https://console.railway.com/user/security/tokens"), // TODO: Replace with actual URL
+		DocsURL:       sdk.URL("https://docs.railway.app/guides/cli#authenticating-with-the-cli"),
+		ManagementURL: sdk.URL("https://railway.app/account/tokens"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,
@@ -23,7 +21,6 @@ func APIToken() schema.CredentialType {
 				Secret:              true,
 				Composition: &schema.ValueComposition{
 					Length: 36,
-					Prefix: "aa7b1a4b-7bb3-", // TODO: Check if this is correct
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
@@ -34,37 +31,9 @@ func APIToken() schema.CredentialType {
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
-			TryRailwayConfigFile(),
 		)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"RAILWAY_TOKEN": fieldname.Token, // TODO: Check if this is correct
+	"RAILWAY_API_TOKEN": fieldname.Token,
 }
-
-// TODO: Check if the platform stores the API Token in a local config file, and if so,
-// implement the function below to add support for importing it.
-func TryRailwayConfigFile() sdk.Importer {
-	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
-		// var config Config
-		// if err := contents.ToYAML(&config); err != nil {
-		// 	out.AddError(err)
-		// 	return
-		// }
-
-		// if config.Token == "" {
-		// 	return
-		// }
-
-		// out.AddCandidate(sdk.ImportCandidate{
-		// 	Fields: map[sdk.FieldName]string{
-		// 		fieldname.Token: config.Token,
-		// 	},
-		// })
-	})
-}
-
-// TODO: Implement the config file schema
-// type Config struct {
-//	Token string
-// }

--- a/plugins/railway/api_token_test.go
+++ b/plugins/railway/api_token_test.go
@@ -1,0 +1,55 @@
+package railway
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.Token: "abcdefghijklm-1234567890-example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"RAILWAY_TOKEN": "abcdefghijklm-1234567890-example",
+				},
+			},
+		},
+	})
+}
+
+func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"RAILWAY_TOKEN": "abcdefghijklm-1234567890-example",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "abcdefghijklm-1234567890-example",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in railway/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "abcdefghijklm-1234567890-example",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/railway/api_token_test.go
+++ b/plugins/railway/api_token_test.go
@@ -2,21 +2,21 @@ package railway
 
 import (
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func TestAPITokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
-			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+			ItemFields: map[sdk.FieldName]string{
 				fieldname.Token: "abcdefghijklm-1234567890-example",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"RAILWAY_TOKEN": "abcdefghijklm-1234567890-example",
+					"RAILWAY_API_TOKEN": "abcdefghijklm-1234567890-example",
 				},
 			},
 		},
@@ -26,8 +26,8 @@ func TestAPITokenProvisioner(t *testing.T) {
 func TestAPITokenImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
 		"environment": {
-			Environment: map[string]string{ // TODO: Check if this is correct
-				"RAILWAY_TOKEN": "abcdefghijklm-1234567890-example",
+			Environment: map[string]string{
+				"RAILWAY_API_TOKEN": "abcdefghijklm-1234567890-example",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
@@ -35,20 +35,6 @@ func TestAPITokenImporter(t *testing.T) {
 						fieldname.Token: "abcdefghijklm-1234567890-example",
 					},
 				},
-			},
-		},
-		// TODO: If you implemented a config file importer, add a test file example in railway/test-fixtures
-		// and fill the necessary details in the test template below.
-		"config file": {
-			Files: map[string]string{
-				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
-			},
-			ExpectedCandidates: []sdk.ImportCandidate{
-			// 	{
-			// 		Fields: map[sdk.FieldName]string{
-			// 			fieldname.Token: "abcdefghijklm-1234567890-example",
-			// 		},
-			// 	},
 			},
 		},
 	})

--- a/plugins/railway/plugin.go
+++ b/plugins/railway/plugin.go
@@ -1,0 +1,22 @@
+package railway
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "railway",
+		Platform: schema.PlatformInfo{
+			Name:     "Railway",
+			Homepage: sdk.URL("https://railway.com"), // TODO: Check if this is correct
+		},
+		Credentials: []schema.CredentialType{
+			APIToken(),
+		},
+		Executables: []schema.Executable{
+			RailwayCLI(),
+		},
+	}
+}

--- a/plugins/railway/plugin.go
+++ b/plugins/railway/plugin.go
@@ -10,7 +10,7 @@ func New() schema.Plugin {
 		Name: "railway",
 		Platform: schema.PlatformInfo{
 			Name:     "Railway",
-			Homepage: sdk.URL("https://railway.com"), // TODO: Check if this is correct
+			Homepage: sdk.URL("https://railway.app"),
 		},
 		Credentials: []schema.CredentialType{
 			APIToken(),

--- a/plugins/railway/railway.go
+++ b/plugins/railway/railway.go
@@ -9,9 +9,9 @@ import (
 
 func RailwayCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Railway CLI", // TODO: Check if this is correct
-		Runs:      []string{"railway"},
-		DocsURL:   sdk.URL("https://railway.com/docs/cli"), // TODO: Replace with actual URL
+		Name:    "Railway CLI",
+		Runs:    []string{"railway"},
+		DocsURL: sdk.URL("https://docs.railway.app/guides/cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/railway/railway.go
+++ b/plugins/railway/railway.go
@@ -1,0 +1,25 @@
+package railway
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func RailwayCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Railway CLI", // TODO: Check if this is correct
+		Runs:      []string{"railway"},
+		DocsURL:   sdk.URL("https://railway.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIToken,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Created a 1Password CLI Shell Plugin for the [Railway CLI](https://docs.railway.app/guides/cli).

See GIF below for a quick demo:
![op-railway](https://github.com/user-attachments/assets/185a0ee2-9cf6-43da-a406-b44ac6652022)

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

* Resolves: #151

## How To Test

1. Create a Railway account from [here](https://railway.app/).
2. Create an account-level API token from [here](https://railway.app/account/tokens). Keep this token handy for later.
3. Install the Railway CLI using official instructions [here](https://docs.railway.app/guides/cli#installing-the-cli) or with Homebrew using:
```sh
brew install railway
```
4. `railway whoami` will now display an error cus you're not logged in to the CLI.
5. Setup this new Railway 1Password Shell Plugin locally or using the following commands from inside this repo:
```sh
make railway/build
```
```sh
op plugin init railway
```
6. Running `op plugin run -- railway whoami` should now correctly authenticate you to the Railway CLI.

## Changelog

Authenticate the Railway CLI using Touch ID and other unlock options with 1Password Shell Plugins.