### PR TITLE
Fix Check Nix flake CI failures

### DIFF
--- a/.github/workflows/check-flake.yml
+++ b/.github/workflows/check-flake.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-flakehub: false
       - name: Check Nix flake inputs
         uses: DeterminateSystems/flake-checker-action@v5
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update `flake.lock` to current `nixpkgs-unstable` (June 16) so the flake-checker 30-day freshness check passes
- Disable FlakeHub in `magic-nix-cache-action` to match the update-flake-dependencies workflow and avoid auth noise in logs

## Test plan
- [ ] Check Nix flake workflow passes on this PR
- [ ] `nix flake check` succeeds locally (optional)
