### PR TITLE
Allow home-manager to specify a custom package for the cli

### DIFF
--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -8,7 +8,7 @@ let
       pkgs.runCommand "op-plugin-list" { }
       # 1Password CLI tries to create the config directory automatically, so set a temp XDG_CONFIG_HOME
       # since we don't actually need it for this
-      "mkdir $out && XDG_CONFIG_HOME=$out ${pkgs._1password}/bin/op plugin list | cut -d ' ' -f1 | tail -n +2 > $out/plugins.txt"
+      "mkdir $out && XDG_CONFIG_HOME=$out ${cfg.package}/bin/op plugin list | cut -d ' ' -f1 | tail -n +2 > $out/plugins.txt"
     }/plugins.txt");
   getExeName = package:
     # NOTE: SAFETY: This is okay because the `packages` list is also referred
@@ -21,6 +21,9 @@ in {
   options = {
     programs._1password-shell-plugins = {
       enable = mkEnableOption "1Password Shell Plugins";
+
+      package = lib.mkPackageOption pkgs "_1password" { };
+
       plugins = mkOption {
         type = types.listOf types.package;
         default = [ ];
@@ -62,7 +65,7 @@ in {
       name = package;
       value = "op plugin run -- ${package}";
     }) pkg-exe-names);
-    packages = [ pkgs._1password ] ++ cfg.plugins;
+    packages = [ cfg.package ] ++ cfg.plugins;
   in mkIf cfg.enable (mkMerge [
     ({
       programs = {


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Adds a nix homemanager option to explicitly specify the nix package to use. This allows them to pin to a specific version or provide a beta version.



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #514 
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
Run home-manager supplying a custom package such as modifying the _1password-cli to point to the beta version.


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Nix users can now pass a custom cli package to the nixos/homemanager config.
