### PR TITLE
Add eksctl support to AWS plugin

### DIFF
--- a/plugins/aws/eksctl.go
+++ b/plugins/aws/eksctl.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func eksctlCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "eksctl CLI",
+		Runs:    []string{"eksctl"},
+		DocsURL: sdk.URL("https://eksctl.io/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name:        credname.AccessKey,
+				Provisioner: CLIProvisioner{},
+			},
+		},
+	}
+}

--- a/plugins/aws/plugin.go
+++ b/plugins/aws/plugin.go
@@ -18,6 +18,7 @@ func New() schema.Plugin {
 		Executables: []schema.Executable{
 			AWSCLI(),
 			AWSCDKToolkit(),
+			eksctlCLI(),
 		},
 	}
 }


### PR DESCRIPTION
## Overview

Adds rudimentary `eksctl` support to the AWS plugin. `eksctl` uses the same authentication schema as `aws` and `cdk`, so all I did was add `eksctl.go`, the related executable to `plugin.go`, and tested it locally.

https://eksctl.io/

`eksctl` is maintained by Amazon.

## Type of change

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

* Resolves: https://github.com/1Password/shell-plugins/issues/499

## How To Test

Any `eksctl` command, ex:

```
14:34:30 › ~/git/skpaz/shell-plugins »
∟ ⌥ skpaz/add-eksctl-to-aws ↑ % eksctl get clusters --region us-west-2
###########################################################################
# WARNING: 'aws' is not from the official registry.                       #
# Only proceed if you are the developer of 'aws'.                         #
# Otherwise, delete the file at /Users/sean/.config/op/plugins/local/aws. #
###########################################################################
NAME			REGION		EKSCTL CREATED
KKR-BORIS		us-west-2	False
basic-cluster-kkr-01	us-west-2	True
john-test-cluster	us-west-2	True
johnl-gex-fullstack	us-west-2	True
vw-kkr-demo01		us-west-2	False
```

Local plugin:

```
15:27:09 › ~/git/skpaz/shell-plugins »
∟ ⌥ skpaz/add-eksctl-to-aws % op plugin list|grep -i aws
Local Build           aws                AWS                   Access Key ID, Secret Access Key
Local Build           cdk                AWS                   Access Key ID, Secret Access Key
Local Build           eksctl             AWS                   Access Key ID, Secret Access Key
```

I haven't tested this exhaustively, so it's possible there might be flags other than `--profile` that need to be added to `cli_provisioner.go`, etc. I'll be running with it for the next week or so to see if I encounter any issues.

## Changelog

The AWS plugin now supports eksctl, AWS' EKS CLI.


