### PR TITLE
nix: avoid IFD

### DIFF
--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, config, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 import ./shell-plugins.nix {
   inherit pkgs;
   inherit lib;

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, config, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 import ./shell-plugins.nix {
   inherit pkgs;
   inherit lib;

--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -96,10 +96,8 @@ in
       };
     };
   };
-
   config =
     let
-
       # executable names as strings, e.g. `pkgs.gh` => `"gh"`, `pkgs.awscli2` => `"aws"`
       pkg-exe-names = map getExeName cfg.plugins;
       plugin-support-check = mkPluginSupportCheck pkg-exe-names;
@@ -149,7 +147,7 @@ in
         };
         home = {
           inherit packages;
-          sessionVariables = { OP_PLUGIN_ALIASES_SOURCED = "1"; };
+           sessionVariables = { OP_PLUGIN_ALIASES_SOURCED = "1"; };
         };
       })
       (optionalAttrs (!is-home-manager) {

--- a/nix/shell-plugins.nix
+++ b/nix/shell-plugins.nix
@@ -1,19 +1,16 @@
-{ pkgs, lib, config, is-home-manager, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  is-home-manager,
+  ...
+}:
 with lib;
 let
   cfg = config.programs._1password-shell-plugins;
 
-  supported_plugins = splitString "\n" (
-    lib.readFile "${
-      # get the list of supported plugin executable names
-      pkgs.runCommand "op-plugin-list" { }
-        # 1Password CLI tries to create the config directory automatically, so set a temp XDG_CONFIG_HOME
-        # since we don't actually need it for this
-        "mkdir $out && XDG_CONFIG_HOME=$out ${
-          if cfg.package != null then cfg.package else pkgs._1password-cli
-        }/bin/op plugin list | cut -d ' ' -f1 | tail -n +2 > $out/plugins.txt"
-    }/plugins.txt"
-  );
+  opPkg = if cfg.package != null then cfg.package else pkgs._1password-cli;
+
   getExeName =
     package:
     # NOTE: SAFETY: This is okay because the `packages` list is also referred
@@ -22,6 +19,62 @@ let
     # compute the dependency tree, even though we're discarding string context here,
     # since the packages are still referred to below without discarding string context.
     strings.unsafeDiscardStringContext (baseNameOf (getExe package));
+
+  mkPluginSupportCheck =
+    pluginExeNames:
+    let
+      configuredFile = pkgs.writeText "op-configured-plugins.txt" (
+        # ensure trailing newline
+        lib.concatStringsSep "\n" pluginExeNames + "\n"
+      );
+    in
+    pkgs.runCommand "op-shell-plugins-support-check"
+      {
+        nativeBuildInputs = [
+          pkgs.coreutils
+          pkgs.gnugrep
+          pkgs.gawk
+          pkgs.gnused
+        ];
+      }
+      ''
+        		set -euo pipefail
+
+        		export XDG_CONFIG_HOME="$TMPDIR/xdg-config"
+        		mkdir -p "$XDG_CONFIG_HOME"
+
+        		"${opPkg}/bin/op" plugin list \
+        		  | awk 'NR>1 { print $1 }' \
+        		  | sed '/^$/d' \
+        		  | sort -u > supported.txt
+
+        		if [ ! -s supported.txt ]; then
+        		  echo "ERROR: \`op plugin list\` produced no supported plugins (unexpected output or CLI failure)." >&2
+        		  echo "Raw output was:" >&2
+        		  "${opPkg}/bin/op" plugin list >&2 || true
+        		  exit 1
+        		fi
+
+        		missing=0
+        		while IFS= read -r plugin; do
+        		  [ -z "$plugin" ] && continue
+        		  if ! grep -Fxq "$plugin" supported.txt; then
+        		    echo "ERROR: Configured plugin '$plugin' is not supported by this op binary (\`${opPkg.name or "op"}\`)." >&2
+        		    missing=1
+        		  fi
+        		done < "${configuredFile}"
+
+        		if [ "$missing" -ne 0 ]; then
+        		  echo "" >&2
+        		  echo "Supported plugins according to \`op plugin list\`:" >&2
+        		  cat supported.txt >&2
+        		  exit 1
+        		fi
+        		mkdir -p "$out"
+        		echo "Plugin support check passed." > "$out/check.txt"
+
+        				  '';
+
 in
 {
   options = {
@@ -39,28 +92,17 @@ in
           ]
         '';
         description = "CLI Packages to enable 1Password Shell Plugins for; ensure that a Shell Plugin exists by checking the docs: https://developer.1password.com/docs/cli/shell-plugins/";
-        # this is a bit of a hack to do option validation;
-        # ensure that the list of packages include only packages
-        # for which the executable has a supported 1Password Shell Plugin
-        apply =
-          package_list:
-          map
-            (
-              package:
-              if (elem (getExeName package) supported_plugins) then
-                package
-              else
-                abort "${getExeName package} is not a valid 1Password Shell Plugin. A list of supported plugins can be found by running `op plugin list` or at: https://developer.1password.com/docs/cli/shell-plugins/"
-            )
-            package_list;
+
       };
     };
   };
 
   config =
     let
