### PR TITLE
Add Octopus Deploy shell plugin

### DIFF
--- a/plugins/octopus/api_key.go
+++ b/plugins/octopus/api_key.go
@@ -1,0 +1,90 @@
+package octopus
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key"),
+		ManagementURL: nil,
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Octopus Deploy.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Charset: schema.Charset{
+						Uppercase: true,
+						Digits:    true,
+					},
+					Prefix: "API-",
+				},
+			},
+			{
+				Name:                fieldname.URL,
+				MarkdownDescription: "URL of the Octopus Deploy server.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Space,
+				MarkdownDescription: "Space to use for the Octopus Deploy CLI.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryOctopusDeployConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"OCTOPUS_API_KEY": fieldname.APIKey,
+	"OCTOPUS_URL":     fieldname.URL,
+	"OCTOPUS_SPACE":   fieldname.Space,
+}
+
+func TryOctopusDeployConfigFile() sdk.Importer {
+	return importer.TryFile("~/.config/octopus/cli_config.json", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToJSON(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		if config.APIKey == "" {
+			return
+		}
+
+		fields := map[sdk.FieldName]string{
+			fieldname.APIKey: config.APIKey,
+		}
+
+		if config.URL != "" {
+			fields[fieldname.URL] = config.URL
+		}
+
+		if config.Space != "" {
+			fields[fieldname.Space] = config.Space
+		}
+
+		out.AddCandidate(sdk.ImportCandidate{
+			Fields: fields,
+		})
+	})
+}
+
+type Config struct {
+	APIKey string `json:"apikey"`
+	URL    string `json:"url"`
+	Space  string `json:"space"`
+}

--- a/plugins/octopus/api_key_test.go
+++ b/plugins/octopus/api_key_test.go
@@ -1,0 +1,63 @@
+package octopus
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "API-PFIPLPKUTCYAWJXUREGWTUYNYEEXAMPLE",
+				fieldname.URL:    "https://my.octopus.app",
+				fieldname.Space:  "Default",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"OCTOPUS_API_KEY": "API-PFIPLPKUTCYAWJXUREGWTUYNYEEXAMPLE",
+					"OCTOPUS_URL":     "https://my.octopus.app",
+					"OCTOPUS_SPACE":   "Default",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"OCTOPUS_API_KEY": "API-PFIPLPKUTCYAWJXUREGWTUYNYEEXAMPLE",
+				"OCTOPUS_URL":     "https://my.octopus.app",
+				"OCTOPUS_SPACE":   "Default",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "API-PFIPLPKUTCYAWJXUREGWTUYNYEEXAMPLE",
+						fieldname.URL:    "https://my.octopus.app",
+						fieldname.Space:  "Default",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files: map[string]string{
+				"~/.config/octopus/cli_config.json": plugintest.LoadFixture(t, "cli_config.json"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "API-PFIPLPKUTCYAWJXUREGWTUYNYEEXAMPLE",
+						fieldname.URL:    "https://my.octopus.app",
+						fieldname.Space:  "Default",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/octopus/octopus.go
+++ b/plugins/octopus/octopus.go
@@ -1,0 +1,27 @@
+package octopus
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func OctopusDeployCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Octopus CLI",
+		Runs:    []string{"octopus"},
+		DocsURL: sdk.URL("https://octopus.com/docs/octopus-rest-api/cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWhenContainsArgs("login"),
+			needsauth.NotWhenContainsArgs("logout"),
+			needsauth.NotWhenContainsArgs("config"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/octopus/plugin.go
+++ b/plugins/octopus/plugin.go
@@ -1,0 +1,22 @@
+package octopus
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "octopus",
+		Platform: schema.PlatformInfo{
+			Name:     "Octopus Deploy",
+			Homepage: sdk.URL("https://octopus.com"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			OctopusDeployCLI(),
+		},
+	}
+}

--- a/plugins/octopus/test-fixtures/cli_config.json
+++ b/plugins/octopus/test-fixtures/cli_config.json
@@ -1,0 +1,6 @@
+{
+  "accesstoken": "",
+  "apikey": "API-PFIPLPKUTCYAWJXUREGWTUYNYEEXAMPLE",
+  "space": "Default",
+  "url": "https://my.octopus.app"
+}

--- a/sdk/schema/fieldname/names.go
+++ b/sdk/schema/fieldname/names.go
@@ -53,6 +53,7 @@ const (
 	Region          = sdk.FieldName("Region")
 	Secret          = sdk.FieldName("Secret")
 	SecretAccessKey = sdk.FieldName("Secret Access Key")
+	Space           = sdk.FieldName("Space")
 	Subdomain       = sdk.FieldName("Subdomain")
 	Token           = sdk.FieldName("Token")
 	URL             = sdk.FieldName("URL")
@@ -110,6 +111,7 @@ func ListAll() []sdk.FieldName {
 		Region,
 		Secret,
 		SecretAccessKey,
+		Space,
 		Token,
 		URL,
 		User,


### PR DESCRIPTION
## Overview

Add a shell plugin for the [Octopus Deploy CLI](https://github.com/OctopusDeploy/cli) (`octopus`) officially provided by [Octopus Deploy](https://octopus.com).

The plugin provisions `OCTOPUS_API_KEY`, `OCTOPUS_URL`, and `OCTOPUS_SPACE` from 1Password. It supports importing existing credentials from:

- environment variables (`OCTOPUS_API_KEY`, `OCTOPUS_URL`, `OCTOPUS_SPACE`), and
- the `octopus login` config file at `~/.config/octopus/cli_config.json`.

It also adds a `Space` field name to the SDK for `OCTOPUS_SPACE`.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

N/A

## How To Test

After configuring the plugin, run a command that requires authentication, for example:

```
octopus space list
```

> [!TIP]
> The guest account on the [Live Demo Server](https://octopus.com/blog/demo-server) officially provided by Octopus Deploy has an API Key registered with no expiration date, which can be used to verify system functionality.
> `OCTOPUS_URL`: `https://samples.octopus.app/`
> `OCTOPUS_API_KEY`: The string beginning with "API-" displayed in the "Purpose" column, which can be found by navigating to "My Profile" > "My API Keys", is available for use as API Key.

## Changelog

Authenticate the Octopus Deploy CLI using Touch ID and other unlock options with 1Password Shell Plugins.