### PR TITLE
feat(sops): add SOPS plugin for age key provisioning

### DIFF
--- a/plugins/sops/age_secret_key.go
+++ b/plugins/sops/age_secret_key.go
@@ -1,0 +1,40 @@
+package sops
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AgeSecretKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.SecretKey,
+		DocsURL:       sdk.URL("https://github.com/getsops/sops#encrypting-using-age"),
+		ManagementURL: nil,
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.PrivateKey,
+				MarkdownDescription: "Age secret key used by SOPS for encryption and decryption.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Prefix: "AGE-SECRET-KEY-",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SOPS_AGE_KEY": fieldname.PrivateKey,
+}

--- a/plugins/sops/age_secret_key_test.go
+++ b/plugins/sops/age_secret_key_test.go
@@ -1,0 +1,41 @@
+package sops
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAgeSecretKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, AgeSecretKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"SOPS_AGE_KEY": "AGE-SECRET-KEY-1QFWENTHXAAPACFPMXHQCREP64GJE5YTHXLX0RPFSXRSPDJGCR0SSWYNX3D",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.PrivateKey: "AGE-SECRET-KEY-1QFWENTHXAAPACFPMXHQCREP64GJE5YTHXLX0RPFSXRSPDJGCR0SSWYNX3D",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAgeSecretKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AgeSecretKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.PrivateKey: "AGE-SECRET-KEY-1QFWENTHXAAPACFPMXHQCREP64GJE5YTHXLX0RPFSXRSPDJGCR0SSWYNX3D",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SOPS_AGE_KEY": "AGE-SECRET-KEY-1QFWENTHXAAPACFPMXHQCREP64GJE5YTHXLX0RPFSXRSPDJGCR0SSWYNX3D",
+				},
+			},
+		},
+	})
+}

--- a/plugins/sops/helm.go
+++ b/plugins/sops/helm.go
@@ -1,0 +1,27 @@
+package sops
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func HelmCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Helm with SOPS Secrets",
+		Runs:    []string{"helm"},
+		DocsURL: sdk.URL("https://github.com/jkroepke/helm-secrets"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			// Only authenticate when using helm-secrets plugin
+			needsauth.ForCommand("secrets"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.SecretKey,
+			},
+		},
+	}
+}

--- a/plugins/sops/plugin.go
+++ b/plugins/sops/plugin.go
@@ -1,0 +1,23 @@
+package sops
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "sops",
+		Platform: schema.PlatformInfo{
+			Name:     "SOPS",
+			Homepage: sdk.URL("https://github.com/getsops/sops"),
+		},
+		Credentials: []schema.CredentialType{
+			AgeSecretKey(),
+		},
+		Executables: []schema.Executable{
+			SOPSCLI(),
+			HelmCLI(),
+		},
+	}
+}

--- a/plugins/sops/sops.go
+++ b/plugins/sops/sops.go
@@ -1,0 +1,25 @@
+package sops
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func SOPSCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "SOPS CLI",
+		Runs:    []string{"sops"},
+		DocsURL: sdk.URL("https://github.com/getsops/sops"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.SecretKey,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Add shell plugin for SOPS (Secrets OPerationS) that provisions `SOPS_AGE_KEY` environment variable from 1Password vault items.

## Supported CLIs

- `sops` - SOPS CLI for encrypt/decrypt operations
- `helm` - With `secrets` subcommand (helm-secrets plugin)

## Credential Type

- `secret_key` - Age secret key (`AGE-SECRET-KEY-...`)

## Provisioning

Sets `SOPS_AGE_KEY` environment variable with the age secret key.

## NeedsAuth Rules

- **sops**: Authenticates for all commands except `--help` and `--version`
- **helm**: Only authenticates when `secrets` subcommand is used

## Test Commands

```bash
# SOPS CLI
sops -d secrets.yaml
sops -e secrets.yaml

# Helm with SOPS secrets plugin
helm secrets decrypt secrets.yaml
helm secrets edit secrets.yaml
```

## Use Case

SOPS with age encryption is commonly used for:
- Encrypting Kubernetes secrets (helm-secrets)
- Encrypting configuration files
- GitOps workflows where secrets are stored encrypted in git

The plugin allows developers to store their age secret key in 1Password and have it automatically provisioned when running SOPS or helm-secrets commands.