### PR TITLE
fix(ci): Don't try to create a PR if one already exists

### DIFF
--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -1,31 +1,31 @@
 # CI job to periodically (once a week) update flake.lock
 name: Update flake dependencies
-
 on:
   schedule:
     - cron: '0 16 * * 5'
   workflow_dispatch: # for allowing manual triggers of the workflow
-
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
-    - name: Update flake.lock and create signed commit with flake.lock changes
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        FILE_TO_COMMIT: flake.lock
-        COMMIT_BRANCH: automation/update-flake-dependencies
-        COMMIT_MESSAGE: "chore(nix): Update Flake dependencies"
-      run: |
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Update flake.lock and create signed commit with flake.lock changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILE_TO_COMMIT: flake.lock
+          COMMIT_BRANCH: automation/update-flake-dependencies
+          COMMIT_MESSAGE: "chore(nix): Update Flake dependencies"
+        run: |
           # fetch remote state
           git fetch
           # if branch exists on remote already
+          BRANCH_EXISTS=false
           if git checkout "$COMMIT_BRANCH" > /dev/null 2>&1; then
             # pull changes
             git pull
+            BRANCH_EXISTS=true
           else
             # otherwise, create the branch and push it to remote
             git checkout -b "$COMMIT_BRANCH"
@@ -41,10 +41,11 @@ jobs:
               --field content=@<(base64 -i $FILE_TO_COMMIT) \
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
-            gh pr create --title "[automation]: Update Flake dependencies" \
-              --body "This is an automated PR to update \`flake.lock\`" \
-              --label "flake.lock automation" \
-              --reviewer mrjones2014 \
-              --reviewer AndyTitu \
-              --base main --head $COMMIT_BRANCH
+            if [ "$BRANCH_EXISTS" = "false" ]; then
+              gh pr create --title "[automation]: Update Flake dependencies" \
+                --body "This is an automated PR to update \`flake.lock\`" \
+                --label "flake.lock automation" \
+                --reviewer mrjones2014 \
+                --base main --head $COMMIT_BRANCH
+            fi
           fi


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Fixes the nix flake update job to skip trying to create a PR if one already exists.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
Green CI


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Fix Nix Flake Update CI job to skip creating a PR if one already exists

