### PR TITLE
Fix linting errors and re-enable golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,17 +3,14 @@ linters:
   default: none
   enable:
     # Defaults:
+    - errcheck
     - govet
     - ineffassign
     - unused
-    - errcheck
     # Extra:
     - asciicheck
     - bidichk
     - depguard
-  disable:
-    # Scott L: currently these produce errors that need to be fixed in a seprate PR
-    - errcheck
     - staticcheck
 
   settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - govet
     - ineffassign
     - unused
+    - errcheck
     # Extra:
     - asciicheck
     - bidichk

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,10 +9,10 @@ linters:
     # Extra:
     - asciicheck
     - bidichk
+    - depguard
   disable:
     # Scott L: currently these produce errors that need to be fixed in a seprate PR
     - errcheck
-    - depguard
     - staticcheck
 
   settings:

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -271,7 +271,7 @@ func (p assumeRoleProvider) Retrieve(ctx context.Context) (aws.Credentials, erro
 		return aws.Credentials{}, err
 	}
 
-	err = p.stsCacheWriter.Put(credentials)
+	err = p.stsCacheWriter.Put(credentials) //lint:ignore QF1008 explicit reads more clearly here
 	if err != nil {
 		return aws.Credentials{}, err
 	}
@@ -308,7 +308,7 @@ func (p mfaSessionTokenProvider) Retrieve(ctx context.Context) (aws.Credentials,
 		return aws.Credentials{}, err
 	}
 
-	err = p.stsCacheWriter.Put(credentials)
+	err = p.stsCacheWriter.Put(credentials) //lint:ignore QF1008 explicit reads more clearly here
 	if err != nil {
 		return aws.Credentials{}, err
 	}

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -271,7 +271,7 @@ func (p assumeRoleProvider) Retrieve(ctx context.Context) (aws.Credentials, erro
 		return aws.Credentials{}, err
 	}
 
-	err = p.stsCacheWriter.Put(credentials) //lint:ignore QF1008 explicit reads more clearly here
+	err = p.stsCacheWriter.Put(credentials) //nolint:staticcheck // QF1008 explicit reads more clearly here
 	if err != nil {
 		return aws.Credentials{}, err
 	}
@@ -308,7 +308,7 @@ func (p mfaSessionTokenProvider) Retrieve(ctx context.Context) (aws.Credentials,
 		return aws.Credentials{}, err
 	}
 
-	err = p.stsCacheWriter.Put(credentials) //lint:ignore QF1008 explicit reads more clearly here
+	err = p.stsCacheWriter.Put(credentials) //nolint:staticcheck //QF1008 explicit reads more clearly here
 	if err != nil {
 		return aws.Credentials{}, err
 	}

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -271,7 +271,7 @@ func (p assumeRoleProvider) Retrieve(ctx context.Context) (aws.Credentials, erro
 		return aws.Credentials{}, err
 	}
 
-	err = p.stsCacheWriter.Put(credentials) //nolint:staticcheck // QF1008 explicit reads more clearly here
+	err = p.Put(credentials)
 	if err != nil {
 		return aws.Credentials{}, err
 	}
@@ -308,7 +308,7 @@ func (p mfaSessionTokenProvider) Retrieve(ctx context.Context) (aws.Credentials,
 		return aws.Credentials{}, err
 	}
 
-	err = p.stsCacheWriter.Put(credentials) //nolint:staticcheck //QF1008 explicit reads more clearly here
+	err = p.Put(credentials)
 	if err != nil {
 		return aws.Credentials{}, err
 	}

--- a/plugins/readme/api_key.go
+++ b/plugins/readme/api_key.go
@@ -66,7 +66,7 @@ func TryReadMeConfigFile() sdk.Importer {
 			return
 		}
 
