### PR TITLE
Add Qodana CLI shell plugin

### DIFF
--- a/plugins/qodana/plugin.go
+++ b/plugins/qodana/plugin.go
@@ -1,0 +1,22 @@
+package qodana
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "qodana",
+		Platform: schema.PlatformInfo{
+			Name:     "Qodana",
+			Homepage: sdk.URL("https://qodana.cloud"),
+		},
+		Credentials: []schema.CredentialType{
+			ProjectToken(),
+		},
+		Executables: []schema.Executable{
+			QodanaCLI(),
+		},
+	}
+}

--- a/plugins/qodana/project_token.go
+++ b/plugins/qodana/project_token.go
@@ -1,0 +1,33 @@
+package qodana
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func ProjectToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIToken,
+		DocsURL:       sdk.URL("https://www.jetbrains.com/help/qodana/cloud-projects.html#cloud-manage-projects"),
+		ManagementURL: sdk.URL("https://qodana.cloud/"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Project token used to authenticate to Qodana Cloud.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+		),
+	}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"QODANA_TOKEN": fieldname.Token,
+}

--- a/plugins/qodana/project_token_test.go
+++ b/plugins/qodana/project_token_test.go
@@ -1,0 +1,41 @@
+package qodana
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestProjectTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, ProjectToken().Importer, map[string]plugintest.ImportCase{
+		"QODANA_TOKEN environment variable": {
+			Environment: map[string]string{
+				"QODANA_TOKEN": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.EXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.EXAMPLE",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestProjectTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, ProjectToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"QODANA_TOKEN": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.EXAMPLE",
+				},
+			},
+		},
+	})
+}

--- a/plugins/qodana/qodana.go
+++ b/plugins/qodana/qodana.go
@@ -1,0 +1,28 @@
+package qodana
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func QodanaCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Qodana CLI",
+		Runs:    []string{"qodana"},
+		DocsURL: sdk.URL("https://www.jetbrains.com/help/qodana/quick-start.html#quickstart-prerequisites-qodana-cli"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWhenContainsArgs("cloc"),
+			needsauth.NotWhenContainsArgs("completion"),
+			needsauth.NotWhenContainsArgs("contributors"),
+			needsauth.NotWhenContainsArgs("pull"),
+			needsauth.NotWhenContainsArgs("show"),
+			needsauth.NotWhenContainsArgs("view"),
+		),
+		Uses: []schema.CredentialUsage{
+			{Name: credname.APIToken},
+		},
+	}
+}


### PR DESCRIPTION
## Overview

Adds a shell plugin for the Qodana CLI, JetBrains' static analysis tool. The plugin provisions the QODANA_TOKEN environment variable so qodana scan and qodana send can authenticate to Qodana Cloud without manually exporting the token.

Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)

- Resolves: #
- Relates: #

## How To Test

Install the Qodana CLI (brew install jetbrains/utils/qodana) and store your project token in 1Password, then run:

```
qodana scan
```

## Changelog

Authenticate the Qodana CLI using 1Password Shell Plugins to automatically provision `QODANA_TOKEN` when running `qodana scan` or `qodana send`.