### PR TITLE
Added authentication for `terraform output` and `terraform taint` commands

### DIFF
--- a/plugins/terraform/terraform.go
+++ b/plugins/terraform/terraform.go
@@ -33,6 +33,8 @@ func TerraformCLI() schema.Executable {
 					needsauth.ForCommand("destroy"),
 					needsauth.ForCommand("import"),
 					needsauth.ForCommand("test"),
+					needsauth.ForCommand("output"),
+					needsauth.ForCommand("taint"),	
 				),
 			},
 		},


### PR DESCRIPTION
## Overview
<!--  
-->
The Terraform shell plugin provides credentials for commands like `terraform output` and `terraform taint`.

## Type of change
<!--  
Check the box below that describes your change best:
--> 
- [ ] Created a new plugin
- [X] Improved an existing plugin
- [X] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test
<!--
-->
As an example, the `output` subcommand is missing from "needsauth" list. This causes the plugin to omit credential injection for the `output` command. 
A key factor is the use of a remote state file in S3, which requires authentication. 
As a result, the terraform process fails to receive the credentials in its environment. Instead terraform falls back to the configuration in `provider.tf` file. Since that file doesn't contain explicit credentials, the backend authentication fails.



## Changelog
<!--  
-->  
Added credential injection to the environment for `terraform output` and `terraform taint` commands.


