### PR TITLE
Prepend arg for defaults-file

### DIFF
--- a/plugins/mysql/database_credentials.go
+++ b/plugins/mysql/database_credentials.go
@@ -43,7 +43,7 @@ func DatabaseCredentials() schema.CredentialType {
 				Optional:            true,
 			},
 		},
-		DefaultProvisioner: provision.TempFile(mysqlConfig, provision.Filename("my.cnf"), provision.AddArgs("--defaults-file={{ .Path }}")),
+		DefaultProvisioner: provision.TempFile(mysqlConfig, provision.Filename("my.cnf"), provision.PrependArgs("--defaults-file={{ .Path }}")),
 		Importer: importer.TryAll(
 			TryMySQLConfigFile("/etc/my.cnf"),
 			TryMySQLConfigFile("/etc/mysql/my.cnf"),

--- a/sdk/provision/file_provisioner.go
+++ b/sdk/provision/file_provisioner.go
@@ -159,7 +159,7 @@ func (p FileProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, o
 			argsResolved[i] = result.String()
 		}
 
-		out.AddArgs(argsResolved...)
+		out.PrependArgs(argsResolved...)
 	}
 }
 

--- a/sdk/provision/file_provisioner.go
+++ b/sdk/provision/file_provisioner.go
@@ -21,6 +21,7 @@ type FileProvisioner struct {
 	outpathEnvVar       string
 	outdirEnvVar        string
 	setOutpathAsArg     bool
+	prependArgs         bool
 	outpathArgTemplates []string
 }
 
@@ -95,6 +96,19 @@ func AddArgs(argTemplates ...string) FileOption {
 	}
 }
 
+// PrependArgs can be used to prepend args to the command line, placing them before any user-provided arguments.
+// This is useful for CLIs like mysql that require certain arguments (e.g., --defaults-file) to be the very first argument.
+// The output path is available as "{{ .Path }}" in each arg.
+// For example:
+// * `PrependArgs("--defaults-file={{ .Path }}")` will result in `--defaults-file=/path/to/tempfile` being placed first.
+func PrependArgs(argTemplates ...string) FileOption {
+	return func(p *FileProvisioner) {
+		p.setOutpathAsArg = true
+		p.prependArgs = true
+		p.outpathArgTemplates = argTemplates
+	}
+}
+
 func (p FileProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
 	contents, err := p.fileContents(in)
 	if err != nil {
@@ -159,7 +173,11 @@ func (p FileProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, o
 			argsResolved[i] = result.String()
 		}
 
-		out.PrependArgs(argsResolved...)
+		if p.prependArgs {
+			out.PrependArgs(argsResolved...)
+		} else {
+			out.AddArgs(argsResolved...)
+		}
 	}
 }
 

--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"slices"
 	"time"
 )
 
@@ -105,6 +106,11 @@ func (out *ProvisionOutput) AddEnvVar(name string, value string) {
 // AddArgs can be used to add additional arguments to the command line of the provision output.
 func (out *ProvisionOutput) AddArgs(args ...string) {
 	out.CommandLine = append(out.CommandLine, args...)
+}
+
+// PrependArgs can be used to insert additional arguments at the beginning of the command line of the provision output.
+func (out *ProvisionOutput) PrependArgs(args ...string) {
+	out.CommandLine = slices.Insert(out.CommandLine, 1, args...)
 }
 
 // AddSecretFile can be used to add a file containing secrets to the provision output.

--- a/sdk/provisioner.go
+++ b/sdk/provisioner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
-	"slices"
 	"time"
 )
 
@@ -110,7 +109,7 @@ func (out *ProvisionOutput) AddArgs(args ...string) {
 
 // PrependArgs can be used to insert additional arguments at the beginning of the command line of the provision output.
 func (out *ProvisionOutput) PrependArgs(args ...string) {
-	out.CommandLine = slices.Insert(out.CommandLine, 1, args...)
+	out.CommandLine = append(out.CommandLine[:1], append(args, out.CommandLine[1:]...)...)
 }
 
 // AddSecretFile can be used to add a file containing secrets to the provision output.


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
This is a continuation of #408, updated to add a separate `PrependArgs` and only use it in the mysql plugin.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #406 

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Update mysql plugin to always add `--defaults-file` as the first argument.

