### PR TITLE
fix(nix): deprecated attributes

### DIFF
--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -105,7 +105,7 @@ in
           # for the Bash and Zsh home-manager modules,
           # the initExtra option is equivalent to Fish's interactiveShellInit
           bash.initExtra = strings.concatStringsSep "\n" posixFunctions;
-          zsh.initExtra = strings.concatStringsSep "\n" posixFunctions;
+          zsh.initContent = mkOrder 1000 (strings.concatStringsSep "\n" posixFunctions);
         };
         home = {
           inherit packages;


### PR DESCRIPTION
Fix https://github.com/1Password/shell-plugins/issues/546.

Fix evaluation warning: `programs.zsh.initExtra` is deprecated, use `programs.zsh.initContent` instead.

See also https://nix-community.github.io/home-manager/options.xhtml\#opt-programs.zsh.initContent.

