### PR TITLE
Sourcegraph - Update AccessToken schema

### DIFF
--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -12,15 +12,15 @@ import (
 func AccessToken() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.AccessToken,
-		DocsURL:       sdk.URL("https://docs.sourcegraph.com/cli"),
-		ManagementURL: sdk.URL("https://sourcegraph.com/user/settings/tokens"),
+		DocsURL:       sdk.URL("https://sourcegraph.com/docs/cli"),
+		ManagementURL: sdk.URL("https://sourcegraph.com/settings/tokens"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Endpoint,
-				MarkdownDescription: "Base URL for your Sourcegraph instance.",
-				Secret:              false,
-				Optional:            true,
+				AlternativeNames:    []string{"Website","URL"},
+				MarkdownDescription: "Base URL for your Sourcegraph instance. Should start with https://",
 				Composition: &schema.ValueComposition{
+					Prefix:  "https://",
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
@@ -30,13 +30,16 @@ func AccessToken() schema.CredentialType {
 			},
 			{
 				Name:                fieldname.Token,
-				MarkdownDescription: "Token used to authenticate to Sourcegraph.",
+				AlternativeNames:    []string{"AccessToken"},
+				MarkdownDescription: "Access token used to authenticate to Sourcegraph. Should start with sgp_",
 				Secret:              true,
 				Composition: &schema.ValueComposition{
-					Length: 40,
+					Length:  60,
+					Prefix:  "sgp_",
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
+						Specific:  []rune{'_'},
 					},
 				},
 			},

--- a/plugins/sourcegraph/access_token.go
+++ b/plugins/sourcegraph/access_token.go
@@ -17,10 +17,10 @@ func AccessToken() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.Endpoint,
-				AlternativeNames:    []string{"Website","URL"},
+				AlternativeNames:    []string{"Website", "URL"},
 				MarkdownDescription: "Base URL for your Sourcegraph instance. Should start with https://",
 				Composition: &schema.ValueComposition{
-					Prefix:  "https://",
+					Prefix: "https://",
 					Charset: schema.Charset{
 						Lowercase: true,
 						Digits:    true,
@@ -34,9 +34,9 @@ func AccessToken() schema.CredentialType {
 				MarkdownDescription: "Access token used to authenticate to Sourcegraph. Should start with sgp_",
 				Secret:              true,
 				Composition: &schema.ValueComposition{
-					Length:  60,
-					Prefix:  "sgp_",
+					Prefix: "sgp_",
 					Charset: schema.Charset{
+						Uppercase: true,
 						Lowercase: true,
 						Digits:    true,
 						Specific:  []rune{'_'},

--- a/plugins/sourcegraph/access_token_test.go
+++ b/plugins/sourcegraph/access_token_test.go
@@ -13,12 +13,12 @@ func TestAccessTokenProvisioner(t *testing.T) {
 		"default": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.Endpoint: "https://sourcegraph.com",
-				fieldname.Token:    "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+				fieldname.Token:    "sgp_fake0123456789ab_fake0123456789abcdef0123456789abcdef0123",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
 					"SRC_ENDPOINT":     "https://sourcegraph.com",
-					"SRC_ACCESS_TOKEN": "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+					"SRC_ACCESS_TOKEN": "sgp_fake0123456789ab_fake0123456789abcdef0123456789abcdef0123",
 				},
 			},
 		},
@@ -30,13 +30,13 @@ func TestAccessTokenImporter(t *testing.T) {
 		"environment": {
 			Environment: map[string]string{
 				"SRC_ENDPOINT":     "https://sourcegraph.com",
-				"SRC_ACCESS_TOKEN": "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+				"SRC_ACCESS_TOKEN": "sgp_fake0123456789ab_fake0123456789abcdef0123456789abcdef0123",
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{
 					Fields: map[sdk.FieldName]string{
 						fieldname.Endpoint: "https://sourcegraph.com",
-						fieldname.Token:    "bqrv8bpqtplf7xv5lkk6oxfldtttmhzx4example",
+						fieldname.Token:    "sgp_fake0123456789ab_fake0123456789abcdef0123456789abcdef0123",
 					},
 				},
 			},

--- a/plugins/sourcegraph/src.go
+++ b/plugins/sourcegraph/src.go
@@ -11,7 +11,7 @@ func SourcegraphCLI() schema.Executable {
 	return schema.Executable{
 		Name:    "Sourcegraph CLI",
 		Runs:    []string{"src"},
-		DocsURL: sdk.URL("https://docs.sourcegraph.com/cli"),
+		DocsURL: sdk.URL("https://sourcegraph.com/docs/cli"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),


### PR DESCRIPTION
## Overview

- Updated the schema, and doc links
- Added support for the new `sgp_` v3 token format support
- Updated input validation rules to include capital hex chars `A-F`
- Endpoint now required

## Type of change

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

- None

## How To Test

1. Create an account on https://sourcegraph.com/search
2. Go to your [user settings](https://sourcegraph.com/settings/tokens) and create an access token
3. Install [src-cli](https://sourcegraph.com/docs/cli/quickstart)
4. Run `op plugin init src` 
5. `Locate your Sourcegraph Access Token`: `Import into 1Password...`
6. `Enter or paste in the value of the Endpoint`: Paste in `https://sourcegraph.com`
7. `Enter or paste in the value of the Token`: Paste in the access token created earlier
8. Run `src login`

```shell
$ src login
✔︎ Authenticated as <user> on <endpoint>
```

Entry created in 1Password desktop app:
<img width="455" height="461" alt="image" src="https://github.com/user-attachments/assets/d0053200-c6d1-41c0-b68e-977872012278" />

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

The Sourcegraph plugin now supports the current `sgp_` access token format, and the Endpoint field is required since each token is tied to a specific endpoint.