### PR TITLE
Add output to commands that need authentication in Terraform

### DIFF
--- a/plugins/terraform/terraform.go
+++ b/plugins/terraform/terraform.go
@@ -33,6 +33,7 @@ func TerraformCLI() schema.Executable {
 					needsauth.ForCommand("destroy"),
 					needsauth.ForCommand("import"),
 					needsauth.ForCommand("test"),
+					needsauth.ForCommand("output"),
 				),
 			},
 		},


### PR DESCRIPTION
## Overview
Terraform needs authentication for output, this adds it.


## Type of change
- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
`terraform output`

## Changelog
The terraform plugin now authenticates when running `terraform output`
