### PR TITLE
bundle working with the GitHub Packages RubyGems registry

### DIFF
--- a/plugins/bundler/bundle.go
+++ b/plugins/bundler/bundle.go
@@ -1,0 +1,25 @@
+package bundler
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func BundleCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Bundler CLI",
+		Runs:    []string{"bundle"},
+		DocsURL: sdk.URL("https://bundler.io/man/bundle-install.1.html"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.ForCommand("install"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/bundler/personal_access_token.go
+++ b/plugins/bundler/personal_access_token.go
@@ -17,7 +17,7 @@ func PersonalAccessToken() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Token,
-				MarkdownDescription: "GitHub Personal Access Token used to authenticate to GitHub Package Registry for Bundler.",
+				MarkdownDescription: "GitHub Personal Access Token (classic) used to authenticate to GitHub Package Registry for Bundler. Note: GitHub Packages only supports authentication using a personal access token (classic). For more information, see [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).",
 				Secret:              true,
 				Composition: &schema.ValueComposition{
 					Length: 40,

--- a/plugins/bundler/personal_access_token.go
+++ b/plugins/bundler/personal_access_token.go
@@ -1,0 +1,42 @@
+package bundler
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAccessToken,
+		DocsURL:       sdk.URL("https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"),
+		ManagementURL: sdk.URL("https://github.com/settings/tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "GitHub Personal Access Token used to authenticate to GitHub Package Registry for Bundler.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 40,
+					Prefix: "ghp_",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"BUNDLE_RUBYGEMS__PKG__GITHUB__COM": fieldname.Token,
+}

--- a/plugins/bundler/personal_access_token_test.go
+++ b/plugins/bundler/personal_access_token_test.go
@@ -1,0 +1,41 @@
+package bundler
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "ghp_1234567890123456789012345678901234567890",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"BUNDLE_RUBYGEMS__PKG__GITHUB__COM": "ghp_1234567890123456789012345678901234567890",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"BUNDLE_RUBYGEMS__PKG__GITHUB__COM": "ghp_1234567890123456789012345678901234567890",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "ghp_1234567890123456789012345678901234567890",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/bundler/plugin.go
+++ b/plugins/bundler/plugin.go
@@ -5,7 +5,6 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
-// github action bug
 func New() schema.Plugin {
 	return schema.Plugin{
 		Name: "bundler",

--- a/plugins/bundler/plugin.go
+++ b/plugins/bundler/plugin.go
@@ -1,0 +1,22 @@
+package bundler
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "bundler",
+		Platform: schema.PlatformInfo{
+			Name:     "Ruby Bundler",
+			Homepage: sdk.URL("https://bundler.io"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			BundleCLI(),
+		},
+	}
+}

--- a/plugins/bundler/plugin.go
+++ b/plugins/bundler/plugin.go
@@ -5,6 +5,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
 
+// github action bug
 func New() schema.Plugin {
 	return schema.Plugin{
 		Name: "bundler",


### PR DESCRIPTION
# Overview

Adds a shell plugin for Ruby Bundler working with the GitHub Packages

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry#authenticating-to-github-packages


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test

1. your Gemfile

```ruby
source "https://rubygems.org"

gem "rails"

source "https://rubygems.pkg.github.com/NAMESPACE" do
  gem "GEM_NAME"
end
```

2. Generate your [GitHub personal access token (classic)](https://github.com/settings/tokens)
3. Build the plugin locally: `make bundler/build`
4. Initialize: `op plugin init bundle`
5. Test: `bundle install`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


