### PR TITLE
Add shell plugin for Google Gemini

### DIFF
--- a/plugins/gemini/api_key.go
+++ b/plugins/gemini/api_key.go
@@ -1,0 +1,40 @@
+package gemini
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/authentication.md"),
+		ManagementURL: sdk.URL("https://aistudio.google.com/app/apikey"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Google Gemini.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 100,
+					Charset: schema.Charset{
+						Uppercase: true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"GEMINI_API_KEY": fieldname.APIKey,
+	"GOOGLE_API_KEY": fieldname.APIKey,
+}

--- a/plugins/gemini/api_key_test.go
+++ b/plugins/gemini/api_key_test.go
@@ -1,0 +1,55 @@
+package gemini
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{ // TODO: Check if this is correct
+				fieldname.APIKey: "UIYISUJNXTDEEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GEMINI_API_KEY": "UIYISUJNXTDEEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{ // TODO: Check if this is correct
+				"GEMINI_API_KEY": "UIYISUJNXTDEEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "UIYISUJNXTDEEXAMPLE",
+					},
+				},
+			},
+		},
+		// TODO: If you implemented a config file importer, add a test file example in gemini/test-fixtures
+		// and fill the necessary details in the test template below.
+		"config file": {
+			Files: map[string]string{
+				// "~/path/to/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+			// 	{
+			// 		Fields: map[sdk.FieldName]string{
+			// 			fieldname.Token: "UIYISUJNXTDEEXAMPLE",
+			// 		},
+			// 	},
+			},
+		},
+	})
+}

--- a/plugins/gemini/gemini.go
+++ b/plugins/gemini/gemini.go
@@ -1,0 +1,25 @@
+package gemini
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func GoogleGeminiCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Google Gemini CLI",
+		Runs:    []string{"gemini"},
+		DocsURL: sdk.URL("https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/index.md"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/gemini/plugin.go
+++ b/plugins/gemini/plugin.go
@@ -1,0 +1,22 @@
+package gemini
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "gemini",
+		Platform: schema.PlatformInfo{
+			Name:     "Google Gemini",
+			Homepage: sdk.URL("https://gemini.google.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			GoogleGeminiCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Add shell plugin support for the Google Gemini CLI. The CLI can authenticate with an API key if present, otherwise it allows the user to authenticate via OAuth. This plugin only supports the environment variable and not the OAuth capability.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [X] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
Once the plugin is installed and initialised simply run:
  gemini


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->
Authenticate the Google Gemini CLI using Touch ID and other unlock options with 1Password Shell Plugins.


