### PR TITLE
IBM Cloud plugin

### DIFF
--- a/plugins/ibmcloud/api_key.go
+++ b/plugins/ibmcloud/api_key.go
@@ -1,0 +1,49 @@
+package ibmcloud
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://cloud.ibm.com/docs/account?topic=account-manapikey"),
+		ManagementURL: sdk.URL("https://cloud.ibm.com/iam/overview"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to IBM Cloud.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 44,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryIBMCloudConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"IBMCLOUD_API_KEY": fieldname.APIKey,
+}
+
+// implement the function below to add support for importing it.
+func TryIBMCloudConfigFile() sdk.Importer {
+	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+	})
+}

--- a/plugins/ibmcloud/api_key.go
+++ b/plugins/ibmcloud/api_key.go
@@ -1,8 +1,6 @@
 package ibmcloud
 
 import (
-	"context"
-
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -34,16 +32,9 @@ func APIKey() schema.CredentialType {
 		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
-			TryIBMCloudConfigFile(),
 		)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"IBMCLOUD_API_KEY": fieldname.APIKey,
-}
-
-// implement the function below to add support for importing it.
-func TryIBMCloudConfigFile() sdk.Importer {
-	return importer.TryFile("~/path/to/config/file.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
-	})
 }

--- a/plugins/ibmcloud/api_key_test.go
+++ b/plugins/ibmcloud/api_key_test.go
@@ -1,0 +1,45 @@
+package ibmcloud
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"IBMCLOUD_API_KEY": "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"IBMCLOUD_API_KEY": "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files:              map[string]string{},
+			ExpectedCandidates: []sdk.ImportCandidate{},
+		},
+	})
+}

--- a/plugins/ibmcloud/api_key_test.go
+++ b/plugins/ibmcloud/api_key_test.go
@@ -12,11 +12,11 @@ func TestAPIKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.APIKey: "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+				fieldname.APIKey: "GeYS3RmGXo7cQhY8UboUSLmWarFF1HGqv4fVKEXAMPLE",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"IBMCLOUD_API_KEY": "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+					"IBMCLOUD_API_KEY": "GeYS3RmGXo7cQhY8UboUSLmWarFF1HGqv4fVKEXAMPLE",
 				},
 			},
 		},
@@ -27,12 +27,12 @@ func TestAPIKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
 		"environment": {
 			Environment: map[string]string{
-				"IBMCLOUD_API_KEY": "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+				"IBMCLOUD_API_KEY": "GeYS3RmGXo7cQhY8UboUSLmWarFF1HGqv4fVKEXAMPLE",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
-						fieldname.APIKey: "2R6HTK2HeEpqPrQX4uGmJr736ng2MlBwA0tfiEXAMPLE",
+						fieldname.APIKey: "GeYS3RmGXo7cQhY8UboUSLmWarFF1HGqv4fVKEXAMPLE",
 					},
 				},
 			},

--- a/plugins/ibmcloud/ibmcloud.go
+++ b/plugins/ibmcloud/ibmcloud.go
@@ -1,0 +1,25 @@
+package ibmcloud
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func IBMCloudCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "IBM Cloud CLI",
+		Runs:    []string{"ibmcloud"},
+		DocsURL: sdk.URL("https://ibmcloud.com/docs/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/ibmcloud/plugin.go
+++ b/plugins/ibmcloud/plugin.go
@@ -1,0 +1,22 @@
+package ibmcloud
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "ibmcloud",
+		Platform: schema.PlatformInfo{
+			Name:     "IBM Cloud",
+			Homepage: sdk.URL("https://cloud.ibm.com/"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			IBMCloudCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
This change implement basic functionality of IBM Cloud plugin


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
Command to test:
`ibmcloud login`


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
The IBM Cloud plugin is now available and can be used with 1Password.


