### PR TITLE
fix: resolve support for Oh Dear CLI 5.x

### DIFF
--- a/plugins/ohdear/api_token.go
+++ b/plugins/ohdear/api_token.go
@@ -1,6 +1,9 @@
 package ohdear
 
 import (
+	"context"
+	"encoding/json"
+
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
 	"github.com/1Password/shell-plugins/sdk/provision"
@@ -12,7 +15,7 @@ import (
 func APIToken() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIToken,
-		DocsURL:       sdk.URL("https://ohdear.app/docs/integrations/the-oh-dear-api#get-your-api-token"),
+		DocsURL:       sdk.URL("https://ohdear.app/docs/api/introduction#get-your-api-token"),
 		ManagementURL: sdk.URL("https://ohdear.app/user/api-tokens"),
 		Fields: []schema.CredentialField{
 			{
@@ -29,12 +32,53 @@ func APIToken() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		DefaultProvisioner: provision.TempFile(configFile,
+			provision.Filename("config.json"),
+			provision.SetPathAsEnvVar("OHDEAR_CONFIG_FILE_PATH"),
+		),
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryOhdearConfigFile(),
 		)}
 }
 
 var defaultEnvVarMapping = map[string]sdk.FieldName{
 	"OHDEAR_API_TOKEN": fieldname.Token,
+}
+
+func configFile(in sdk.ProvisionInput) ([]byte, error) {
+	config := Config{
+		Token: in.ItemFields[fieldname.Token],
+	}
+
+	contents, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(contents), nil
+}
+
+func TryOhdearConfigFile() sdk.Importer {
+	return importer.TryFile("~/.ohdear/config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.Token == "" {
+			return
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token: config.Token,
+			},
+		})
+	})
+}
+
+type Config struct {
+	Token string `json:"token"`
 }

--- a/plugins/ohdear/api_token_test.go
+++ b/plugins/ohdear/api_token_test.go
@@ -16,7 +16,12 @@ func TestAPITokenProvisioner(t *testing.T) {
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"OHDEAR_API_TOKEN": "SZ5rluwzbtMyyQFQNoeqEFbpVbTL0ItsXEXAMPLE",
+					"OHDEAR_CONFIG_FILE_PATH": "/tmp/config.json",
+				},
+				Files: map[string]sdk.OutputFile{
+					"/tmp/config.json": {
+						Contents: []byte(plugintest.LoadFixture(t, "import_or_provision")),
+					},
 				},
 			},
 		},
@@ -24,6 +29,20 @@ func TestAPITokenProvisioner(t *testing.T) {
 }
 
 func TestAPITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
+		"config file": {
+			Files: map[string]string{
+				"~/.ohdear/config.json": plugintest.LoadFixture(t, "import_or_provision"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "SZ5rluwzbtMyyQFQNoeqEFbpVbTL0ItsXEXAMPLE",
+					},
+				},
+			},
+		},
+	})
 	plugintest.TestImporter(t, APIToken().Importer, map[string]plugintest.ImportCase{
 		"environment": {
 			Environment: map[string]string{

--- a/plugins/ohdear/test-fixtures/import_or_provision
+++ b/plugins/ohdear/test-fixtures/import_or_provision
@@ -1,0 +1,1 @@
+{"token":"SZ5rluwzbtMyyQFQNoeqEFbpVbTL0ItsXEXAMPLE"}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Oh Dear CLI 5.x removed support for the `OHDEAR_API_TOKEN` environment variable, and moved to a static configuration file (`~/.ohdear/config.json`).

This PR generates a temporary config file and passes the path via a new env variable.


## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

This requires [Oh Dear CLI 5.1.1](https://github.com/ohdearapp/ohdear-cli/releases/tag/5.1.1) or later.

`ohdear get-me`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


The Oh Dear plugin now checks for the `~/.ohdear/config.json` file and attempts to import credentials.