### PR TITLE
Add OpenTofu CLI support to Terraform plugin

### DIFF
--- a/plugins/terraform/opentofu.go
+++ b/plugins/terraform/opentofu.go
@@ -1,0 +1,40 @@
+package terraform
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func OpenTofuCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "OpenTofu CLI",
+		Runs:    []string{"tofu"},
+		DocsURL: sdk.URL("https://opentofu.org/docs/cli/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Description: "Credentials to use within the OpenTofu project",
+				SelectFrom: &schema.CredentialSelection{
+					ID:                    "project",
+					IncludeAllCredentials: true,
+					AllowMultiple:         true,
+				},
+				Optional: true,
+				NeedsAuth: needsauth.IfAny(
+					needsauth.ForCommand("refresh"),
+					needsauth.ForCommand("init"),
+					needsauth.ForCommand("state"),
+					needsauth.ForCommand("plan"),
+					needsauth.ForCommand("apply"),
+					needsauth.ForCommand("destroy"),
+					needsauth.ForCommand("import"),
+					needsauth.ForCommand("test"),
+				),
+			},
+		},
+	}
+}

--- a/plugins/terraform/plugin.go
+++ b/plugins/terraform/plugin.go
@@ -14,6 +14,7 @@ func New() schema.Plugin {
 		},
 		Executables: []schema.Executable{
 			TerraformCLI(),
+			OpenTofuCLI(),
 		},
 	}
 }


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

Add OpenTofu as a new executable in the existing Terraform plugin, allowing `tofu` commands to authenticate via 1Password shell plugins.

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #483
* Relates: #583 #553

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

This change should work identically to the `terraform` version of the plug in, only it will act with `tofu`.

To test:

1. Install OpenTofu (`brew install opentofu` on macos)
2. Ensure tofu is aliased to op: `alias tofu='op plugin run -- tofu'`
3. In an empty dir create `main.tf` with the following config:

```hcl
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 5.0"
    }
  }
}

provider "aws" {}

data "aws_caller_identity" "current" {}

output "account_id" {
  value = data.aws_caller_identity.current.account_id
}

output "caller_arn" {
  value = data.aws_caller_identity.current.arn
}

output "caller_user_id" {
  value = data.aws_caller_identity.current.user_id
}
```

Run `tofu init`

Choose an `AWS Access Key` credential type.

The command should complete successfully.

Optionally run `tofu apply`

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

* Terraform plugin now supports OpenTofu authentication via `tofu` command line.
