### PR TITLE
Add Cursor shell plugin

### DIFF
--- a/plugins/cursor/api_key.go
+++ b/plugins/cursor/api_key.go
@@ -1,0 +1,39 @@
+package cursor
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://cursor.com/docs/cli/reference/authentication"),
+		ManagementURL: sdk.URL("https://cursor.com/dashboard"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Cursor CLI.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Prefix: "crsr_",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"CURSOR_API_KEY": fieldname.APIKey,
+}

--- a/plugins/cursor/api_key_test.go
+++ b/plugins/cursor/api_key_test.go
@@ -1,0 +1,43 @@
+package cursor
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const exampleAPIKey = "crsr_12345678"
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: exampleAPIKey,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"CURSOR_API_KEY": exampleAPIKey,
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"CURSOR_API_KEY": exampleAPIKey,
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: exampleAPIKey,
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/cursor/cursor.go
+++ b/plugins/cursor/cursor.go
@@ -1,0 +1,27 @@
+package cursor
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func CursorCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Cursor CLI",
+		Runs:    []string{"agent"},
+		DocsURL: sdk.URL("https://cursor.com/docs/cli/overview"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("login"),
+			needsauth.NotWhenContainsArgs("logout"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/cursor/cursor.go
+++ b/plugins/cursor/cursor.go
@@ -15,8 +15,8 @@ func CursorCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
-			needsauth.NotWhenContainsArgs("login"),
-			needsauth.NotWhenContainsArgs("logout"),
+			needsauth.NotForExactArgs("login"),
+			needsauth.NotForExactArgs("logout"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/cursor/cursor.go
+++ b/plugins/cursor/cursor.go
@@ -17,6 +17,8 @@ func CursorCLI() schema.Executable {
 			needsauth.NotWithoutArgs(),
 			needsauth.NotForExactArgs("login"),
 			needsauth.NotForExactArgs("logout"),
+			needsauth.NotForExactArgs("status"),
+			needsauth.NotWhenContainsArgs("--api-key"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/cursor/plugin.go
+++ b/plugins/cursor/plugin.go
@@ -1,0 +1,22 @@
+package cursor
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "cursor",
+		Platform: schema.PlatformInfo{
+			Name:     "Cursor",
+			Homepage: sdk.URL("https://cursor.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			CursorCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a new Cursor shell plugin for the `agent` CLI.

The plugin provisions an auth token through `CURSOR_API_KEY`. It also supports importing an existing token from `CURSOR_API_KEY`.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

N/A

## How To Test

Run plugin validation:

```shell
make cursor/validate
```

Run the Cursor plugin tests:

```shell
go test ./plugins/cursor
```

Example authenticated command for functional testing:

```shell
agent "explain this repo"
```

## Changelog
Authenticate the Cursor CLI using Touch ID and other unlock options with 1Password Shell Plugins.
