### PR TITLE
Add shell plugin for Netlify CLI

### DIFF
--- a/plugins/netlify/netlify.go
+++ b/plugins/netlify/netlify.go
@@ -1,0 +1,30 @@
+package netlify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func NetlifyCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Netlify CLI",
+		Runs:    []string{"netlify"},
+		DocsURL: sdk.URL("https://cli.netlify.com"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotWhenContainsArgs("login"),
+			needsauth.NotForExactArgs("logout"),
+			needsauth.NotWhenContainsArgs("switch"),
+			needsauth.NotWhenContainsArgs("completion"),
+			needsauth.NotWhenContainsArgs("unlink"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.PersonalAccessToken,
+			},
+		},
+	}
+}

--- a/plugins/netlify/personal_access_token.go
+++ b/plugins/netlify/personal_access_token.go
@@ -1,0 +1,31 @@
+package netlify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func PersonalAccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.PersonalAccessToken,
+		DocsURL:       sdk.URL("https://docs.netlify.com/api-and-cli-guides/cli-guides/get-started-with-cli"),
+		ManagementURL: sdk.URL("https://app.netlify.com/user/applications#personal-access-tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Netlify.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer:           importer.TryEnvVarPair(defaultEnvVarMapping),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"NETLIFY_AUTH_TOKEN": fieldname.Token,
+}

--- a/plugins/netlify/personal_access_token_test.go
+++ b/plugins/netlify/personal_access_token_test.go
@@ -1,0 +1,41 @@
+package netlify
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestPersonalAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PersonalAccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "kV9wTq3ZtN0aB4cD7eF1gH5iJ8kL2mN6oP0qR4sT8uV",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NETLIFY_AUTH_TOKEN": "kV9wTq3ZtN0aB4cD7eF1gH5iJ8kL2mN6oP0qR4sT8uV",
+				},
+			},
+		},
+	})
+}
+
+func TestPersonalAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, PersonalAccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"NETLIFY_AUTH_TOKEN": "kV9wTq3ZtN0aB4cD7eF1gH5iJ8kL2mN6oP0qR4sT8uV",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "kV9wTq3ZtN0aB4cD7eF1gH5iJ8kL2mN6oP0qR4sT8uV",
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/netlify/plugin.go
+++ b/plugins/netlify/plugin.go
@@ -1,0 +1,22 @@
+package netlify
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "netlify",
+		Platform: schema.PlatformInfo{
+			Name:     "Netlify",
+			Homepage: sdk.URL("https://netlify.com"),
+		},
+		Credentials: []schema.CredentialType{
+			PersonalAccessToken(),
+		},
+		Executables: []schema.Executable{
+			NetlifyCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a shell plugin for the [Netlify CLI](https://cli.netlify.com). The plugin provisions the
`NETLIFY_AUTH_TOKEN` environment variable from 1Password, enabling seamless authentication without
exposing the personal access token in shell history or dotfiles.

## Type of change

- [x] Created a new plugin

## Related Issue(s)

* Relates: #

## How To Test

After installing the plugin, run any Netlify CLI command that requires authentication:

netlify sites:list

1Password will provision `NETLIFY_AUTH_TOKEN` automatically before the command runs.

## Changelog

Authenticate the Netlify CLI using 1Password Shell Plugins with credentials stored securely in your 1Password vault.