### PR TITLE
Add Google Gemini AI plugin

### DIFF
--- a/plugins/gemini/api_key.go
+++ b/plugins/gemini/api_key.go
@@ -36,5 +36,5 @@ func APIKey() schema.CredentialType {
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
-	"GEMINI_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+	"GEMINI_API_KEY": fieldname.APIKey,
 }

--- a/plugins/gemini/api_key.go
+++ b/plugins/gemini/api_key.go
@@ -1,0 +1,40 @@
+package gemini
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://ai.google.dev/gemini-api/docs/quickstart"),
+		ManagementURL: sdk.URL("https://aistudio.google.com/app/apikey"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Google Gemini CLI.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 39,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"GEMINI_API_KEY": fieldname.APIKey, // TODO: Check if this is correct
+}

--- a/plugins/gemini/api_key_test.go
+++ b/plugins/gemini/api_key_test.go
@@ -1,0 +1,41 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "1y1RvqUVfm6eTlAUfzFfxcEo1EP9dWMdEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GEMINI_API_KEY": "1y1RvqUVfm6eTlAUfzFfxcEo1EP9dWMdEXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"GEMINI_API_KEY": "1y1RvqUVfm6eTlAUfzFfxcEo1EP9dWMdEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "1y1RvqUVfm6eTlAUfzFfxcEo1EP9dWMdEXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/gemini/gemini.go
+++ b/plugins/gemini/gemini.go
@@ -1,0 +1,24 @@
+package gemini
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func GoogleGeminiCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Google Gemini CLI",
+		Runs:    []string{"gemini"},
+		DocsURL: sdk.URL("https://geminicli.com/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/gemini/plugin.go
+++ b/plugins/gemini/plugin.go
@@ -1,0 +1,22 @@
+package gemini
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "gemini",
+		Platform: schema.PlatformInfo{
+			Name:     "Google Gemini CLI",
+			Homepage: sdk.URL("https://geminicli.com/"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			GoogleGeminiCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a new shell plugin for the Google Gemini AI API, enabling secure credential management for the `gemini` CLI tool through 1Password.

### Features
- **API Key credential type** with automatic provisioning via `GEMINI_API_KEY` environment variable
- **Credential importer** to detect and import existing Gemini API keys from environment
- **Full validation** - all schema checks pass
- **Test coverage** - includes tests for both provisioner and importer
- **Documentation** - includes links to Google AI Studio API key management

### Validation Results
✅ All schema validations passed
✅ Plugin builds successfully  
✅ All tests passing
✅ Example secrets generated
✅ Commits signed

### Testing
The plugin has been tested locally using `make gemini/build` and installed to `~/.op/plugins/local/gemini`.

## Checklist
- [x] Plugin created using `make new-plugin`
- [x] Schema validation passes (`make gemini/validate`)
- [x] Plugin builds successfully (`make gemini/build`)
- [x] Tests written and passing
- [x] Example secrets generated (`make gemini/example-secrets`)
- [x] Commits are signed
- [x] No third-party dependencies added
- [x] Follows contribution guidelines

---

Closes #[if there's a related issue]