### PR TITLE
Make the push target more specific

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: Test and Validate
 on:
   push:
+    branches: [main]
     paths-ignore:
       - '**.md'
       - '.github/ISSUE_TEMPLATE/**'


### PR DESCRIPTION
This will reduce the amount of pipelines executed in PRs to once instead of twice due to two targets matching previously in PRs.

## Overview
<!--  
Provide a high-level description of this change.   
-->

When running pipelines on existing Pull Requests, it's very likely that the testing pipelines will be executed twice. That is becuase both `push` and `pull_request` criteria match when pushing new code on the branch that has an open Pull Request.

This PR adjusts the `push` target to only be executed on `main` branch to reduce the amount of pipelines executed on Pull Requests. A similar thing has been done for `load-secrets-action`'s testing pipeline as part of https://github.com/1Password/load-secrets-action/pull/87, followed by https://github.com/1Password/load-secrets-action/pull/90.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Check that the pipeline will only execute the Test and Validate once from the `pull_request` target. Compare that with https://github.com/1Password/shell-plugins/pull/505:

![image](https://github.com/user-attachments/assets/943f8f74-01b6-4d5a-90be-5cff8befc3d8)


