### PR TITLE
Add shell plugin for SonarQube CLI

### DIFF
--- a/plugins/sonarqube/cli_token.go
+++ b/plugins/sonarqube/cli_token.go
@@ -1,0 +1,47 @@
+package sonarqube
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func CLIToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.CLIToken,
+		DocsURL:       sdk.URL("https://docs.sonarsource.com/sonarqube-cli/using-sonarqube-cli/environment-variables"),
+		ManagementURL: sdk.URL("https://sonarcloud.io/account/security"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "User token used to authenticate to SonarQube CLI.",
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Organization,
+				MarkdownDescription: "SonarQube Cloud organization key. Use together with the token to authenticate to SonarQube Cloud.",
+				Secret:              false,
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.URL,
+				MarkdownDescription: "Server URL. Use together with the token to authenticate to a self-hosted SonarQube instance or a specific SonarQube Cloud region.",
+				Secret:              false,
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"SONARQUBE_CLI_TOKEN":  fieldname.Token,
+	"SONARQUBE_CLI_ORG":    fieldname.Organization,
+	"SONARQUBE_CLI_SERVER": fieldname.URL,
+}

--- a/plugins/sonarqube/cli_token_test.go
+++ b/plugins/sonarqube/cli_token_test.go
@@ -1,0 +1,93 @@
+package sonarqube
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestCLITokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, CLIToken().Importer, map[string]plugintest.ImportCase{
+		"token only": {
+			Environment: map[string]string{
+				"SONARQUBE_CLI_TOKEN": "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+					},
+				},
+			},
+		},
+		"token with organization": {
+			Environment: map[string]string{
+				"SONARQUBE_CLI_TOKEN": "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+				"SONARQUBE_CLI_ORG":   "my-org",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token:        "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+						fieldname.Organization: "my-org",
+					},
+				},
+			},
+		},
+		"token with server": {
+			Environment: map[string]string{
+				"SONARQUBE_CLI_TOKEN":  "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+				"SONARQUBE_CLI_SERVER": "https://sonarqube.example.com",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+						fieldname.URL:   "https://sonarqube.example.com",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestCLITokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, CLIToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"token only": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SONARQUBE_CLI_TOKEN": "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+				},
+			},
+		},
+		"token with organization": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token:        "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+				fieldname.Organization: "my-org",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SONARQUBE_CLI_TOKEN": "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+					"SONARQUBE_CLI_ORG":   "my-org",
+				},
+			},
+		},
+		"token with server": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+				fieldname.URL:   "https://sonarqube.example.com",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"SONARQUBE_CLI_TOKEN":  "sqp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+					"SONARQUBE_CLI_SERVER": "https://sonarqube.example.com",
+				},
+			},
+		},
+	})
+}

--- a/plugins/sonarqube/plugin.go
+++ b/plugins/sonarqube/plugin.go
@@ -16,7 +16,7 @@ func New() schema.Plugin {
 			CLIToken(),
 		},
 		Executables: []schema.Executable{
-			SonarScannerCLI(),
+			SonarQubeCLI(),
 		},
 	}
 }

--- a/plugins/sonarqube/plugin.go
+++ b/plugins/sonarqube/plugin.go
@@ -1,0 +1,22 @@
+package sonarqube
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "sonarqube",
+		Platform: schema.PlatformInfo{
+			Name:     "SonarQube CLI",
+			Homepage: sdk.URL("https://docs.sonarsource.com/sonarqube-cli/"),
+		},
+		Credentials: []schema.CredentialType{
+			CLIToken(),
+		},
+		Executables: []schema.Executable{
+			SonarScannerCLI(),
+		},
+	}
+}

--- a/plugins/sonarqube/sonar_scanner.go
+++ b/plugins/sonarqube/sonar_scanner.go
@@ -1,0 +1,30 @@
+package sonarqube
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func SonarScannerCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "SonarQube CLI",
+		Runs:    []string{"sonar"},
+		DocsURL: sdk.URL("https://docs.sonarsource.com/sonarqube-cli/"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+			needsauth.NotForExactArgs("auth", "login"),
+			needsauth.NotForExactArgs("auth", "logout"),
+			needsauth.NotWhenContainsArgs("config", "telemetry"),
+			needsauth.NotWhenContainsArgs("system",),
+			needsauth.NotWhenContainsArgs("self-update"),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.CLIToken,
+			},
+		},
+	}
+}

--- a/plugins/sonarqube/sonar_scanner.go
+++ b/plugins/sonarqube/sonar_scanner.go
@@ -18,7 +18,7 @@ func SonarScannerCLI() schema.Executable {
 			needsauth.NotForExactArgs("auth", "login"),
 			needsauth.NotForExactArgs("auth", "logout"),
 			needsauth.NotWhenContainsArgs("config", "telemetry"),
-			needsauth.NotWhenContainsArgs("system",),
+			needsauth.NotWhenContainsArgs("system"),
 			needsauth.NotWhenContainsArgs("self-update"),
 		),
 		Uses: []schema.CredentialUsage{

--- a/plugins/sonarqube/sonarqube.go
+++ b/plugins/sonarqube/sonarqube.go
@@ -7,7 +7,7 @@ import (
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 )
 
-func SonarScannerCLI() schema.Executable {
+func SonarQubeCLI() schema.Executable {
 	return schema.Executable{
 		Name:    "SonarQube CLI",
 		Runs:    []string{"sonar"},


### PR DESCRIPTION
## Overview

Adds a shell plugin for SonarQube CLI (sonar), enabling 1Password to automatically inject authentication credentials via environment variables.

The plugin supports the three environment variables from the SonarQube CLI docs:

- SONARQUBE_CLI_TOKEN — user token (required, secret)
- SONARQUBE_CLI_ORG — SonarQube Cloud organization key (optional)
- SONARQUBE_CLI_SERVER — server URL for self-hosted instances or regional SonarQube Cloud endpoints (optional)

## Type of change

- [x] Created a new plugin

## Related Issue(s)

- Resolves: #
- Relates: #

## How To Test

Run a scan using the SonarQube CLI with credentials stored in 1Password:

```
sonar scan \
  --project-key my-project \
  --source-dir .
```

With 1Password Shell Plugins configured, `SONARQUBE_CLI_TOKEN` and optionally `SONARQUBE_CLI_ORG` or `SONARQUBE_CLI_SERVER will be injected automatically from the stored item.

## Changelog

Added a shell plugin for the SonarQube CLI that enables authenticating sonar using credentials stored in 1Password.