### PR TITLE
Add `awslogs` executable to aws plugin

### DIFF
--- a/plugins/aws/awslogs.go
+++ b/plugins/aws/awslogs.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func awslogsCli() schema.Executable {
+	return schema.Executable{
+		Name:    "awslogs",
+		Runs:    []string{"awslogs"},
+		DocsURL: sdk.URL("https://github.com/jorgebastida/awslogs"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name:        credname.AccessKey,
+				Provisioner: CLIProvisioner{},
+			},
+		},
+	}
+}

--- a/plugins/aws/plugin.go
+++ b/plugins/aws/plugin.go
@@ -19,6 +19,7 @@ func New() schema.Plugin {
 			AWSCLI(),
 			AWSCDKToolkit(),
 			eksctlCLI(),
+			awslogsCli(),
 		},
 	}
 }


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

This PR adds `awslogs` as a possible CLI tool to use with 1Pass.



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience



## Changelog
- Add `awslogs` executable to `aws` plugin.


