### PR TITLE
fix: correct environment variable for output directory

### DIFF
--- a/sdk/provision/file_provisioner.go
+++ b/sdk/provision/file_provisioner.go
@@ -130,7 +130,7 @@ func (p FileProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, o
 	if p.outdirEnvVar != "" {
 		// Populate the specified environment variable with the output dir.
 		dir := filepath.Dir(outpath)
-		out.AddEnvVar(p.outpathEnvVar, dir)
+		out.AddEnvVar(p.outdirEnvVar, dir)
 	}
 
 	// Add args to specify the output path.

--- a/sdk/provision/file_provisioner_test.go
+++ b/sdk/provision/file_provisioner_test.go
@@ -1,0 +1,28 @@
+package provision
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+)
+
+func TestSetOutputDirAsEnvVar(t *testing.T) {
+	provisioner := TempFile(
+		FieldAsFile("Config"),
+		Filename("config.yaml"),
+		SetOutputDirAsEnvVar("OUTPUT_DIR"),
+	)
+
+	plugintest.TestProvisioner(t, provisioner, map[string]plugintest.ProvisionCase{
+		"sets_output_dir_env_var": {
+			ItemFields: map[sdk.FieldName]string{"Config": ""},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{"OUTPUT_DIR": "/tmp"},
+				Files: map[string]sdk.OutputFile{
+					"/tmp/config.yaml": {Contents: []byte("")},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

A env var should be set to the output directory if `SetOutputDirAsEnvVar` is called. The current implementation override the wrong env var. This PR corrects the behavior.

Note: Non of the existing plugins will be effected by this fix (at the time of writing), I am the only one who try to call this function.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related PR(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  


* Relates: #183

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

```bash
go test -count=1 ./sdk/provision -run . -v
```

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Correct environment variable for output directory (SDK)


