### PR TITLE
Rename awslogsCLI function for consistency

### DIFF
--- a/plugins/aws/awslogs.go
+++ b/plugins/aws/awslogs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
 
-func awslogsCli() schema.Executable {
+func awslogsCLI() schema.Executable {
 	return schema.Executable{
 		Name:    "awslogs",
 		Runs:    []string{"awslogs"},

--- a/plugins/aws/plugin.go
+++ b/plugins/aws/plugin.go
@@ -20,7 +20,7 @@ func New() schema.Plugin {
 			AWSCDKToolkit(),
 			AWSSAMCLI(),
 			eksctlCLI(),
-			awslogsCli(),
+			awslogsCLI(),
 		},
 	}
 }


### PR DESCRIPTION
Fast follow for #504

The other CLI functions use capitalized CLI, I've renamed this function to do the same for consistency.