### PR TITLE
Add plugin for Anthropic Claude Code CLI

### DIFF
--- a/plugins/anthropic/api_key.go
+++ b/plugins/anthropic/api_key.go
@@ -1,0 +1,40 @@
+package anthropic
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://docs.anthropic.com/en/home"),
+		ManagementURL: sdk.URL("https://console.anthropic.com/settings/keys"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to the Anthropic API.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Prefix: "sk-ant-",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"ANTHROPIC_API_KEY": fieldname.APIKey,
+}

--- a/plugins/anthropic/api_key_test.go
+++ b/plugins/anthropic/api_key_test.go
@@ -1,0 +1,41 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "sk-ant-api03-6ZuKEYkQUs5tduCvwiQ7YmfDlx2h13q3ovHLfHX2NAXiUA81ixbluqFo4CfUqmodkho4HvYAmlYk0wuIFTLV5w-EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"ANTHROPIC_API_KEY": "sk-ant-api03-6ZuKEYkQUs5tduCvwiQ7YmfDlx2h13q3ovHLfHX2NAXiUA81ixbluqFo4CfUqmodkho4HvYAmlYk0wuIFTLV5w-EXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"ANTHROPIC_API_KEY": "sk-ant-api03-6ZuKEYkQUs5tduCvwiQ7YmfDlx2h13q3ovHLfHX2NAXiUA81ixbluqFo4CfUqmodkho4HvYAmlYk0wuIFTLV5w-EXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "sk-ant-api03-6ZuKEYkQUs5tduCvwiQ7YmfDlx2h13q3ovHLfHX2NAXiUA81ixbluqFo4CfUqmodkho4HvYAmlYk0wuIFTLV5w-EXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/anthropic/claude_code.go
+++ b/plugins/anthropic/claude_code.go
@@ -1,0 +1,22 @@
+package anthropic
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ClaudeCodeCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Claude Code",
+		Runs:      []string{"claude"},
+		DocsURL:   sdk.URL("https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/anthropic/plugin.go
+++ b/plugins/anthropic/plugin.go
@@ -1,0 +1,22 @@
+package anthropic
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "anthropic",
+		Platform: schema.PlatformInfo{
+			Name:     "Anthropic",
+			Homepage: sdk.URL("https://anthropic.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			ClaudeCodeCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
Adding new plugin for Anthropic platform, with `claude` CLI.

## Type of change
- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
```
claude -p hello
```

## Changelog
Use Claude Code CLI in non-interactive mode using Touch ID and other unlock options with 1Password Shell Plugin.


