### PR TITLE
Add OpenTofu plugin

### DIFF
--- a/plugins/tofu/plugin.go
+++ b/plugins/tofu/plugin.go
@@ -1,0 +1,19 @@
+package tofu
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "tofu",
+		Platform: schema.PlatformInfo{
+			Name:     "OpenTofu",
+			Homepage: sdk.URL("https://opentofu.org"),
+		},
+		Executables: []schema.Executable{
+			TofuCLI(),
+		},
+	}
+}

--- a/plugins/tofu/terraform.go
+++ b/plugins/tofu/terraform.go
@@ -1,0 +1,40 @@
+package tofu
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func TofuCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "OpenTofu",
+		Runs:    []string{"tofu"},
+		DocsURL: sdk.URL("https://opentofu.org/docs/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Description: "Credentials to use within the OpenTofu project",
+				SelectFrom: &schema.CredentialSelection{
+					ID:                    "project",
+					IncludeAllCredentials: true,
+					AllowMultiple:         true,
+				},
+				Optional: true,
+				NeedsAuth: needsauth.IfAny(
+					needsauth.ForCommand("refresh"),
+					needsauth.ForCommand("init"),
+					needsauth.ForCommand("state"),
+					needsauth.ForCommand("plan"),
+					needsauth.ForCommand("apply"),
+					needsauth.ForCommand("destroy"),
+					needsauth.ForCommand("import"),
+					needsauth.ForCommand("test"),
+				),
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview

This PR adds a plugin for [OpenTofu](https://opentofu.org).
The plugin is essentially a copy of the terraform plugin.

## Type of change

- [X] Created a new plugin

## How To Test

Run `tofu plan` for `tofu` modules.

## Changelog

Authenticate the OpenTofu CLI with any supported provider using Touch ID and other unlock options with 1Password Shell Plugins.
