### PR TITLE
Add JetBrains Junie CLI shell plugin

### DIFF
--- a/plugins/junie/api_key.go
+++ b/plugins/junie/api_key.go
@@ -1,0 +1,31 @@
+package junie
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://junie.jetbrains.com/docs/environment-variables.html"),
+		ManagementURL: sdk.URL("https://junie.jetbrains.com/cli"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "Junie API key used to authenticate to JetBrains Junie CLI.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"JUNIE_API_KEY": fieldname.APIKey,
+}

--- a/plugins/junie/api_key_test.go
+++ b/plugins/junie/api_key_test.go
@@ -1,0 +1,72 @@
+package junie
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"junie api key": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "perm-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"JUNIE_API_KEY": "perm-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				},
+			},
+		},
+		"does not provision provider api keys": {
+			ItemFields: map[sdk.FieldName]string{
+				sdk.FieldName("Anthropic API Key"):  "sk-ant-api03-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				sdk.FieldName("OpenAI API Key"):     "sk-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				sdk.FieldName("Google API Key"):     "AI-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				sdk.FieldName("Grok API Key"):       "xai-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				sdk.FieldName("OpenRouter API Key"): "sk-or-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{},
+			},
+		},
+		"does not provision project or task runtime inputs": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Project:     "/tmp/example-project",
+				sdk.FieldName("Task"): "Review and fix any code quality issues in the latest commit",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"junie api key environment": {
+			Environment: map[string]string{
+				"JUNIE_API_KEY": "perm-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "perm-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+					},
+				},
+			},
+		},
+		"provider api key environment": {
+			Environment: map[string]string{
+				"JUNIE_ANTHROPIC_API_KEY":  "sk-ant-api03-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				"JUNIE_OPENAI_API_KEY":     "sk-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				"JUNIE_GOOGLE_API_KEY":     "AI-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				"JUNIE_GROK_API_KEY":       "xai-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+				"JUNIE_OPENROUTER_API_KEY": "sk-or-yEyY18xzH5IiiORdCDzstp1h2xrxCydfh9tjFveUyEXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{},
+		},
+	})
+}

--- a/plugins/junie/junie.go
+++ b/plugins/junie/junie.go
@@ -12,7 +12,10 @@ func JunieCLI() schema.Executable {
 		Name:      "JetBrains Junie CLI",
 		Runs:      []string{"junie"},
 		DocsURL:   sdk.URL("https://junie.jetbrains.com/docs/junie-cli-usage.html"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIKey,

--- a/plugins/junie/junie.go
+++ b/plugins/junie/junie.go
@@ -1,0 +1,22 @@
+package junie
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func JunieCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "JetBrains Junie CLI",
+		Runs:      []string{"junie"},
+		DocsURL:   sdk.URL("https://junie.jetbrains.com/docs/junie-cli-usage.html"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/junie/junie.go
+++ b/plugins/junie/junie.go
@@ -9,9 +9,9 @@ import (
 
 func JunieCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "JetBrains Junie CLI",
-		Runs:      []string{"junie"},
-		DocsURL:   sdk.URL("https://junie.jetbrains.com/docs/junie-cli-usage.html"),
+		Name:    "JetBrains Junie CLI",
+		Runs:    []string{"junie"},
+		DocsURL: sdk.URL("https://junie.jetbrains.com/docs/junie-cli-usage.html"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/junie/plugin.go
+++ b/plugins/junie/plugin.go
@@ -1,0 +1,22 @@
+package junie
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "junie",
+		Platform: schema.PlatformInfo{
+			Name:     "JetBrains Junie",
+			Homepage: sdk.URL("https://junie.jetbrains.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			JunieCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a new JetBrains Junie shell plugin for authenticating the `junie` CLI with a Junie API key from 1Password.

The plugin provisions and imports `JUNIE_API_KEY` only. Provider-specific BYOK variables such as `JUNIE_OPENAI_API_KEY` and `JUNIE_ANTHROPIC_API_KEY` are intentionally not supported by this plugin.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

N/A

## How To Test

For functional testing, initialize the plugin with a Junie API key and run an authenticated Junie command, for example:

```sh
junie "Summarize this project"
```

## Changelog
Authenticate JetBrains Junie CLI using Touch ID and other unlock options with 1Password Shell Plugins.