### PR TITLE
feat(terraform): require authentication for workspace subcommands

### DIFF
--- a/plugins/terraform/terraform.go
+++ b/plugins/terraform/terraform.go
@@ -33,6 +33,7 @@ func TerraformCLI() schema.Executable {
 					needsauth.ForCommand("destroy"),
 					needsauth.ForCommand("import"),
 					needsauth.ForCommand("test"),
+					needsauth.ForCommand("workspace"),
 				),
 			},
 		},


### PR DESCRIPTION
Follow-up https://github.com/1Password/shell-plugins/issues/581

This PR adds the 'workspace' subcommand to the NeedsAuth list, ensuring it is marked as requiring authentication via 1Password.

## Overview
<!--  
Provide a high-level description of this change.   
-->



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #581 

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

1. Ensure the Terraform plugin is configured with credentials provisioned via 1Password.
2. Run the following commands inside a Terraform project:

> - terraform workspace list
> - terraform workspace select
> - terraform workspace new

3. Confirm that each command triggers authentication via 1Password and executes successfully using provisioned credentials.


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

Terraform 'workspace' subcommands trigger authentication via 1Password.