### PR TITLE
[DRAFT] feat(plugin) : Add Apono plugin

### DIFF
--- a/plugins/apono/apono.go
+++ b/plugins/apono/apono.go
@@ -1,0 +1,29 @@
+package apono
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func AponoCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Apono CLI",
+		Runs:    []string{"apono"},
+		DocsURL: sdk.URL("https://docs.apono.io/docs/access-requests-and-approvals/cli/install-and-manage-the-apono-cli"),
+		NeedsAuth: needsauth.IfAll(
+			// The Apono CLI only accepts a token on "apono login"; all other
+			// commands authenticate through the session it stores itself.
+			needsauth.ForCommand("login"),
+			needsauth.NotForHelp(),
+			needsauth.NotWhenContainsArgs("--personal-token"),
+			needsauth.NotWhenContainsArgs("__complete"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAPIToken,
+			},
+		},
+	}
+}

--- a/plugins/apono/personal_api_token.go
+++ b/plugins/apono/personal_api_token.go
@@ -1,0 +1,92 @@
+package apono
+
+import (
+	"context"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAPIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:    credname.PersonalAPIToken,
+		DocsURL: sdk.URL("https://docs.apono.io/docs/architecture-and-security/personal-api-tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Personal API Token used to authenticate to Apono.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: aponoLoginProvisioner{},
+		Importer: importer.TryAll(
+			importer.MacOnly(
+				TryAponoConfigFile("~/Library/Application Support/apono-cli/config.json"),
+			),
+			importer.LinuxOnly(
+				TryAponoConfigFile("~/.config/apono-cli/config.json"),
+			),
+		),
+	}
+}
+
+// aponoLoginProvisioner provisions the Personal API Token as the
+// --personal-token flag of "apono login". The Apono CLI does not read
+// credentials from environment variables or accept a token flag on other
+// commands: it only takes a token at login time, after which it manages
+// its own session in its config file.
+type aponoLoginProvisioner struct{}
+
+func (p aponoLoginProvisioner) Description() string {
+	return "Provision Apono Personal API Token as the --personal-token flag of 'apono login'"
+}
+
+func (p aponoLoginProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	out.AddArgs("--personal-token", in.ItemFields[fieldname.Token])
+}
+
+func (p aponoLoginProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// Nothing to do here: provisioned command-line args get cleaned up automatically.
+}
+
+func TryAponoConfigFile(path string) sdk.Importer {
+	return importer.TryFile(
+		path,
+		func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+			var config Config
+			if err := contents.ToJSON(&config); err != nil {
+				out.AddError(err)
+				return
+			}
+
+			for profileName, profile := range config.Auth.Profiles {
+				if profile.PersonalToken == "" {
+					continue
+				}
+
+				out.AddCandidate(sdk.ImportCandidate{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: profile.PersonalToken,
+					},
+					NameHint: importer.SanitizeNameHint(profileName),
+				})
+			}
+		},
+	)
+}
+
+type Config struct {
+	Auth AuthConfig `json:"auth"`
+}
+
+type AuthConfig struct {
+	ActiveProfile string                   `json:"active_profile"`
+	Profiles      map[string]ProfileConfig `json:"profiles"`
+}
+
+type ProfileConfig struct {
+	PersonalToken string `json:"personal_token"`
+}

--- a/plugins/apono/personal_api_token_test.go
+++ b/plugins/apono/personal_api_token_test.go
@@ -1,0 +1,54 @@
+package apono
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAPITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(
+		t, PersonalAPIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+			"default": {
+				ItemFields: map[sdk.FieldName]string{
+					fieldname.Token: "apono_example_personal_token_ynAvsvBcxSGzMkPr",
+				},
+				ExpectedOutput: sdk.ProvisionOutput{
+					CommandLine: []string{"--personal-token", "apono_example_personal_token_ynAvsvBcxSGzMkPr"},
+				},
+			},
+		},
+	)
+}
+
+func TestPersonalAPITokenImporter(t *testing.T) {
+	expectedCandidates := []sdk.ImportCandidate{
+		{
+			Fields: map[sdk.FieldName]string{
+				fieldname.Token: "apono_example_personal_token_ynAvsvBcxSGzMkPr",
+			},
+			NameHint: "work",
+		},
+	}
+
+	plugintest.TestImporter(
+		t, PersonalAPIToken().Importer, map[string]plugintest.ImportCase{
+			"config file (macOS)": {
+				OS: "darwin",
+				Files: map[string]string{
+					"~/Library/Application Support/apono-cli/config.json": plugintest.LoadFixture(t, "config.json"),
+				},
+				ExpectedCandidates: expectedCandidates,
+			},
+			"config file (Linux)": {
+				OS: "linux",
+				Files: map[string]string{
+					"~/.config/apono-cli/config.json": plugintest.LoadFixture(t, "config.json"),
+				},
+				ExpectedCandidates: expectedCandidates,
+			},
+		},
+	)
+}

