### PR TITLE
Add GitHub Enterprise support to the gh CLI provisioner.

### DIFF
--- a/plugins/github/personal_access_token.go
+++ b/plugins/github/personal_access_token.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
-	"github.com/1Password/shell-plugins/sdk/provision"
 	"github.com/1Password/shell-plugins/sdk/schema"
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
@@ -38,7 +37,7 @@ func PersonalAccessToken() schema.CredentialType {
 				Optional:            true,
 			},
 		},
-		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		DefaultProvisioner: GitHubCLIProvisioner{},
 		Importer: importer.TryAll(
 			importer.TryEnvVarPair(defaultEnvVarMapping),
 			importer.TryAllEnvVars(fieldname.Token, "GH_TOKEN", "GITHUB_PAT"),

--- a/plugins/github/personal_access_token_test.go
+++ b/plugins/github/personal_access_token_test.go
@@ -121,6 +121,7 @@ func TestPersonalAccessTokenProvisioner(t *testing.T) {
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
+					"GH_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
 					"GITHUB_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
 				},
 			},

--- a/plugins/github/provisioner.go
+++ b/plugins/github/provisioner.go
@@ -1,0 +1,64 @@
+package github
+
+import (
+	"context"
+	"strings"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const (
+	githubHost    = "github.com"
+	localhostHost = "github.localhost"
+	tenancyHost   = "ghe.com"
+)
+
+// GitHubCLIProvisioner provisions auth tokens using the environment variables expected by the GitHub CLI.
+// GitHub.com and GitHub Enterprise Cloud (*.ghe.com) use GH_TOKEN and GITHUB_TOKEN.
+// GitHub Enterprise Server uses GH_ENTERPRISE_TOKEN and GITHUB_ENTERPRISE_TOKEN with GH_HOST.
+type GitHubCLIProvisioner struct{}
+
+func (p GitHubCLIProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	token, ok := in.ItemFields[fieldname.Token]
+	if !ok {
+		return
+	}
+
+	host := strings.ToLower(strings.TrimSpace(in.ItemFields[fieldname.Host]))
+
+	if usesEnterpriseToken(host) {
+		out.AddEnvVar("GH_ENTERPRISE_TOKEN", token)
+		out.AddEnvVar("GITHUB_ENTERPRISE_TOKEN", token)
+		if host != "" {
+			out.AddEnvVar("GH_HOST", host)
+		}
+		return
+	}
+
+	out.AddEnvVar("GH_TOKEN", token)
+	out.AddEnvVar("GITHUB_TOKEN", token)
+	if host != "" && host != githubHost {
+		out.AddEnvVar("GH_HOST", host)
+	}
+}
+
+func usesEnterpriseToken(host string) bool {
+	if host == "" || host == githubHost || host == localhostHost {
+		return false
+	}
+
+	return !isTenancyHost(host)
+}
+
+func isTenancyHost(host string) bool {
+	return strings.HasSuffix(host, "."+tenancyHost)
+}
+
+func (p GitHubCLIProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Environment variables get wiped automatically when the process exits.
+}
+
+func (p GitHubCLIProvisioner) Description() string {
+	return "Provision GitHub CLI environment variables: GH_TOKEN, GITHUB_TOKEN, GH_ENTERPRISE_TOKEN, GITHUB_ENTERPRISE_TOKEN, GH_HOST"
+}

--- a/plugins/github/provisioner_test.go
+++ b/plugins/github/provisioner_test.go
@@ -1,0 +1,76 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestGitHubCLIProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, GitHubCLIProvisioner{}, map[string]plugintest.ProvisionCase{
+		"github.com": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GH_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GITHUB_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+				},
+			},
+		},
+		"github.com with explicit host": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+				fieldname.Host:  "github.com",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GH_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GITHUB_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+				},
+			},
+		},
+		"GitHub Enterprise Server": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+				fieldname.Host:  "enterprise.github.com",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GH_ENTERPRISE_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GITHUB_ENTERPRISE_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GH_HOST":                 "enterprise.github.com",
+				},
+			},
+		},
+		"GitHub Enterprise Cloud": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+				fieldname.Host:  "company.ghe.com",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GH_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GITHUB_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GH_HOST":        "company.ghe.com",
+				},
+			},
+		},
+		"github.localhost": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+				fieldname.Host:  "github.localhost",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"GH_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GITHUB_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
+					"GH_HOST":        "github.localhost",
+				},
+			},
+		},
+	})
+}

--- a/plugins/github/provisioner_test.go
+++ b/plugins/github/provisioner_test.go
@@ -55,7 +55,7 @@ func TestGitHubCLIProvisioner(t *testing.T) {
 				Environment: map[string]string{
 					"GH_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
 					"GITHUB_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
-					"GH_HOST":        "company.ghe.com",
+					"GH_HOST":      "company.ghe.com",
 				},
 			},
 		},
@@ -68,7 +68,7 @@ func TestGitHubCLIProvisioner(t *testing.T) {
 				Environment: map[string]string{
 					"GH_TOKEN":     "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
 					"GITHUB_TOKEN": "github_pat_OYXGsaLFxgNy9msXs44LFNzg3wh0VsXRGycViVc0iKPOqczc1QKlB3ZVVrm5ESukqKR8nE3jzPBEXAMPLE",
-					"GH_HOST":        "github.localhost",
+					"GH_HOST":      "github.localhost",
 				},
 			},
 		},


### PR DESCRIPTION
## Overview

The GitHub shell plugin previously always provisioned `GITHUB_TOKEN`, which does not work for GitHub Enterprise Server hosts. This change adds a host-aware provisioner that sets the environment variables `gh` expects based on the credential's **Host** field:

- **github.com** (default): `GH_TOKEN`, `GITHUB_TOKEN`
- **GitHub Enterprise Cloud** (`*.ghe.com`): `GH_TOKEN`, `GITHUB_TOKEN`, `GH_HOST`
- **GitHub Enterprise Server** (other hosts): `GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN`, `GH_HOST`

When separate 1Password items are configured for github.com and Enterprise Server, both sets of variables are provisioned so `gh` can authenticate to either host.

## Type of change

- [ ] Created a new plugin
- [x] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

* Resolves: #137
* Relates: #

## How To Test

1. Run the GitHub plugin tests:

   ```sh
   go test ./plugins/github/...
   ```

2. Configure a 1Password item with a personal access token and **Host** set to a GitHub Enterprise Server hostname (for example `enterprise.github.com`), then enable the GitHub shell plugin for `gh`.

3. Run `gh auth status` or `gh repo list` and confirm the process receives `GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN`, and `GH_HOST` instead of only `GH_TOKEN` / `GITHUB_TOKEN`.

4. Optionally configure a second item for github.com (with **Host** empty) alongside the Enterprise item and confirm both token variables are available when running `gh`.

## Changelog

The GitHub plugin now provisions `GH_ENTERPRISE_TOKEN` for GitHub Enterprise Server hosts and supports authenticating to both github.com and Enterprise when separate credentials are configured.
