### PR TITLE
fix(tofu): prompt for auth on workspace subcommand

### DIFF
--- a/plugins/tofu/terraform.go
+++ b/plugins/tofu/terraform.go
@@ -33,6 +33,7 @@ func TofuCLI() schema.Executable {
 					needsauth.ForCommand("destroy"),
 					needsauth.ForCommand("import"),
 					needsauth.ForCommand("test"),
+					needsauth.ForCommand("workspace"),
 				),
 			},
 		},


### PR DESCRIPTION
## Summary
Adds `workspace` to the list of subcommands requiring authentication in the OpenTofu plugin (`plugins/tofu/terraform.go`). 

Previously, running commands like `tofu workspace select` or `tofu workspace list` did not trigger credential injection.

Fixes #618