### PR TITLE
feat(plugin): add `cockroach sql` support

### DIFF
--- a/plugins/cockroachdb/cockroach.go
+++ b/plugins/cockroachdb/cockroach.go
@@ -1,0 +1,26 @@
+package cockroachdb
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func Cockroach() schema.Executable {
+	return schema.Executable{
+		Name:    "cockroach",
+		Runs:    []string{"cockroach"},
+		DocsURL: sdk.URL("https://www.cockroachlabs.com/docs/stable/cockroach-sql.html"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.ForCommand("sql"),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.DatabaseCredentials,
+			},
+		},
+	}
+}

--- a/plugins/cockroachdb/database_credentials.go
+++ b/plugins/cockroachdb/database_credentials.go
@@ -1,0 +1,60 @@
+package cockroachdb
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func DatabaseCredentials() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.DatabaseCredentials,
+		DocsURL:       sdk.URL("https://www.cockroachlabs.com/docs/stable/connection-parameters.html"),
+		ManagementURL: sdk.URL("https://cockroachlabs.cloud/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "CockroachDB host to connect to.",
+			},
+			{
+				Name:                fieldname.Port,
+				MarkdownDescription: "Port used to connect to CockroachDB.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.User,
+				MarkdownDescription: "CockroachDB user to authenticate as.",
+			},
+			{
+				Name:                fieldname.Password,
+				MarkdownDescription: "Password used to authenticate to CockroachDB.",
+				Secret:              true,
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Database,
+				MarkdownDescription: "Database name to connect to. Defaults to 'defaultdb'.",
+				Optional:            true,
+			},
+			{
+				Name:                "insecure",
+				MarkdownDescription: "Connect in insecure mode (skip TLS verification). Set to '1' to skip TLS verification.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"COCKROACH_HOST":     fieldname.Host,
+	"COCKROACH_PORT":     fieldname.Port,
+	"COCKROACH_USER":     fieldname.User,
+	"COCKROACH_PASSWORD": fieldname.Password,
+	"COCKROACH_DATABASE": fieldname.Database,
+	"COCKROACH_INSECURE": "insecure",
+}

