### PR TITLE
[fix] fix update-flake-dependencies failures

### DIFF
--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -28,11 +28,9 @@ jobs:
           # fetch remote state
           git fetch
           # if branch exists on remote already
-          BRANCH_EXISTS=false
           if git checkout "$COMMIT_BRANCH" > /dev/null 2>&1; then
             # pull changes
             git pull
-            BRANCH_EXISTS=true
           else
             # otherwise, create the branch and push it to remote
             git checkout -b "$COMMIT_BRANCH"
@@ -49,7 +47,7 @@ jobs:
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
             OPEN_PR_COUNT=$(gh pr list --head "$COMMIT_BRANCH" --state open --json number --jq 'length')
-            if [ "$OPEN_PR_COUNT" -eq 0]; then
+            if [ "$OPEN_PR_COUNT" -eq 0 ]; then
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -13,14 +13,23 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.FLAKE_BOT_APP_ID }}
+          private-key: ${{ secrets.FLAKE_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
         with:
           use-flakehub: false
       - name: Update flake.lock and create signed commit with flake.lock changes
         env:
-          GITHUB_TOKEN: ${{ secrets.OP_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           FILE_TO_COMMIT: flake.lock
           COMMIT_BRANCH: automation/update-flake-dependencies
           COMMIT_MESSAGE: "chore(nix): Update Flake dependencies"
@@ -51,7 +60,7 @@ jobs:
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \
-                --reviewer 1password/open-source \
+                --reviewer 1Password/open-source \
                 --base main --head $COMMIT_BRANCH
             fi
           fi

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -53,7 +53,7 @@ jobs:
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \
-                --reviewer mrjones2014 \
+                --reviewer scottisloud,bertrmz,jillregan,rishiy15 \
                 --base main --head $COMMIT_BRANCH
             fi
           fi

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -51,7 +51,7 @@ jobs:
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \
-                --reviewer open-source \
+                --reviewer 1password/open-source \
                 --base main --head $COMMIT_BRANCH
             fi
           fi

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -30,7 +30,7 @@ jobs:
           # if branch exists on remote already
           BRANCH_EXISTS=false
           if git checkout "$COMMIT_BRANCH" > /dev/null 2>&1; then
-            # pull changeshttps://github.com/1Password/shell-plugins/pull/595
+            # pull changes
             git pull
             BRANCH_EXISTS=true
           else
@@ -48,7 +48,8 @@ jobs:
               --field content="$(base64 -w 0 $FILE_TO_COMMIT)" \
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
-            if [ "$BRANCH_EXISTS" = "false" ]; then
+            OPEN_PR_COUNT=$(gh pr list --head "$COMMIT_BRANCH" --state open --json number --jq 'length')
+            if [ "$OPEN_PR_COUNT" -eq 0]; then
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.FLAKE_BOT_APP_ID }}
+          client-id: ${{ secrets.FLAKE_BOT_APP_ID }}
           private-key: ${{ secrets.FLAKE_BOT_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -61,7 +61,7 @@ jobs:
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \
-                --reviewer mrjones2014 \
+                --reviewer open-source \
                 --base main --head $COMMIT_BRANCH
             fi
           fi

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -13,23 +13,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Generate GitHub App installation token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.FLAKE_BOT_APP_ID }}
-          private-key: ${{ secrets.FLAKE_BOT_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          token: ${{ steps.app-token.outputs.token }}
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
         with:
           use-flakehub: false
       - name: Update flake.lock and create signed commit with flake.lock changes
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.OP_BOT_TOKEN }}
           FILE_TO_COMMIT: flake.lock
           COMMIT_BRANCH: automation/update-flake-dependencies
           COMMIT_MESSAGE: "chore(nix): Update Flake dependencies"
@@ -37,11 +28,9 @@ jobs:
           # fetch remote state
           git fetch
           # if branch exists on remote already
-          BRANCH_EXISTS=false
           if git checkout "$COMMIT_BRANCH" > /dev/null 2>&1; then
-            # pull changeshttps://github.com/1Password/shell-plugins/pull/595
+            # pull changes
             git pull
-            BRANCH_EXISTS=true
           else
             # otherwise, create the branch and push it to remote
             git checkout -b "$COMMIT_BRANCH"
@@ -57,7 +46,8 @@ jobs:
               --field content="$(base64 -w 0 $FILE_TO_COMMIT)" \
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
-            if [ "$BRANCH_EXISTS" = "false" ]; then
+            OPEN_PR_COUNT=$(gh pr list --head "$COMMIT_BRANCH" --state open --json number --jq 'length')
+            if [ "$OPEN_PR_COUNT" -eq 0 ]; then
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -13,14 +13,23 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.FLAKE_BOT_APP_ID }}
+          private-key: ${{ secrets.FLAKE_BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
         with:
           use-flakehub: false
       - name: Update flake.lock and create signed commit with flake.lock changes
         env:
-          GITHUB_TOKEN: ${{ secrets.OP_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           FILE_TO_COMMIT: flake.lock
           COMMIT_BRANCH: automation/update-flake-dependencies
           COMMIT_MESSAGE: "chore(nix): Update Flake dependencies"
@@ -28,9 +37,11 @@ jobs:
           # fetch remote state
           git fetch
           # if branch exists on remote already
+          BRANCH_EXISTS=false
           if git checkout "$COMMIT_BRANCH" > /dev/null 2>&1; then
-            # pull changes
+            # pull changeshttps://github.com/1Password/shell-plugins/pull/595
             git pull
+            BRANCH_EXISTS=true
           else
             # otherwise, create the branch and push it to remote
             git checkout -b "$COMMIT_BRANCH"
@@ -46,12 +57,11 @@ jobs:
               --field content="$(base64 -w 0 $FILE_TO_COMMIT)" \
               --field branch="$COMMIT_BRANCH" \
               --field sha="$(git rev-parse $COMMIT_BRANCH:$FILE_TO_COMMIT)"
-            OPEN_PR_COUNT=$(gh pr list --head "$COMMIT_BRANCH" --state open --json number --jq 'length')
-            if [ "$OPEN_PR_COUNT" -eq 0 ]; then
+            if [ "$BRANCH_EXISTS" = "false" ]; then
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \
-                --reviewer scottisloud,bertrmz,jillregan,rishiy15 \
+                --reviewer mrjones2014 \
                 --base main --head $COMMIT_BRANCH
             fi
           fi

--- a/.github/workflows/update-flake-dependencies.yml
+++ b/.github/workflows/update-flake-dependencies.yml
@@ -60,7 +60,6 @@ jobs:
               gh pr create --title "[automation]: Update Flake dependencies" \
                 --body "This is an automated PR to update \`flake.lock\`" \
                 --label "flake.lock automation" \
-                --reviewer 1Password/open-source \
                 --base main --head $COMMIT_BRANCH
             fi
           fi


### PR DESCRIPTION
This PR:
* checks for the presence of a PR on the `automation/update-flake-dependencies` branch, rather than the previous logic which checked whether a branch of that name exists. 
  * If a PR doesn't exist, it opens a PR. 
* Updated the list of reviewers to be current and recent members of the Open Source team.  

**Background**
update-flake-dependencies would only open a PR with the updated flake.lock file if a branch called `automation/update-flake-dependencies` did not exist. Since that branch was not reliably deleted, and hasn't been for years, the workflow would find the branch and thus not open a PR. 

See this workflow test run which is executed off of this branch: https://github.com/1Password/shell-plugins/pull/656