### PR TITLE
[Nix] CI Fixes for `nix flake check`

### DIFF
--- a/.github/workflows/check-flake.yml
+++ b/.github/workflows/check-flake.yml
@@ -1,8 +1,8 @@
 name: Check Nix flake
 on:
-  pull_request_target:
+  pull_request:
     paths:
-      - '*.nix'
+      - '**.nix'
       - flake.lock
   push:
     branches:

--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -47,7 +47,7 @@ in
           map
             (
               package:
-              if (elem (getExeNameasdasdas package) supported_plugins) then
+              if (elem (getExeName package) supported_plugins) then
                 package
               else
                 abort "${getExeName package} is not a valid 1Password Shell Plugin. A list of supported plugins can be found by running `op plugin list` or at: https://developer.1password.com/docs/cli/shell-plugins/"

--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -47,7 +47,7 @@ in
           map
             (
               package:
-              if (elem (getExeName package) supported_plugins) then
+              if (elem (getExeNameasdasdas package) supported_plugins) then
                 package
               else
                 abort "${getExeName package} is not a valid 1Password Shell Plugin. A list of supported plugins can be found by running `op plugin list` or at: https://developer.1password.com/docs/cli/shell-plugins/"


### PR DESCRIPTION
## Overview
There are two changes here:

1. Ensure CI for `nix flake check` is triggered by changes to any .nix file 
1. Ensure that CI for `nix flake check` runs against the most recent commits to the current branch (currently runs against the base branch used to create the PR)

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
* Relates: #533

## How To Test
I don't have the permissions to test this myself, but theoretically a maintainer can test this by doing the following:
1. Create a new branch, and do something that intentionally causes `nix flake check` to fail locally in the file `nix/shell-plugins.nix`
1. Push your changes, and notice that the CI workflow checks for `nix flake check` does not trigger (you can check this [here](https://github.com/1Password/shell-plugins/actions/workflows/check-flake.yml))
1. Push the line change that include `'**.nix'` from this PR, and observe [here](https://github.com/1Password/shell-plugins/actions/workflows/check-flake.yml)) again that now there should be a successful run of `nix flake check` (even though we are expecting an error. This occurs because they are essentially run against `main` rather than the current branch's most recent commits).
1. Push the other line change from this PR (the line that contains `pull_request`), and watch as the checks now should run against the most recent commit on this branch. We now expect them to fail `nix flake check`, like it does locally.
1. Undo the intentional bug introduced in step 1 causing `nix flake check` to fail, and watch as the checks should run successfully.

Note: the above test may not work, as sometimes GitHub PRs won't allow the actions to be updated until after the PR is merged, so if there are any issues this should be considered as well.

A maintainer can run this action manually in order for the checks on this PR to pass: https://github.com/1Password/shell-plugins/actions/runs/17350571621 (or see "workflow awaiting approval" at the bottom of this PR description page where the CI checks are shown).

## Changelog
GitHub CI for `nix flake check` now triggers for any `.nix` file, not just the ones in the project root. Additionally, it now tests the most recent commits on the current branch rather than the branch the PR is based from.