--- a/plugins/cockroachdb/database_credentials_test.go
+++ b/plugins/cockroachdb/database_credentials_test.go
@@ -1,0 +1,174 @@
+package cockroachdb
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestDatabaseCredentialsImporter(t *testing.T) {
+	plugintest.TestImporter(t, DatabaseCredentials().Importer, map[string]plugintest.ImportCase{
+		"environment variables - complete": {
+			Environment: map[string]string{
+				"COCKROACH_HOST":     "localhost",
+				"COCKROACH_PORT":     "26257",
+				"COCKROACH_USER":     "root",
+				"COCKROACH_PASSWORD": "password123",
+				"COCKROACH_DATABASE": "defaultdb",
+				"COCKROACH_INSECURE": "1",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:     "localhost",
+						fieldname.Port:     "26257",
+						fieldname.User:     "root",
+						fieldname.Password: "password123",
+						fieldname.Database: "defaultdb",
+						"insecure":         "1",
+					},
+				},
+			},
+		},
+		"environment variables - minimal": {
+			Environment: map[string]string{
+				"COCKROACH_HOST": "cockroach.example.com",
+				"COCKROACH_USER": "admin",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host: "cockroach.example.com",
+						fieldname.User: "admin",
+					},
+				},
+			},
+		},
+		"environment variables - production secure": {
+			Environment: map[string]string{
+				"COCKROACH_HOST":     "prod-cluster.cockroachlabs.cloud",
+				"COCKROACH_PORT":     "26257",
+				"COCKROACH_USER":     "produser",
+				"COCKROACH_PASSWORD": "securepass123",
+				"COCKROACH_DATABASE": "proddb",
+				"COCKROACH_INSECURE": "0",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Host:     "prod-cluster.cockroachlabs.cloud",
+						fieldname.Port:     "26257",
+						fieldname.User:     "produser",
+						fieldname.Password: "securepass123",
+						fieldname.Database: "proddb",
+						"insecure":         "0",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestDatabaseCredentialsProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, DatabaseCredentials().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"local development - insecure": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Host:     "localhost",
+				fieldname.Port:     "26257",
+				fieldname.User:     "root",
+				fieldname.Password: "password123",
+				fieldname.Database: "defaultdb",
+				"insecure":         "1",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"COCKROACH_HOST":     "localhost",
+					"COCKROACH_PORT":     "26257",
+					"COCKROACH_USER":     "root",
+					"COCKROACH_PASSWORD": "password123",
+					"COCKROACH_DATABASE": "defaultdb",
+					"COCKROACH_INSECURE": "1",
+				},
+			},
+		},
+		"production - secure": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Host:     "prod-cluster.cockroachlabs.cloud",
+				fieldname.Port:     "26257",
+				fieldname.User:     "produser",
+				fieldname.Password: "securepass123",
+				fieldname.Database: "proddb",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"COCKROACH_HOST":     "prod-cluster.cockroachlabs.cloud",
+					"COCKROACH_PORT":     "26257",
+					"COCKROACH_USER":     "produser",
+					"COCKROACH_PASSWORD": "securepass123",
+					"COCKROACH_DATABASE": "proddb",
+				},
+			},
+		},
+		"minimal configuration": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Host: "cockroach.example.com",
+				fieldname.User: "admin",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"COCKROACH_HOST": "cockroach.example.com",
+					"COCKROACH_USER": "admin",
+				},
+			},
+		},
+	})
+}
+
+// TestCockroachSQLExecutable tests the cockroach sql executable configuration
+func TestCockroachSQLExecutable(t *testing.T) {
+	plugin := New()
+
+	// Find the cockroach sql executable
+	var cockroachSQL *schema.Executable
+	for _, exec := range plugin.Executables {
+		if exec.Name == "cockroach" {
+			cockroachSQL = &exec
+			break
+		}
+	}
+
+	if cockroachSQL == nil {
+		t.Fatal("cockroach sql executable not found in plugin")
+	}
+
+	// Test that it uses database credentials
+	if len(cockroachSQL.Uses) != 1 {
+		t.Errorf("Expected 1 credential usage, got %d", len(cockroachSQL.Uses))
+	}
+
+	if cockroachSQL.Uses[0].Name != credname.DatabaseCredentials {
+		t.Errorf("Expected DatabaseCredentials, got %s", cockroachSQL.Uses[0].Name)
+	}
+}
+
+// TestPluginValidation tests that the plugin passes all validation checks
+func TestPluginValidation(t *testing.T) {
+	plugin := New()
+
+	// Basic plugin validation
+	if plugin.Name != "cockroachdb" {
+		t.Errorf("Expected plugin name 'cockroachdb', got '%s'", plugin.Name)
+	}
+
+	if len(plugin.Credentials) != 1 {
+		t.Errorf("Expected 1 credential type, got %d", len(plugin.Credentials))
+	}
+
+	if len(plugin.Executables) != 1 {
+		t.Errorf("Expected 1 executable, got %d", len(plugin.Executables))
+	}
+}

--- a/plugins/cockroachdb/plugin.go
+++ b/plugins/cockroachdb/plugin.go
@@ -1,0 +1,22 @@
+package cockroachdb
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "cockroachdb",
+		Platform: schema.PlatformInfo{
+			Name:     "CockroachDB",
+			Homepage: sdk.URL("https://www.cockroachlabs.com"),
+		},
+		Credentials: []schema.CredentialType{
+			DatabaseCredentials(),
+		},
+		Executables: []schema.Executable{
+			Cockroach(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

This PR adds a new shell plugin for CockroachDB that enables secure credential management for the `cockroach sql` command. The plugin supports both local development (insecure mode) and production environments (secure TLS connections) through environment variable configuration.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

tl;dr There's a demo. https://streamable.com/btqzp5. It goes from a clean DB credential creation, renaming fields to match the expected format, etc.

Apologies for the streamable link, but GitHub has a 10mb file size limit and the mp4 demo video was already 58 or so mb.

1. **Set up database credentials in 1Password** with the following fields:
   - Host: `localhost`
   - Port: `26257` 
   - User: `root`
   - Database: `defaultdb`
   - insecure: `1` (for local development)

2. **Test with local CockroachDB instance:**
   ```bash
   # Start CockroachDB in insecure mode
   cockroach start-single-node --insecure --listen-addr=localhost:26257
   
   # Test the plugin
   op run -- cockroach sql
   ```

3. **Test environment variable import:**
   ```bash
   export COCKROACH_HOST=localhost
   export COCKROACH_PORT=26257
   export COCKROACH_USER=root
   export COCKROACH_INSECURE=1
   op plugin init cockroachdb
   ```

4. **Run plugin validation:**
   ```bash
   go run cmd/contrib/main.go cockroachdb/validate
   ```

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

The CockroachDB plugin enables authentication for the `cockroach sql` command using Touch ID and other unlock options with 1Password Shell Plugins.
