### PR TITLE
Add Kiro shell plugin

### DIFF
--- a/plugins/kiro/api_key.go
+++ b/plugins/kiro/api_key.go
@@ -1,0 +1,39 @@
+package kiro
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://kiro.dev/docs/cli/authentication/"),
+		ManagementURL: sdk.URL("https://app.kiro.dev"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Kiro.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Prefix: "ksk_",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"KIRO_API_KEY": fieldname.APIKey,
+}

--- a/plugins/kiro/api_key_test.go
+++ b/plugins/kiro/api_key_test.go
@@ -1,0 +1,43 @@
+package kiro
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const exampleAPIKey = "ksk_12345678"
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: exampleAPIKey,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"KIRO_API_KEY": exampleAPIKey,
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"KIRO_API_KEY": exampleAPIKey,
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: exampleAPIKey,
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/kiro/kiro.go
+++ b/plugins/kiro/kiro.go
@@ -1,0 +1,22 @@
+package kiro
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func KiroCLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Kiro CLI",
+		Runs:      []string{"kiro-cli"},
+		DocsURL:   sdk.URL("https://kiro.dev/docs/cli/"),
+		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/kiro/kiro.go
+++ b/plugins/kiro/kiro.go
@@ -9,9 +9,9 @@ import (
 
 func KiroCLI() schema.Executable {
 	return schema.Executable{
-		Name:      "Kiro CLI",
-		Runs:      []string{"kiro-cli"},
-		DocsURL:   sdk.URL("https://kiro.dev/docs/cli/"),
+		Name:    "Kiro CLI",
+		Runs:    []string{"kiro-cli"},
+		DocsURL: sdk.URL("https://kiro.dev/docs/cli/"),
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),

--- a/plugins/kiro/kiro.go
+++ b/plugins/kiro/kiro.go
@@ -12,7 +12,12 @@ func KiroCLI() schema.Executable {
 		Name:      "Kiro CLI",
 		Runs:      []string{"kiro-cli"},
 		DocsURL:   sdk.URL("https://kiro.dev/docs/cli/"),
-		NeedsAuth: needsauth.NotForHelpOrVersion(),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("login"),
+			needsauth.NotWhenContainsArgs("logout"),
+		),
 		Uses: []schema.CredentialUsage{
 			{
 				Name: credname.APIKey,

--- a/plugins/kiro/plugin.go
+++ b/plugins/kiro/plugin.go
@@ -1,0 +1,22 @@
+package kiro
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "kiro",
+		Platform: schema.PlatformInfo{
+			Name:     "Kiro",
+			Homepage: sdk.URL("https://kiro.dev"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			KiroCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a new Kiro shell plugin for authenticating the Kiro CLI with a Kiro API key. The plugin provisions and imports the documented `KIRO_API_KEY` environment variable for `kiro-cli`.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

N/A

## How To Test

To test authentication manually after initializing the plugin:

```
kiro-cli whoami
```

## Changelog
Authenticate the Kiro CLI with API keys using 1Password Shell Plugins.