### PR TITLE
Add Cline shell plugin

### DIFF
--- a/plugins/cline/api_key.go
+++ b/plugins/cline/api_key.go
@@ -1,0 +1,31 @@
+package cline
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://docs.cline.bot/api/authentication"),
+		ManagementURL: sdk.URL("https://app.cline.bot"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "Cline API key used to authenticate to the Cline CLI.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"CLINE_API_KEY": fieldname.APIKey,
+}

--- a/plugins/cline/api_key_test.go
+++ b/plugins/cline/api_key_test.go
@@ -1,0 +1,43 @@
+package cline
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const exampleAPIKey = "abcdef1234567890abcdef1234567890"
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: exampleAPIKey,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"CLINE_API_KEY": exampleAPIKey,
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"CLINE_API_KEY": exampleAPIKey,
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: exampleAPIKey,
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/cline/cline.go
+++ b/plugins/cline/cline.go
@@ -1,0 +1,26 @@
+package cline
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func ClineCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Cline CLI",
+		Runs:    []string{"cline"},
+		DocsURL: sdk.URL("https://docs.cline.bot"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("auth"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/cline/plugin.go
+++ b/plugins/cline/plugin.go
@@ -1,0 +1,22 @@
+package cline
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "cline",
+		Platform: schema.PlatformInfo{
+			Name:     "Cline",
+			Homepage: sdk.URL("https://cline.bot"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			ClineCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a new Cline shell plugin for the `cline` CLI.

The plugin provisions an auth token through `CLINE_API_KEY`. It also supports importing an existing token from `CLINE_API_KEY`.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

N/A

## How To Test

Run plugin validation:

```shell
make cline/validate
```

Run the Cline plugin tests:

```shell
go test ./plugins/cline
```

Example authenticated command for functional testing:

```shell
cline "explain this repo"
```

## Changelog
Authenticate the Cline CLI using Touch ID and other unlock options with 1Password Shell Plugins.
