### PR TITLE
feat: add support for openbao

### DIFF
--- a/plugins/openbao/auth_token.go
+++ b/plugins/openbao/auth_token.go
@@ -1,0 +1,57 @@
+package openbao
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AuthToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AuthToken,
+		DocsURL:       sdk.URL("https://openbao.org/docs/concepts/tokens/"),
+		ManagementURL: nil,
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to OpenBao.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+			{
+				Name:                fieldname.Address,
+				MarkdownDescription: "Default address of the Vault server to use for this auth token.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Namespace,
+				MarkdownDescription: "Default namespace to use for this auth token.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryOpenBaoConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"BAO_TOKEN":     fieldname.Token,
+	"BAO_ADDR":      fieldname.Address,
+	"BAO_NAMESPACE": fieldname.Namespace,
+}
+
+func TryOpenBaoConfigFile() sdk.Importer {
+	return importer.NoOp()
+}
+

--- a/plugins/openbao/auth_token_test.go
+++ b/plugins/openbao/auth_token_test.go
@@ -1,0 +1,49 @@
+package openbao
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAuthTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, Token().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string {
+				fieldname.Token: "s.UrpjvNwnaPjTFFj2RAyEXAMPLE",
+				fieldname.Address: "https://bao.acme.com",
+				fieldname.Namespace: "default",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"BAO_TOKEN":     "s.UrpjvNwnaPjTFFj2RAyEXAMPLE",
+					"BAO_ADDR":      "https://bao.acme.com",
+					"BAO_NAMESPACE": "default",
+				},
+			},
+		},
+	})
+}
+
+func TestAuthTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, Token().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string {
+				"BAO_TOKEN":     "s.UrpjvNwnaPjTFFj2RAyEXAMPLE",
+				"BAO_ADDR":      "https://bao.acme.com",
+				"BAO_NAMESPACE": "default",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "s.UrpjvNwnaPjTFFj2RAyEXAMPLE",
+						fieldname.Address: "https://bao.acme.com",
+						fieldname.Namespace: "default",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/openbao/bao.go
+++ b/plugins/openbao/bao.go
@@ -1,0 +1,25 @@
+package openbao
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func OpenBaoCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "OpenBao CLI", // TODO: Check if this is correct
+		Runs:      []string{"bao"},
+		DocsURL:   sdk.URL("https://openbao.com/docs/cli"), // TODO: Replace with actual URL
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AuthToken,
+			},
+		},
+	}
+}

--- a/plugins/openbao/plugin.go
+++ b/plugins/openbao/plugin.go
@@ -1,0 +1,22 @@
+package openbao
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "openbao",
+		Platform: schema.PlatformInfo{
+			Name:     "OpenBao",
+			Homepage: sdk.URL("https://openbao.org"),
+		},
+		Credentials: []schema.CredentialType{
+			AuthToken(),
+		},
+		Executables: []schema.Executable{
+			OpenBaoCLI(),
+		},
+	}
+}


### PR DESCRIPTION

## Overview

Add support for OpenBAO command line tools (bao). This is an open source, community-driven fork of Vault managed by the Linux Foundation.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

The easiest test is to use:
  bao token lookup
Which should verify that the BAO_TOKEN (and optional BAO_ADDR and BAO_NAMESPACE) are appropriately
set.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Add support for OpenBao CLI 

