### PR TITLE
refactor(flake): replace flake-utils with nix-systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1756035328,
@@ -36,8 +18,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,24 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils = { url = "github:numtide/flake-utils"; };
+    systems.url = "github:nix-systems/default";
   };
-  outputs = { nixpkgs, flake-utils, ... }:
-    (flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        devShells.default = pkgs.mkShell {
+  outputs = { nixpkgs, systems, ... }:
+    let
+      forAllSystems = function:
+        nixpkgs.lib.genAttrs (import systems) (
+          system: function nixpkgs.legacyPackages.${system}
+        );
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
           name = "Shell with Go toolchain";
           packages = with pkgs; [ go gopls ];
         };
-      })) // {
-        nixosModules.default = import ./nix/nixos.nix;
-        hmModules.default = import ./nix/home-manager.nix;
-      };
+      });
+
+      nixosModules.default = import ./nix/nixos.nix;
+      hmModules.default = import ./nix/home-manager.nix;
+    };
 }


### PR DESCRIPTION
## Overview
This change removes the dependency on `flake-utils` and replaces it with `nix-systems`.  
It introduces a `forAllSystems` helper based on `nixpkgs.lib.genAttrs` to generate development shells for all supported systems.  
The overall structure of the flake remains the same, but the dependency graph is simplified and more explicit.

## Type of change

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)

* Resolves: #
* Relates: #

## How To Test
1. Run `nix develop` on any supported system.  
2. Confirm that a development shell is created with the Go toolchain (`go`, `gopls`).  
3. Validate that `nixosModules` and `hmModules` can still be imported as before.  

## Changelog
Replaced `flake-utils` with `nix-systems` and refactored flake outputs to generate development shells for all supported systems.
