### PR TITLE
Make 1Password CLI package configurable and fix `pkgs._1password` warning

### DIFF
--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -8,7 +8,7 @@ let
       pkgs.runCommand "op-plugin-list" { }
       # 1Password CLI tries to create the config directory automatically, so set a temp XDG_CONFIG_HOME
       # since we don't actually need it for this
-      "mkdir $out && XDG_CONFIG_HOME=$out ${pkgs._1password}/bin/op plugin list | cut -d ' ' -f1 | tail -n +2 > $out/plugins.txt"
+      "mkdir $out && XDG_CONFIG_HOME=$out ${getExe cfg.cliPackage} plugin list | cut -d ' ' -f1 | tail -n +2 > $out/plugins.txt"
     }/plugins.txt");
   getExeName = package:
     # NOTE: SAFETY: This is okay because the `packages` list is also referred
@@ -21,6 +21,13 @@ in {
   options = {
     programs._1password-shell-plugins = {
       enable = mkEnableOption "1Password Shell Plugins";
+      cliPackage = mkOption {
+        type = types.package;
+        default = pkgs._1password-cli;
+        description = ''
+          The 1Password CLI package
+        '';
+      };
       plugins = mkOption {
         type = types.listOf types.package;
         default = [ ];
@@ -62,7 +69,7 @@ in {
       name = package;
       value = "op plugin run -- ${package}";
     }) pkg-exe-names);
-    packages = [ pkgs._1password ] ++ cfg.plugins;
+    packages = [ cfg.cliPackage ] ++ cfg.plugins;
   in mkIf cfg.enable (mkMerge [
     ({
       programs = {


### PR DESCRIPTION
The `_1password` package was renamed to `_1password-cli` in nixpkgs.

Using the `_1password` package prints the following:

```
evaluation warning: _1password has been renamed to _1password-cli to better follow upstream name usage
```

This PR is similar to #498, but they missed the invocation on line 11 so it still prints the warning.

## Changes

- Add a `cliPackage` option, which defaults to `_1password-cli`. Users may want to use a custom version of the 1Password CLI without using an overlay - this provides that option.
- The evaluation message is no longer printed
