### PR TITLE
fix: [CI] pin 6 unpinned 3rd party actions

### DIFF
--- a/.github/workflows/check-flake.yml
+++ b/.github/workflows/check-flake.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
         with:
           use-flakehub: false
       - name: Check Nix flake inputs
-        uses: DeterminateSystems/flake-checker-action@v5
+        uses: DeterminateSystems/flake-checker-action@4b90f9fc724969ff153fe1803460917c84fe00a3 # v5
         with:
           fail-mode: true
           send-statistics: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
           go-version: 1.19
 
       - name: Lint with golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           # version of golangci-lint to use
           # Version should stay in sync with version used for local linting (lint job in Makefile).

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
         with:
           use-flakehub: false
       - name: Update flake.lock and create signed commit with flake.lock changes


### PR DESCRIPTION
## Overview

Pins the 6 third-party GitHub Actions used in this repo's workflows to immutable commit SHAs instead of mutable version tags, per GitHub's [security guidance](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). The version tag is kept as a trailing comment for readability.

No functional changes each SHA is the exact commit the version tag currently resolves to, so workflow behaviour is unchanged.

If you see this Hi Scott.

## Type of change

- [x] Other CI Security cleanup

## How To Test

No behavior change to verify CI on this PR runs the same steps against the same action versions, now pinned. Each pin can be independently confirmed by comparing the tag to the SHA, e.g.:

```
https://github.com/golangci/golangci-lint-action/compare/v9...ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a
```

## Changelog

N/A  CI/CD infrastructure change only, no user-facing impact.