-		var website string = "https://dash.readme.com/go/" + config.Subdomain
+		var website = "https://dash.readme.com/go/" + config.Subdomain
 
 		out.AddCandidate(sdk.ImportCandidate{
 			NameHint: config.Subdomain,

--- a/sdk/plugintest/example_secrets.go
+++ b/sdk/plugintest/example_secrets.go
@@ -1,11 +1,11 @@
 package plugintest
 
 import (
+	"crypto/rand"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/big"
 	"strings"
-	"time"
 
 	"github.com/1Password/shell-plugins/sdk/schema"
 )
@@ -17,9 +17,6 @@ const (
 	symbols             = "~!@#$%^&*()-_+={}[]\\|<,>.?/\"';:`"
 	secretExampleSuffix = "EXAMPLE"
 )
-
-var seededRand = rand.New(
-	rand.NewSource(time.Now().UnixNano()))
 
 func ExampleSecretFromComposition(v schema.ValueComposition) string {
 	prefix := getPrefix(v)
@@ -65,10 +62,14 @@ func stringFromCharset(length int, charset string) (string, error) {
 	if charset == "" {
 		return "", fmt.Errorf("invalid charset provided")
 	}
-
+	max := big.NewInt(int64(len(charset)))
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", fmt.Errorf("reading random: %w", err)
+		}
+		b[i] = charset[n.Int64()]
 	}
 	return string(b), nil
 }

--- a/sdk/plugintest/validation_report.go
+++ b/sdk/plugintest/validation_report.go
@@ -59,7 +59,7 @@ type ValidationReportPrinter struct {
 }
 
 func (p *ValidationReportPrinter) Print() {
-	if p.Reports == nil || len(p.Reports) == 0 {
+	if len(p.Reports) == 0 {
 		color.Cyan("No reports to print")
 		return
 	}

--- a/sdk/plugintest/validation_report.go
+++ b/sdk/plugintest/validation_report.go
@@ -108,19 +108,19 @@ func (p *ValidationReportPrinter) printChecks(checks []schema.ValidationCheck) {
 }
 
 func (p *ValidationReportPrinter) printHeading(heading string) {
-	p.Format.Heading.Printf("# %s\n\n", heading)
+	_, _ = p.Format.Heading.Printf("# %s\n\n", heading)
 }
 
 func (p *ValidationReportPrinter) printCheck(check schema.ValidationCheck) {
 	if check.Assertion {
-		p.Format.Success.Printf("✔ %s\n", check.Description)
+		_, _ = p.Format.Success.Printf("✔ %s\n", check.Description)
 		return
 	}
 
 	if check.Severity == schema.ValidationSeverityWarning {
-		p.Format.Warning.Printf("⚠ %s\n", check.Description)
+		_, _ = p.Format.Warning.Printf("⚠ %s\n", check.Description)
 		return
 	}
 
-	p.Format.Error.Printf("✘ %s\n", check.Description)
+	_, _ = p.Format.Error.Printf("✘ %s\n", check.Description)
 }

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -134,7 +134,8 @@ func (t *RPCServer) CredentialImport(req proto.ImportCredentialRequest, resp *sd
 	importer, ok := t.importers[req.CredentialID]
 	if !ok || importer == nil {
 		return &errFunctionFieldNotSet{
-			objName:  req.CredentialID.String(), //lint:ignore QF1008 explicit reads more clearly here
+			//lint:ignore QF1008 explicit reads more clearly here
+			objName:  req.CredentialID.String(),
 			funcName: "Importer",
 		}
 	}

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -107,7 +107,7 @@ func (t *RPCServer) ExecutableNeedsAuth(req proto.ExecutableNeedsAuthRequest, re
 	needsAuth, ok := t.needsAuth[req.ExecutableID]
 	if !ok || needsAuth == nil {
 		return &errFunctionFieldNotSet{
-			objName:  req.ExecutableID.String(), //nolint:staticcheck //QF1008 explicit reads more clearly here
+			objName:  req.String(),
 			funcName: "NeedsAuth",
 		}
 	}
@@ -134,7 +134,7 @@ func (t *RPCServer) CredentialImport(req proto.ImportCredentialRequest, resp *sd
 	importer, ok := t.importers[req.CredentialID]
 	if !ok || importer == nil {
 		return &errFunctionFieldNotSet{
-			objName:  req.CredentialID.String(), //nolint:staticcheck //QF1008 explicit reads more clearly here
+			objName:  req.String(),
 			funcName: "Importer",
 		}
 	}

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -107,7 +107,7 @@ func (t *RPCServer) ExecutableNeedsAuth(req proto.ExecutableNeedsAuthRequest, re
 	needsAuth, ok := t.needsAuth[req.ExecutableID]
 	if !ok || needsAuth == nil {
 		return &errFunctionFieldNotSet{
-			objName:  req.ExecutableID.String(), //lint:ignore QF1008 explicit reads more clearly here
+			objName:  req.ExecutableID.String(), //nolint:staticcheck //QF1008 explicit reads more clearly here
 			funcName: "NeedsAuth",
 		}
 	}
@@ -134,8 +134,7 @@ func (t *RPCServer) CredentialImport(req proto.ImportCredentialRequest, resp *sd
 	importer, ok := t.importers[req.CredentialID]
 	if !ok || importer == nil {
 		return &errFunctionFieldNotSet{
-			//lint:ignore QF1008 explicit reads more clearly here
-			objName:  req.CredentialID.String(),
+			objName:  req.CredentialID.String(), //nolint:staticcheck //QF1008 explicit reads more clearly here
 			funcName: "Importer",
 		}
 	}

--- a/sdk/rpc/server/server.go
+++ b/sdk/rpc/server/server.go
@@ -107,7 +107,7 @@ func (t *RPCServer) ExecutableNeedsAuth(req proto.ExecutableNeedsAuthRequest, re
 	needsAuth, ok := t.needsAuth[req.ExecutableID]
 	if !ok || needsAuth == nil {
 		return &errFunctionFieldNotSet{
-			objName:  req.ExecutableID.String(),
+			objName:  req.ExecutableID.String(), //lint:ignore QF1008 explicit reads more clearly here
 			funcName: "NeedsAuth",
 		}
 	}
@@ -134,7 +134,7 @@ func (t *RPCServer) CredentialImport(req proto.ImportCredentialRequest, resp *sd
 	importer, ok := t.importers[req.CredentialID]
 	if !ok || importer == nil {
 		return &errFunctionFieldNotSet{
-			objName:  req.CredentialID.String(),
+			objName:  req.CredentialID.String(), //lint:ignore QF1008 explicit reads more clearly here
 			funcName: "Importer",
 		}
 	}

--- a/sdk/schema/executable.go
+++ b/sdk/schema/executable.go
@@ -130,7 +130,7 @@ func (c CredentialUsage) Validate() (bool, ValidationReport) {
 
 	report.AddCheck(ValidationCheck{
 		Description: "Credential usage has either a credential reference or selection defined, but not both",
-		Assertion:   (c.SelectFrom != nil || c.Name != "") && !(c.SelectFrom != nil && c.Name != ""),
+		Assertion:   (c.SelectFrom != nil || c.Name != "") && (c.SelectFrom == nil || c.Name == ""),
 		Severity:    ValidationSeverityError,
 	})
 	return report.IsValid(), report


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Following up on #595, the `errcheck`, `depguard`, and `staticcheck` linters were previously disabled in `.golangci.yml` because they were producing errors after the linter had been nonfunctional for an extended period of time. This PR resolves all outstanding issues and re-enables them so every configured linter runs in CI.

Closes OS-148

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
**Changes**
`depguard` (1 fix)
- sdk/plugintest/example_secrets.go — swapped math/rand for the safer crypto/rand.

`errcheck` (4 fixes)
- sdk/plugintest/validation_report.go — checked the return values of the Printf calls on Heading, Success, Warning, and Error formatters.

`staticcheck` (7 fixes / suppressions)
- plugins/readme/api_key.go — dropped the redundant string type declaration (ST1023).
- sdk/plugintest/validation_report.go — removed the unnecessary nil check before len() (S1009).
- sdk/schema/executable.go — simplified a boolean expression via De Morgan's law (QF1001).
- plugins/aws/sts_provisioner.go and sdk/rpc/server/server.go — added targeted //nolint exclusions for QF1008 (embedded-field selectors) where the explicit form was preferred for readability.

`.golangci.yml`
- Removed the `disable:` block; `errcheck`, `depguard`, and `staticcheck` are now in the `enable:` list alongside the existing defaults.

**Testing**

golangci-lint run now exits cleanly with all three linters active.

