### PR TITLE
Add GitHub Copilot CLI shell plugin

### DIFF
--- a/plugins/copilot/auth_token.go
+++ b/plugins/copilot/auth_token.go
@@ -1,0 +1,31 @@
+package copilot
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AuthToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AuthToken,
+		DocsURL:       sdk.URL("https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli"),
+		ManagementURL: sdk.URL("https://github.com/settings/personal-access-tokens/new"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to GitHub Copilot.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"COPILOT_GITHUB_TOKEN": fieldname.Token,
+}

--- a/plugins/copilot/auth_token_test.go
+++ b/plugins/copilot/auth_token_test.go
@@ -1,0 +1,50 @@
+package copilot
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const exampleCopilotToken = "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE"
+
+func TestAuthTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AuthToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: exampleCopilotToken,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"COPILOT_GITHUB_TOKEN": exampleCopilotToken,
+				},
+			},
+		},
+	})
+}
+
+func TestAuthTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AuthToken().Importer, map[string]plugintest.ImportCase{
+		"COPILOT_GITHUB_TOKEN": {
+			Environment: map[string]string{
+				"COPILOT_GITHUB_TOKEN": exampleCopilotToken,
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: exampleCopilotToken,
+					},
+				},
+			},
+		},
+		"GITHUB_TOKEN ignored": {
+			Environment: map[string]string{
+				"COPILOT_GITHUB_TOKEN": "",
+				"GITHUB_TOKEN":         exampleCopilotToken,
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{},
+		},
+	})
+}

--- a/plugins/copilot/copilot.go
+++ b/plugins/copilot/copilot.go
@@ -1,0 +1,22 @@
+package copilot
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func CopilotCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "GitHub Copilot CLI",
+		Runs:      []string{"copilot"},
+		DocsURL:   sdk.URL("https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AuthToken,
+			},
+		},
+	}
+}

--- a/plugins/copilot/copilot.go
+++ b/plugins/copilot/copilot.go
@@ -9,10 +9,16 @@ import (
 
 func CopilotCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "GitHub Copilot CLI",
-		Runs:      []string{"copilot"},
-		DocsURL:   sdk.URL("https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Name:    "GitHub Copilot CLI",
+		Runs:    []string{"copilot"},
+		DocsURL: sdk.URL("https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("login"),
+			needsauth.NotForExactArgs("version"),
+			needsauth.NotWhenContainsArgs("completion"),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.AuthToken,

--- a/plugins/copilot/plugin.go
+++ b/plugins/copilot/plugin.go
@@ -1,0 +1,22 @@
+package copilot
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "copilot",
+		Platform: schema.PlatformInfo{
+			Name:     "GitHub Copilot",
+			Homepage: sdk.URL("https://github.com/features/copilot/cli"),
+		},
+		Credentials: []schema.CredentialType{
+			AuthToken(),
+		},
+		Executables: []schema.Executable{
+			CopilotCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a new GitHub Copilot shell plugin for the `copilot` CLI.

The plugin provisions an auth token through `COPILOT_GITHUB_TOKEN`, which is the environment variable supported by Copilot CLI. It also supports importing an existing token from `COPILOT_GITHUB_TOKEN`.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

N/A

## How To Test

Run plugin validation:

```shell
make copilot/validate
```

Run the Copilot plugin tests:

```shell
go test ./plugins/copilot
```

Example authenticated command for functional testing:

```shell
copilot -p "explain this repo" -s
```

## Changelog
Authenticate the GitHub Copilot CLI using Touch ID and other unlock options with 1Password Shell Plugins.
