### PR TITLE
add firectl plugin

### DIFF
--- a/plugins/firectl/api_key.go
+++ b/plugins/firectl/api_key.go
@@ -1,0 +1,23 @@
+package firectl
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func APIKey() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.APIKey,
+		ManagementURL: sdk.URL("https://app.fireworks.ai/settings/users/api-keys"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.APIKey,
+				MarkdownDescription: "API Key used to authenticate to Firectl.",
+				Secret:              true,
+			},
+		},
+		DefaultProvisioner: FirectlCLIArgProvisioner(),
+	}
+}

--- a/plugins/firectl/api_key_test.go
+++ b/plugins/firectl/api_key_test.go
@@ -1,0 +1,37 @@
+package firectl
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAPIKeyProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, APIKey().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			CommandLine: []string{"firectl", "users", "list"},
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.APIKey: "fw_G2bznICSywu0kUNkfqX4xpz7ECaTjrZd9EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"firectl", "users", "list", "--api-key", "fw_G2bznICSywu0kUNkfqX4xpz7ECaTjrZd9EXAMPLE"},
+			},
+		},
+		"missing API key": {
+			CommandLine: []string{"firectl", "users", "list"},
+			ItemFields:  map[sdk.FieldName]string{},
+			ExpectedOutput: sdk.ProvisionOutput{
+				CommandLine: []string{"firectl", "users", "list"},
+				Diagnostics: sdk.Diagnostics{
+					Errors: []sdk.Error{
+						{
+							Message: "missing API key field",
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/plugins/firectl/firectl.go
+++ b/plugins/firectl/firectl.go
@@ -1,0 +1,25 @@
+package firectl
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func FirectlCLI() schema.Executable {
+	return schema.Executable{
+		Name:    "Firectl CLI",
+		Runs:    []string{"firectl"},
+		DocsURL: sdk.URL("https://docs.fireworks.ai/tools-sdks/firectl/firectl"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.APIKey,
+			},
+		},
+	}
+}

--- a/plugins/firectl/plugin.go
+++ b/plugins/firectl/plugin.go
@@ -1,0 +1,22 @@
+package firectl
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "firectl",
+		Platform: schema.PlatformInfo{
+			Name:     "Fireworks AI",
+			Homepage: sdk.URL("https://fireworks.ai"),
+		},
+		Credentials: []schema.CredentialType{
+			APIKey(),
+		},
+		Executables: []schema.Executable{
+			FirectlCLI(),
+		},
+	}
+}

--- a/plugins/firectl/provisioner.go
+++ b/plugins/firectl/provisioner.go
@@ -1,0 +1,37 @@
+package firectl
+
+import (
+	"context"
+	"errors"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+type firectlCLIArgProvisioner struct {
+	sdk.Provisioner
+}
+
+func FirectlCLIArgProvisioner() sdk.Provisioner {
+	return firectlCLIArgProvisioner{}
+}
+
+const firectlApiKeyFlag = "--api-key"
+
+func (p firectlCLIArgProvisioner) Provision(ctx context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	apiKey, ok := in.ItemFields[fieldname.APIKey]
+	if !ok {
+		out.AddError(errors.New("missing API key field"))
+		return
+	}
+
+	out.AddArgs(firectlApiKeyFlag, apiKey)
+}
+
+func (p firectlCLIArgProvisioner) Deprovision(ctx context.Context, in sdk.DeprovisionInput, out *sdk.DeprovisionOutput) {
+	// No op
+}
+
+func (p firectlCLIArgProvisioner) Description() string {
+	return "Firectl CLI API Key argument provisioner"
+}


### PR DESCRIPTION
## Overview
Adds a new plugin for [firectl](https://docs.fireworks.ai/tools-sdks/firectl/firectl)



## Type of change

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

* Resolves: N/A
* Relates: N/A

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

0. Install the firectl as per https://docs.fireworks.ai/tools-sdks/firectl/firectl
1. Make sure you have a 1Password "API Credentials" item with a field named "API Key" and with value of a fireworks.ai API key (starts with `fw_` prefix).
2. op plugin init firectl
3. Configure it and select the 1Password item created in step 1 as a credential
4. Run `firectl users list` to test if the api key is correctly passed to the binary

_Note,_ `firectl whoami` command is not supported when using an API Key to authenticate, it requires a prior OAuth2 flow via `firectl signin` which is deliberately not supported by this plugin as it opens up a browser window with `fireworks.auth.us-west-2.amazoncognito.com` domain, looking very generic and untrustworthy and it also increases friction with 1Password because this domain is not typically associated with fireworks.ai item in 1Password vault.

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->
Added the firectl plugin to authenticate the Fireworks AI CLI with 1Password Shell Plugins.