### PR TITLE
fix: Gittea write config to XDG_CONFIG_HOME when set

### DIFF
--- a/plugins/gitea/personal_access_token.go
+++ b/plugins/gitea/personal_access_token.go
@@ -3,6 +3,7 @@ package gitea
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
@@ -14,11 +15,16 @@ import (
 )
 
 func ConfigPath() string {
+	// tea's config resolver honors XDG_CONFIG_HOME on macOS; os.UserConfigDir does not.
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		return filepath.Join(xdgConfigHome, "tea", "config.yml")
+	}
+
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return "~/.config/tea/config.yml"
 	}
-	return configDir + "/tea/config.yml"
+	return filepath.Join(configDir, "tea", "config.yml")
 }
 
 func PersonalAccessToken() schema.CredentialType {

--- a/plugins/gitea/personal_access_token_test.go
+++ b/plugins/gitea/personal_access_token_test.go
@@ -1,12 +1,42 @@
 package gitea
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/plugintest"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
 )
+
+func TestConfigPath(t *testing.T) {
+	t.Run("honors XDG_CONFIG_HOME when set", func(t *testing.T) {
+		// tea reads its config from $XDG_CONFIG_HOME/tea/config.yml via
+		// github.com/adrg/xdg, so the plugin must write to the same place.
+		xdgConfigHome := filepath.Join(t.TempDir(), "xdg")
+		t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+		want := filepath.Join(xdgConfigHome, "tea", "config.yml")
+		if got := ConfigPath(); got != want {
+			t.Errorf("ConfigPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("falls back to os.UserConfigDir when XDG_CONFIG_HOME is unset", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		configDir, err := os.UserConfigDir()
+		if err != nil {
+			t.Skipf("os.UserConfigDir() unavailable: %v", err)
+		}
+
+		want := filepath.Join(configDir, "tea", "config.yml")
+		if got := ConfigPath(); got != want {
+			t.Errorf("ConfigPath() = %q, want %q", got, want)
+		}
+	})
+}
 
 func TestPersonalAccessTokenProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
@@ -27,12 +57,65 @@ func TestPersonalAccessTokenProvisioner(t *testing.T) {
 	})
 }
 
+func TestPersonalAccessTokenProvisionerHonorsXDGConfigHome(t *testing.T) {
+	xdgConfigHome := filepath.Join(t.TempDir(), "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"xdg config path": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token:       "oyyfsny27bgphldmhvffxhhlmqvdkzjrfslrsj9f",
+				fieldname.HostAddress: "https://git.example.com",
+				fieldname.User:        "example",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					filepath.Join(xdgConfigHome, "tea", "config.yml"): {
+						Contents: []byte(plugintest.LoadFixture(t, "config.yml")),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestPersonalAccessTokenImporter(t *testing.T) {
 	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
 
 		"config file": {
 			Files: map[string]string{
 				ConfigPath(): plugintest.LoadFixture(t, "import_config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:       "oyyfsny27bgphldmhvffxhhlmqvdkzjrfslrsj9f",
+						fieldname.HostAddress: "https://git.example.com",
+						fieldname.User:        "example",
+					},
+					NameHint: "git.example.com",
+				},
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:       "enjkarzu2ca5ffcnvzaczxncuczeoq9utlpqqrzs",
+						fieldname.HostAddress: "https://gitea.com",
+						fieldname.User:        "example@example.com",
+					},
+					NameHint: "gitea.com",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporterHonorsXDGConfigHome(t *testing.T) {
+	xdgConfigHome := filepath.Join(t.TempDir(), "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"xdg config file": {
+			Files: map[string]string{
+				filepath.Join(xdgConfigHome, "tea", "config.yml"): plugintest.LoadFixture(t, "import_config.yml"),
 			},
 			ExpectedCandidates: []sdk.ImportCandidate{
 				{


### PR DESCRIPTION
## Overview

On macOS with `$XDG_CONFIG_HOME` exported, `op plugin init tea` writes tea's config to a path tea never reads, so every `tea` command fails with `Error: no available login`.

The plugin resolves the config path with `os.UserConfigDir()`, which ignores `$XDG_CONFIG_HOME` on darwin, while tea resolves it through [`adrg/xdg`](https://github.com/adrg/xdg), which prefers `$XDG_CONFIG_HOME` on every platform. When the variable is set (common for users syncing dotfiles across Linux and macOS), the two diverge: the plugin writes to `~/Library/Application Support/tea/config.yml` while tea reads from `$XDG_CONFIG_HOME/tea/config.yml`.

`ConfigPath()` now checks `$XDG_CONFIG_HOME` first and falls back to `os.UserConfigDir()`, matching tea's own resolution order. Added tests covering both branches.

## Type of change

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

* Resolves: #601

## How To Test

```sh
export XDG_CONFIG_HOME=$HOME/.config
op plugin init tea   # link a Gitea personal access token
tea pulls            # previously: Error: no available login
```

Without `$XDG_CONFIG_HOME` set, behavior is unchanged (`os.UserConfigDir()` fallback). `go test ./plugins/gitea/...` and `make gitea/validate` pass.

## Changelog

The Gitea plugin now writes tea's configuration to the location tea reads when `XDG_CONFIG_HOME` is set.