### PR TITLE
feat: add plugin support for OpenSSF Scorecard CLI

### DIFF
--- a/plugins/scorecard/plugin.go
+++ b/plugins/scorecard/plugin.go
@@ -1,0 +1,22 @@
+package scorecard
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "scorecard",
+		Platform: schema.PlatformInfo{
+			Name:     "OpenSSF Scorecard",
+			Homepage: sdk.URL("https://github.com/ossf/scorecard"),
+		},
+		Credentials: []schema.CredentialType{
+			SecretKey(),
+		},
+		Executables: []schema.Executable{
+			OpenSSFScorecardCLI(),
+		},
+	}
+}

--- a/plugins/scorecard/scorecard.go
+++ b/plugins/scorecard/scorecard.go
@@ -9,9 +9,9 @@ import (
 
 func OpenSSFScorecardCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "OpenSSF Scorecard CLI",
-		Runs:      []string{"scorecard"},
-		DocsURL:   sdk.URL("https://github.com/ossf/scorecard"),
+		Name:    "OpenSSF Scorecard CLI",
+		Runs:    []string{"scorecard"},
+		DocsURL: sdk.URL("https://github.com/ossf/scorecard"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/scorecard/scorecard.go
+++ b/plugins/scorecard/scorecard.go
@@ -1,0 +1,25 @@
+package scorecard
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func OpenSSFScorecardCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "OpenSSF Scorecard CLI",
+		Runs:      []string{"scorecard"},
+		DocsURL:   sdk.URL("https://github.com/ossf/scorecard"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.SecretKey,
+			},
+		},
+	}
+}

--- a/plugins/scorecard/secret_key.go
+++ b/plugins/scorecard/secret_key.go
@@ -50,8 +50,8 @@ func SecretKey() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"GITHUB_APP_KEY_PATH":         fieldname.Key,
-	"GITHUB_APP_ID":               "App ID",
+	"GITHUB_APP_KEY_PATH":        fieldname.Key,
+	"GITHUB_APP_ID":              "App ID",
 	"GITHUB_APP_INSTALLATION_ID": "Installation ID",
 }
 

--- a/plugins/scorecard/secret_key.go
+++ b/plugins/scorecard/secret_key.go
@@ -1,0 +1,83 @@
+package scorecard
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func SecretKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.SecretKey,
+		DocsURL:       sdk.URL("https://github.com/ossf/scorecard?tab=readme-ov-file#authentication"),
+		ManagementURL: sdk.URL("https://github.com/settings/installations"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Key,
+				MarkdownDescription: "RSA private key used to authenticate GitHub App for OpenSSF Scorecard. This should be a PEM-formatted private key.",
+				Secret:              true,
+			},
+			{
+				Name:                "App ID",
+				MarkdownDescription: "GitHub App ID for authentication. This is a numeric ID.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Digits: true,
+					},
+				},
+			},
+			{
+				Name:                "Installation ID",
+				MarkdownDescription: "GitHub App Installation ID for the target repository or organization. This is a numeric ID and is required.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Digits: true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: scorecardProvisioner{},
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"GITHUB_APP_KEY_PATH":         fieldname.Key,
+	"GITHUB_APP_ID":               "App ID",
+	"GITHUB_APP_INSTALLATION_ID": "Installation ID",
+}
+
+type scorecardProvisioner struct{}
+
+func (p scorecardProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	// Provision the private key as a file
+	if key, ok := in.ItemFields[fieldname.Key]; ok {
+		keyPath := in.FromTempDir("github-app-key.pem")
+		out.AddSecretFile(keyPath, []byte(key))
+		out.AddEnvVar("GITHUB_APP_KEY_PATH", keyPath)
+	}
+
+	// Provision App ID and Installation ID as environment variables
+	if appID, ok := in.ItemFields["App ID"]; ok && appID != "" {
+		out.AddEnvVar("GITHUB_APP_ID", appID)
+	}
+	if installationID, ok := in.ItemFields["Installation ID"]; ok && installationID != "" {
+		out.AddEnvVar("GITHUB_APP_INSTALLATION_ID", installationID)
+	}
+}
+
+func (p scorecardProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Files get deleted automatically by 1Password CLI and environment variables get wiped when process exits
+}
+
+func (p scorecardProvisioner) Description() string {
+	return "Provision GitHub App private key as file and IDs as environment variables for OpenSSF Scorecard"
+}

