### PR TITLE
fix(ci): Fix command substitution in update flake.lock CI job

### DIFF
--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -38,7 +38,7 @@ jobs:
             # commit via the GitHub API so we get automatic commit signing
             gh api --method PUT /repos/1Password/shell-plugins/contents/$FILE_TO_COMMIT \
               --field message="$COMMIT_MESSAGE" \
-              --field content=@<(base64 -i $FILE_TO_COMMIT) \
+              --field content="$(base64 -w 0 $FILE_TO_COMMIT)" \
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
             if [ "$BRANCH_EXISTS" = "false" ]; then


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Fixes the automated flake.lock update job. There was a typo in the command substitution.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Merge and run the job.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Fix automated "update flake.lock" CI job