--- a/plugins/apono/plugin.go
+++ b/plugins/apono/plugin.go
@@ -1,0 +1,22 @@
+package apono
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "apono",
+		Platform: schema.PlatformInfo{
+			Name:     "Apono",
+			Homepage: sdk.URL("https://apono.io"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAPIToken(),
+		},
+		Executables: []schema.Executable{
+			AponoCLI(),
+		},
+	}
+}

--- a/plugins/apono/test-fixtures/config.json
+++ b/plugins/apono/test-fixtures/config.json
@@ -1,0 +1,28 @@
+{
+  "auth": {
+    "active_profile": "work",
+    "profiles": {
+      "work": {
+        "client_id": "3afae9ff-48e6-45f3-b0e8-37658b7271b7",
+        "api_url": "https://api.apono.io",
+        "app_url": "https://app.apono.io",
+        "account_id": "example-account-id",
+        "user_email": "user@example.com",
+        "personal_token": "apono_example_personal_token_ynAvsvBcxSGzMkPr"
+      },
+      "sso": {
+        "client_id": "3afae9ff-48e6-45f3-b0e8-37658b7271b7",
+        "api_url": "https://api.apono.io",
+        "app_url": "https://app.apono.io",
+        "account_id": "example-account-id",
+        "user_email": "user@example.com",
+        "personal_token": "",
+        "token": {
+          "access_token": "example-oauth-access-token",
+          "refresh_token": "example-oauth-refresh-token",
+          "expiry": "2026-01-01T00:00:00Z"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Adds a shell plugin for the [Apono CLI](https://github.com/apono-io/apono-cli) (`apono`), which requests and receives just-in-time access to services, databases, and applications.

Apono personal API tokens are created in the Apono web UI (Settings → Personal API Token) and are long-lived bearer credentials, so they're a good fit for 1Password storage. This plugin:

- Stores the **Personal API Token** credential in 1Password (`credname.PersonalAPIToken`, single `Token` field).
- Provisions it as the `--personal-token` flag of `apono login` via a custom arg provisioner, scoped with `needsauth.ForCommand("login")`.
- Imports existing tokens from the CLI's `config.json` (`~/Library/Application Support/apono-cli/config.json` on macOS, `~/.config/apono-cli/config.json` on Linux), one candidate per profile that has a `personal_token` set, skipping OAuth-only profiles.

### Why the provisioner targets `apono login` instead of environment variables

The Apono CLI currently reads no credentials from environment variables and has no per-command token flag — the only token injection point is `apono login --personal-token <TOKEN>`, which validates the token and persists it to the CLI's own `config.json`. This plugin therefore keeps the token out of shell history and clipboards and enables 1Password import/storage, but after login the CLI still stores the token on disk by its own design.

apono-io/apono-cli#116 (draft) adds `APONO_PERSONAL_TOKEN` support to the CLI. Once that ships, this plugin can switch to a standard `provision.EnvVars` provisioner covering every `apono` command per-invocation, with nothing written to disk. Happy to do that as a follow-up here.

`ManagementURL` is intentionally omitted for now; will add the exact settings-page URL once confirmed.

## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

* Relates: apono-io/apono-cli#116

## How To Test

1. Create a personal API token in the Apono web UI (Settings → Personal API Token).
2. `make apono/build && op plugin init apono` and save the token as a Personal API Token item.
3. Run `apono login` — the token should be injected as `--personal-token` and the CLI should create a profile without opening a browser.
4. Run `apono access list` to confirm the authenticated session works.
5. Importer: with an existing `config.json` containing a `personal_token`, `op plugin init apono` should offer to import it.

Unit tests: `go test ./plugins/apono/...`; schema: `make apono/validate` (all checks pass; single warning for the omitted management URL).

## Changelog

Authenticate the Apono CLI using Touch ID and other unlock options with 1Password Shell Plugins.