### PR TITLE
Add OpenCode shell plugin

### DIFF
--- a/plugins/opencode/api_key.go
+++ b/plugins/opencode/api_key.go
@@ -17,7 +17,7 @@ func APIKey() schema.CredentialType {
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,
-				MarkdownDescription: "API Key used to authenticate to opencode.",
+				MarkdownDescription: "API Key used to authenticate to OpenCode.",
 				Secret:              true,
 			},
 		},

--- a/plugins/opencode/api_key.go
+++ b/plugins/opencode/api_key.go
@@ -1,0 +1,31 @@
+package opencode
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://opencode.ai/docs/"),
+		ManagementURL: sdk.URL("https://opencode.ai/auth"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to opencode.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"OPENCODE_API_KEY": fieldname.APIKey,
+}

--- a/plugins/opencode/api_key.go
+++ b/plugins/opencode/api_key.go
@@ -12,12 +12,12 @@ import (
 func APIKey() schema.CredentialType {
 	return schema.CredentialType{
 		Name:          credname.APIKey,
-		DocsURL:       sdk.URL("https://opencode.ai/docs/"),
+		DocsURL:       sdk.URL("https://opencode.ai/docs/providers/"),
 		ManagementURL: sdk.URL("https://opencode.ai/auth"),
 		Fields: []schema.CredentialField{
 			{
 				Name:                fieldname.APIKey,
-				MarkdownDescription: "API Key used to authenticate to OpenCode.",
+				MarkdownDescription: "OpenCode Zen API key from https://opencode.ai/auth used to authenticate to OpenCode. `OPENCODE_API_KEY` covers only the OpenCode Zen gateway, not BYOK keys such as `ANTHROPIC_API_KEY`.",
 				Secret:              true,
 			},
 		},

--- a/plugins/opencode/api_key_test.go
+++ b/plugins/opencode/api_key_test.go
@@ -1,0 +1,43 @@
+package opencode
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const exampleAPIKey = "sk-0123456789abcdefghijEXAMPLE"
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: exampleAPIKey,
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"OPENCODE_API_KEY": exampleAPIKey,
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"OPENCODE_API_KEY": exampleAPIKey,
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: exampleAPIKey,
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/opencode/opencode.go
+++ b/plugins/opencode/opencode.go
@@ -9,7 +9,7 @@ import (
 
 func OpencodeCLI() schema.Executable {
 	return schema.Executable{
-		Name:    "opencode CLI",
+		Name:    "OpenCode CLI",
 		Runs:    []string{"opencode"},
 		DocsURL: sdk.URL("https://opencode.ai/docs/"),
 		NeedsAuth: needsauth.IfAll(

--- a/plugins/opencode/opencode.go
+++ b/plugins/opencode/opencode.go
@@ -1,0 +1,25 @@
+package opencode
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func OpencodeCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "opencode CLI",
+		Runs:    []string{"opencode"},
+		DocsURL: sdk.URL("https://opencode.ai/docs/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/opencode/opencode.go
+++ b/plugins/opencode/opencode.go
@@ -15,6 +15,7 @@ func OpencodeCLI() schema.Executable {
 		NeedsAuth: needsauth.IfAll(
 			needsauth.NotForHelpOrVersion(),
 			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("auth"),
 		),
 		Uses: []schema.CredentialUsage{
 			{

--- a/plugins/opencode/plugin.go
+++ b/plugins/opencode/plugin.go
@@ -9,7 +9,7 @@ func New() schema.Plugin {
 	return schema.Plugin{
 		Name: "opencode",
 		Platform: schema.PlatformInfo{
-			Name:     "opencode",
+			Name:     "OpenCode",
 			Homepage: sdk.URL("https://opencode.ai"),
 		},
 		Credentials: []schema.CredentialType{

--- a/plugins/opencode/plugin.go
+++ b/plugins/opencode/plugin.go
@@ -1,0 +1,22 @@
+package opencode
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "opencode",
+		Platform: schema.PlatformInfo{
+			Name:     "opencode",
+			Homepage: sdk.URL("https://opencode.ai"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			OpencodeCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a new OpenCode shell plugin for the `opencode` CLI.

The plugin provisions an auth token through `OPENCODE_API_KEY`. It also supports importing an existing token from `OPENCODE_API_KEY`.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

N/A

## How To Test

Run plugin validation:

```shell
make opencode/validate
```

Run the OpenCode plugin tests:

```shell
go test ./plugins/opencode
```

Example authenticated command for functional testing:

```shell
opencode run "explain this repo"
```

## Changelog
Authenticate the OpenCode CLI using Touch ID and other unlock options with 1Password Shell Plugins.