+
       # executable names as strings, e.g. `pkgs.gh` => `"gh"`, `pkgs.awscli2` => `"aws"`
       pkg-exe-names = map getExeName cfg.plugins;
+      plugin-support-check = mkPluginSupportCheck pkg-exe-names;
       # Explanation:
       # Map over `cfg.plugins` (the value of the `plugins` option provided by the user)
       # and for each package specified, get the executable name, then create a shell function
@@ -80,20 +122,16 @@ in
       #  end
       # ```
       # where `{pkg}` is the executable name of the package
-      posixFunctions = map
-        (package: ''
-          ${package}() {
-            op plugin run -- ${package} "$@";
-          }
-        '')
-        pkg-exe-names;
-      fishFunctions = map
-        (package: ''
-          function ${package} --wraps "${package}" --description "1Password Shell Plugin for ${package}"
-            op plugin run -- ${package} $argv
-          end
-        '')
-        pkg-exe-names;
+      posixFunctions = map (package: ''
+        ${package}() {
+          op plugin run -- ${package} "$@";
+        }
+      '') pkg-exe-names;
+      fishFunctions = map (package: ''
+        function ${package} --wraps "${package}" --description "1Password Shell Plugin for ${package}"
+          op plugin run -- ${package} $argv
+        end
+      '') pkg-exe-names;
       packages = lib.optional (cfg.package != null) cfg.package ++ cfg.plugins;
       initExtraPosix = strings.concatStringsSep "\n" posixFunctions;
     in
@@ -102,6 +140,7 @@ in
         programs.fish.interactiveShellInit = strings.concatStringsSep "\n" fishFunctions;
       }
       (optionalAttrs is-home-manager {
+        home.checks = [ plugin-support-check ];
         programs = {
           # for the Bash and Zsh home-manager modules,
           # the initExtra/initContent option is equivalent to Fish's interactiveShellInit
@@ -114,9 +153,9 @@ in
         };
       })
       (optionalAttrs (!is-home-manager) {
+        system.checks = [ plugin-support-check ];
         programs = {
-          bash.interactiveShellInit =
-            strings.concatStringsSep "\n" posixFunctions;
+          bash.interactiveShellInit = strings.concatStringsSep "\n" posixFunctions;
           zsh.interactiveShellInit = strings.concatStringsSep "\n" posixFunctions;
         };
         environment = {
@@ -126,4 +165,3 @@ in
       })
     ]);
 }
-


### PR DESCRIPTION
## Overview
Removed IFD (import from derivation) from the nix module 

the current implementation requires building the op executable before anything else can happen which results in significant slowdown of system builds as everything is halted until 1password builds. Removing IFD allows the nix module to be built without building the op executable first, which should speed up system builds significantly. The check still happens, but as a derivation instead of a plugin, which means it can be built in parallel with the rest of the system instead of halting everything until it's done.



## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #
* Relates: #

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->
Attempt to use the nix module on home-manager or nixos



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

- Removed IFD (import from derivation) from the nix module, allowing it to be built in parallel with the rest of the system instead of halting everything until it's done.
