### PR TITLE
appending advanced configuration to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Still not sure where or how to begin? We're happy to help! You can:
 By default, `op plugin init` writes its configuration to `~/.config/op/plugins.sh`
 and manages that file for you. If you'd rather keep your plugin configuration in
 your own dotfiles (for example, tracked in version control), you can define the
-shell functions yourself instead.
+shell functions yourself and source them in your shell's configuration file. 
 
 ### Step 1: Define the plugin functions
 Shell functions for each shell should follow this pattern. In this case, 
@@ -92,18 +92,18 @@ end
 
 ### Step 2: Tell `op` your plugins are already configured
 
-Set `OP_PLUGINS_SOURCED=1` so 1Password CLI knows the shell plugins have
+Set `OP_PLUGIN_ALIASES_SOURCED=1` so 1Password CLI knows the shell plugins have
 already been set up:
 
 ### bash / zsh
 
 ```bash
-export OP_PLUGINS_SOURCED="1"
+export OP_PLUGIN_ALIASES_SOURCED="1"
 ```
 
 ### fish
 ```fish
-set -x OP_PLUGINS_SOURCED 1
+set -x OP_PLUGIN_ALIASES_SOURCED 1
 ```
 
 > **Note:** `op plugin init <plugin>` edits `~/.config/op/plugins.sh` directly and won't update your own dotfiles, so configure plugins manually as shown above.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,52 @@ Still not sure where or how to begin? We're happy to help! You can:
 - Book a free [pairing session](https://calendly.com/d/grs-x2h-pmb/1password-shell-plugins-pairing-session) with one of our developers
 - Join the [Developer Slack workspace](https://developer.1password.com/joinslack), and ask us any questions there
 
+## Advanced Configuration
+### Managing shell plugins in your own dotfiles
+
+By default, `op plugin init` writes its configuration to `~/.config/op/plugins.sh`
+and manages that file for you. If you'd rather keep your plugin configuration in
+your own dotfiles (for example, tracked in version control), you can define the
+shell functions yourself instead.
+
+### 1. Define the plugin functions
+Shell functions for each shell should follow this pattern. In this case, 
+
+### bash / zsh
+
+```bash
+gh() {
+  op plugin run -- gh "$@"
+}
+```
+
+### fish
+
+```fish
+function gh --wraps gh --description "1Password shell plugin for GitHub CLI"
+  op plugin run -- gh $argv
+end
+```
+
+### 2. Tell `op` your plugins are already configured
+
+Set `OP_PLUGINS_SOURCED=1` so the 1Password CLI knows the shell plugins have
+already been set up:
+
+### bash / zsh
+
+```bash
+export OP_PLUGINS_SOURCED="1"
+```
+
+### fish
+```fish
+set -x OP_PLUGINS_SOURCED 1
+```
+
+> **Note:** `op plugin init <plugin>` edits `~/.config/op/plugins.sh` directly and won't update your own dotfiles, so configure plugins manually as shown above.
+
+
 ## 💙 Community & Support
 
 - File an [issue](https://github.com/1Password/shell-plugins/issues/new/choose) for bugs and feature requests

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and manages that file for you. If you'd rather keep your plugin configuration in
 your own dotfiles (for example, tracked in version control), you can define the
 shell functions yourself instead.
 
-### 1. Define the plugin functions
+### Step 1: Define the plugin functions
 Shell functions for each shell should follow this pattern. In this case, 
 
 ### bash / zsh
@@ -90,9 +90,9 @@ function gh --wraps gh --description "1Password shell plugin for GitHub CLI"
 end
 ```
 
-### 2. Tell `op` your plugins are already configured
+### Step 2: Tell `op` your plugins are already configured
 
-Set `OP_PLUGINS_SOURCED=1` so the 1Password CLI knows the shell plugins have
+Set `OP_PLUGINS_SOURCED=1` so 1Password CLI knows the shell plugins have
 already been set up:
 
 ### bash / zsh


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->
Adds documentation for a workaround for people who choose to stow or symlink their `op`-related configuration files. 

The existing header levels didn't necessarily make it easy to slot this in, and as is, won't scale if we add docs for any additional "advanced configurations". But since we've got some custom stuff going on here I didn't want to step too far out of my lane and refactor the header levels in the readme. 
## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: #378 

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->



## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  