--- a/plugins/scorecard/secret_key_test.go
+++ b/plugins/scorecard/secret_key_test.go
@@ -1,0 +1,92 @@
+package scorecard
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func generateTestPrivateKey(t *testing.T) string {
+	// Generate a test RSA private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate test private key: %v", err)
+	}
+
+	// Encode to PEM format
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	})
+
+	return string(privateKeyPEM)
+}
+
+func TestSecretKeyProvisioner(t *testing.T) {
+	testPrivateKey := generateTestPrivateKey(t)
+
+	plugintest.TestProvisioner(t, SecretKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Key: testPrivateKey,
+				"App ID":         "123456",
+				"Installation ID": "7890123",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GITHUB_APP_ID":              "123456",
+					"GITHUB_APP_INSTALLATION_ID": "7890123",
+					"GITHUB_APP_KEY_PATH":        "/tmp/github-app-key.pem",
+				},
+				Files: map[string]sdk.OutputFile{
+					"/tmp/github-app-key.pem": {Contents: []byte(testPrivateKey)},
+				},
+			},
+		},
+		"partial fields": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Key: testPrivateKey,
+				"App ID": "123456",
+				// Installation ID is missing to test handling of partial fields
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GITHUB_APP_ID":       "123456",
+					"GITHUB_APP_KEY_PATH": "/tmp/github-app-key.pem",
+					// GITHUB_APP_INSTALLATION_ID should not be set when field is missing
+				},
+				Files: map[string]sdk.OutputFile{
+					"/tmp/github-app-key.pem": {Contents: []byte(testPrivateKey)},
+				},
+			},
+		},
+	})
+}
+
+func TestSecretKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, SecretKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"GITHUB_APP_KEY_PATH":         "/path/to/key.pem",
+				"GITHUB_APP_ID":               "123456", 
+				"GITHUB_APP_INSTALLATION_ID":  "7890123",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Key:     "/path/to/key.pem",
+						"App ID":          "123456",
+						"Installation ID": "7890123",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/scorecard/secret_key_test.go
+++ b/plugins/scorecard/secret_key_test.go
@@ -6,12 +6,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
-	
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
-	
+
 func generateTestPrivateKey(t *testing.T) string {
 	// Generate a test RSA private key
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -35,8 +35,8 @@ func TestSecretKeyProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, SecretKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
-				fieldname.Key: testPrivateKey,
-				"App ID":         "123456",
+				fieldname.Key:     testPrivateKey,
+				"App ID":          "123456",
 				"Installation ID": "7890123",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -53,7 +53,7 @@ func TestSecretKeyProvisioner(t *testing.T) {
 		"partial fields": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.Key: testPrivateKey,
-				"App ID": "123456",
+				"App ID":      "123456",
 				// Installation ID is missing to test handling of partial fields
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
@@ -74,9 +74,9 @@ func TestSecretKeyImporter(t *testing.T) {
 	plugintest.TestImporter(t, SecretKey().Importer, map[string]plugintest.ImportCase{
 		"environment": {
 			Environment: map[string]string{
-				"GITHUB_APP_KEY_PATH":         "/path/to/key.pem",
-				"GITHUB_APP_ID":               "123456", 
-				"GITHUB_APP_INSTALLATION_ID":  "7890123",
+				"GITHUB_APP_KEY_PATH":        "/path/to/key.pem",
+				"GITHUB_APP_ID":              "123456",
+				"GITHUB_APP_INSTALLATION_ID": "7890123",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{


### PR DESCRIPTION
## Overview

This PR adds plugin support for [OpenSSF's Scorecard CLI](https://scorecard.dev/) targeting GitHub repositories. I specifically opted for [their support to authenticate as a GitHub app](https://github.com/ossf/scorecard?tab=readme-ov-file#authentication) rather than using personal access tokens that tend to never expire.

This involves using the private key, app ID, and installation ID for GitHub's [documented flow](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) where a signed JWT is exchanged for the temporary installation access token.

`scorecard` expects a file path to the private key, so I've used the SDK's file provisioner to load the PEM formatted private key.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test

1. Create a new GitHub app under your account settings (https://github.com/settings/apps)
2. Disable the webhook setting
![image](https://github.com/user-attachments/assets/2f300c8d-206f-4d6f-abe6-fcd4e4ce867a)
4. Under "Permissions" and then "Repository permissions" grant the following:
    - Administration: Read-Only
    - Attestations: Read-Only
    - Contents: Read-Only
    - Commit Statuses: Read-Only
    - Packages: Read-Only
    
    _I believe this is everything required for scorecard to complete its scan successfully, but there may be more required. It's outside of the scope for `op` to define though._
5. Keep "Only on this account" checked
6. Finish up & click "Create GitHub App"
7. Once created, you'll automatically be taken to your app's settings page
8. Make note of of the "App ID" (the entirely numeric value, not the Client ID)
9. Scroll down and click "Generate a private key" (this should automatically download the PEM file to your system) 
10. Scroll back up to the top of the page and click "Install App". Install the application on your account.
11. Make note of the installation number in the URL once completed: `https://github.com/settings/installations/<your-installation-id-here>`
12. Create a new 1Password credential with three values:
    - `key`: upload the private key downloaded in the earlier step
    - `App ID`: copy your app ID from step 7 here (it does not need to be secret)
    - `Installation ID`: copy your installation ID from step 10 here (it does not need to be secret)
13. Initialize the plugin `op plugin init scorecard`
14. Search for the credential you created (you may be prompted to rename the private key field if you used the _SSH Key_ credential type in 1Password)
15. Test scanning one of your repos: `scorecard --repo=https://github.com/<username>/<repo-name>`

## Changelog

Authenticate with GitHub as a GitHub App with OpenSSF's Scorecard CLI using the new `scorecard` plugin to assess your repositories' security best practices.




