### PR TITLE
Add Buildkite CLI plugin

### DIFF
--- a/plugins/buildkite/api_token.go
+++ b/plugins/buildkite/api_token.go
@@ -1,0 +1,96 @@
+package buildkite
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://buildkite.com/docs/platform/cli"),
+		ManagementURL: sdk.URL("https://buildkite.com/user/api-access-tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Organization,
+				MarkdownDescription: "Organization slug for your Buildkite account.",
+				Secret:              false,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+						Symbols:   false,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "API Token used to authenticate with Buildkite.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 45,
+					Prefix: "bkua_",
+					Charset: schema.Charset{
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryBuildkiteConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"BUILDKITE_ORGANIZATION_SLUG": fieldname.Organization,
+	"BUILDKITE_API_TOKEN": fieldname.Token,
+}
+
+// Check if the platform stores the API Token in a local config file, and if so,
+// implement the function below to add support for importing it.
+func TryBuildkiteConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/bk.yaml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToYAML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if len(config.Organizations) == 0 {
+			return
+		}
+
+		for organizationSlug, organization := range config.Organizations {
+
+			if organizationSlug == "" || organization.Token == "" {
+				return
+			}
+
+			out.AddCandidate(sdk.ImportCandidate{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: organization.Token,
+					fieldname.Organization: organizationSlug,
+				},
+				NameHint: importer.SanitizeNameHint(organizationSlug),
+			})
+		}
+	})
+}
+
+type Config struct {
+    Organizations map[string]Organization `yaml:"organizations"`
+}
+
+type Organization struct {
+    Token string `yaml:"api_token"`
+}

--- a/plugins/buildkite/api_token_test.go
+++ b/plugins/buildkite/api_token_test.go
@@ -1,0 +1,91 @@
+package buildkite
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Organization: "example",
+				fieldname.Token: "bkua_abcdefghijklmnopqrstuvwxyz1234567890abcd",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"BUILDKITE_ORGANIZATION_SLUG": "example",
+					"BUILDKITE_API_TOKEN": "bkua_abcdefghijklmnopqrstuvwxyz1234567890abcd",
+				},
+			},
+		},
+	})
+}
+
+func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"BUILDKITE_ORGANIZATION_SLUG": "example",
+				"BUILDKITE_API_TOKEN": "bkua_abcdefghijklmnopqrstuvwxyz1234567890abcd",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Organization: "example",
+						fieldname.Token: "bkua_abcdefghijklmnopqrstuvwxyz1234567890abcd",
+					},
+				},
+			},
+		},
+		"config file default path": {
+			Files: map[string]string{
+				"~/.config/bk.yaml": plugintest.LoadFixture(t, "bk.yaml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Organization: "example",
+						fieldname.Token: "bkua_abcdefghijklmnopqrstuvwxyz1234567890abcd",
+					},
+					NameHint: "example",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Organization: "example2",
+						fieldname.Token: "bkua_abcdefghijklmnopqrstuvwxyz1234567890defg",
+					},
+					NameHint: "example2",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyNeedsAuth(t *testing.T) {
+	plugintest.TestNeedsAuth(t, BuildkiteCLI().NeedsAuth, map[string]plugintest.NeedsAuthCase{
+		"no for --help": {
+			Args: []string{"--help"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for --version": {
+			Args: []string{"--version"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for configure": {
+			Args: []string{"configure"},
+			ExpectedNeedsAuth: false,
+		},
+		"no for without args": {
+			Args: []string{},
+			ExpectedNeedsAuth: false,
+		},
+		"yes for all other commands": {
+			Args: []string{"example"},
+			ExpectedNeedsAuth: true,
+		},
+	})
+}

--- a/plugins/buildkite/bk.go
+++ b/plugins/buildkite/bk.go
@@ -1,0 +1,26 @@
+package buildkite
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func BuildkiteCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Buildkite CLI",
+		Runs:      []string{"bk"},
+		DocsURL:   sdk.URL("https://buildkite.com/docs/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("configure"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIToken,
+			},
+		},
+	}
+}

--- a/plugins/buildkite/plugin.go
+++ b/plugins/buildkite/plugin.go
@@ -1,0 +1,22 @@
+package buildkite
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "buildkite",
+		Platform: schema.PlatformInfo{
+			Name:     "Buildkite",
+			Homepage: sdk.URL("https://buildkite.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIToken(),
+		},
+		Executables: []schema.Executable{
+			BuildkiteCLI(),
+		},
+	}
+}

--- a/plugins/buildkite/test-fixtures/bk.yaml
+++ b/plugins/buildkite/test-fixtures/bk.yaml
@@ -1,0 +1,5 @@
+organizations:
+    example:
+        api_token: bkua_abcdefghijklmnopqrstuvwxyz1234567890abcd
+    example2:
+        api_token: bkua_abcdefghijklmnopqrstuvwxyz1234567890defg


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

This PR adds a shell plugin for the Buildkite CLI: https://buildkite.com/docs/platform/cli.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: N/A
* Relates: N/A

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

### Requirements

- Buildkite account: https://buildkite.com/signup (it's free)
- Buildkite API token: https://buildkite.com/user/api-access-tokens
- API token saved to 1Password with these fields:
  - organization: _your_organization_slug_ (Buildkite > Settings)
  - token: _your_api_token_

### Steps

1. Build the plugin locally: `make buildkite/build`
2. Initialize: `op plugin init buildkite`
3. Test authentication: `bk whoami`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Authenticate the Buildkite CLI using Touch ID and other unlock options with 1Password Shell Plugins.
