### PR TITLE
Remove warning when importing the `1Password/shell-plugins` module in a nix flake

### DIFF
--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -8,7 +8,7 @@ let
       pkgs.runCommand "op-plugin-list" { }
       # 1Password CLI tries to create the config directory automatically, so set a temp XDG_CONFIG_HOME
       # since we don't actually need it for this
-      "mkdir $out && XDG_CONFIG_HOME=$out ${pkgs._1password}/bin/op plugin list | cut -d ' ' -f1 | tail -n +2 > $out/plugins.txt"
+      "mkdir $out && XDG_CONFIG_HOME=$out ${pkgs._1password-cli}/bin/op plugin list | cut -d ' ' -f1 | tail -n +2 > $out/plugins.txt"
     }/plugins.txt");
   getExeName = package:
     # NOTE: SAFETY: This is okay because the `packages` list is also referred
@@ -62,7 +62,7 @@ in {
       name = package;
       value = "op plugin run -- ${package}";
     }) pkg-exe-names);
-    packages = [ pkgs._1password ] ++ cfg.plugins;
+    packages = [ pkgs._1password-cli ] ++ cfg.plugins;
   in mkIf cfg.enable (mkMerge [
     ({
       programs = {


### PR DESCRIPTION
## Overview
Remove warning when importing the `1Password/shell-plugins` module in a nix flake.
```SHELL
evaluation warning: _1password has been renamed to _1password-cli to better follow upstream name usage
```



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
#527 

* Resolves: 
  - #527
  - #496
  - #498

* Relates: 
  - #527
  - #503 (this is probably a superior fix, but it is seemingly being ignored...?)

## How To Test
- Manual Tests: in order to replicate the warning and confirm that it is fixed, you would have to import the package into a separate flake using home-manager, and then run `nix flake check` in that flake. Unfortunately I think you have no choice but to test it this way right now.
- Automated Tests: you probably should be able to `nix flake check` in order to see these kind of warnings in your library directly, however this does not work with the current `flake.nix` configuration you have, and it would require more significant updates to your Nix code in order to support. Perhaps something worth considering.

## Changelog
Nix Support: Remove evaluation warning when importing this module in a nix flake.


