### PR TITLE
Add shell plugin for xAI Grok CLI

### DIFF
--- a/plugins/grok/api_key.go
+++ b/plugins/grok/api_key.go
@@ -1,0 +1,39 @@
+package grok
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		DocsURL:       sdk.URL("https://docs.x.ai/build/overview"),
+		ManagementURL: sdk.URL("https://console.x.ai/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to the xAI API.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Prefix: "xai-",
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"XAI_API_KEY": fieldname.APIKey,
+}

--- a/plugins/grok/api_key_test.go
+++ b/plugins/grok/api_key_test.go
@@ -1,0 +1,41 @@
+package grok
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "xai-EXAMPLE1234abcdefEXAMPLE1234abcdef",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"XAI_API_KEY": "xai-EXAMPLE1234abcdefEXAMPLE1234abcdef",
+				},
+			},
+		},
+	})
+}
+
+func TestAPIKeyImporter(t *testing.T) {
+	plugintest.TestImporter(t, APIKey().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"XAI_API_KEY": "xai-EXAMPLE1234abcdefEXAMPLE1234abcdef",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.APIKey: "xai-EXAMPLE1234abcdefEXAMPLE1234abcdef",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/grok/grok.go
+++ b/plugins/grok/grok.go
@@ -1,0 +1,28 @@
+package grok
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func GrokCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Grok CLI",
+		Runs:    []string{"grok"},
+		DocsURL: sdk.URL("https://docs.x.ai/build/cli/reference"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWhenContainsArgs("completions"),
+			needsauth.NotForExactArgs("login"),
+			needsauth.NotForExactArgs("logout"),
+			needsauth.NotForExactArgs("update"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/grok/plugin.go
+++ b/plugins/grok/plugin.go
@@ -1,0 +1,22 @@
+package grok
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "grok",
+		Platform: schema.PlatformInfo{
+			Name:     "xAI Grok",
+			Homepage: sdk.URL("https://x.ai"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			GrokCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a shell plugin for the [Grok CLI](https://docs.x.ai/build/cli/reference) from xAI. The plugin
provisions the `XAI_API_KEY` environment variable from 1Password, enabling seamless authentication
for the `grok` CLI without exposing the key in shell history or environment files.

## Type of change

- [x] Created a new plugin

## Related Issue(s)

* Relates: #

## How To Test

After installing the plugin, run any Grok CLI command that requires authentication:

grok models

Or start an interactive session:

grok

1Password will provision `XAI_API_KEY` automatically before the command runs.

## Changelog

Authenticate the Grok CLI using 1Password Shell Plugins with credentials stored securely in your 1Password vault.