### PR TITLE
Add Travis CI plugin

### DIFF
--- a/plugins/travis/access_token.go
+++ b/plugins/travis/access_token.go
@@ -1,0 +1,80 @@
+package travis
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://developer.travis-ci.com/authentication"),
+		ManagementURL: sdk.URL("https://app.travis-ci.com/account/preferences"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Token used to authenticate to Travis CI.",
+				Secret:              true,
+				Composition: &schema.ValueComposition{
+					Length: 22,
+					Charset: schema.Charset{
+						Uppercase: true,
+						Lowercase: true,
+						Digits:    true,
+					},
+				},
+			},
+		},
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
+		Importer: importer.TryAll(
+			importer.TryEnvVarPair(defaultEnvVarMapping),
+			TryTravisCIConfigFile(),
+		)}
+}
+
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"TRAVIS_TOKEN": fieldname.Token,
+}
+
+func TryTravisCIConfigFile() sdk.Importer {
+	return importer.TryFile("~/.travis/config.yml", func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		var config Config
+		if err := contents.ToYAML(&config); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		for endpoint, endpointConfig := range config.Endpoints {
+			if endpointConfig.AccessToken == "" {
+				continue
+			}
+
+			nameHint := endpoint
+			if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
+				nameHint = parsed.Host
+			}
+
+			out.AddCandidate(sdk.ImportCandidate{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: endpointConfig.AccessToken,
+				},
+				NameHint: importer.SanitizeNameHint(nameHint),
+			})
+		}
+	})
+}
+
+type Config struct {
+	Endpoints map[string]Endpoint `yaml:"endpoints"`
+}
+
+type Endpoint struct {
+	AccessToken string `yaml:"access_token"`
+}

--- a/plugins/travis/access_token_test.go
+++ b/plugins/travis/access_token_test.go
@@ -1,0 +1,54 @@
+package travis
+
+import (
+	"testing"
+	
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+	
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "qxNQCrHk8EyjsK5EXAMPLE",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"TRAVIS_TOKEN": "qxNQCrHk8EyjsK5EXAMPLE",
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"environment": {
+			Environment: map[string]string{
+				"TRAVIS_TOKEN": "qxNQCrHk8EyjsK5EXAMPLE",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "qxNQCrHk8EyjsK5EXAMPLE",
+					},
+				},
+			},
+		},
+		"config file": {
+			Files: map[string]string{
+				"~/.travis/config.yml": plugintest.LoadFixture(t, "config.yml"),
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{
+				{
+					Fields: map[sdk.FieldName]string{
+						fieldname.Token: "qxNQCrHk8EyjsK5EXAMPLE",
+					},
+					NameHint: "api.travis-ci.com",
+				},
+			},
+		},
+	})
+}

--- a/plugins/travis/plugin.go
+++ b/plugins/travis/plugin.go
@@ -1,0 +1,22 @@
+package travis
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "travis",
+		Platform: schema.PlatformInfo{
+			Name:     "Travis CI",
+			Homepage: sdk.URL("https://www.travis-ci.com"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			TravisCICLI(),
+		},
+	}
+}

--- a/plugins/travis/test-fixtures/config.yml
+++ b/plugins/travis/test-fixtures/config.yml
@@ -1,0 +1,3 @@
+endpoints:
+  https://api.travis-ci.com/:
+    access_token: qxNQCrHk8EyjsK5EXAMPLE

--- a/plugins/travis/travis.go
+++ b/plugins/travis/travis.go
@@ -1,0 +1,25 @@
+package travis
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func TravisCICLI() schema.Executable {
+	return schema.Executable{
+		Name:      "Travis CI CLI",
+		Runs:      []string{"travis"},
+		DocsURL:   sdk.URL("https://github.com/travis-ci/travis.rb"),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.NotWithoutArgs(),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Overview
Add the Travis CI shell plugin with access-token support:

- Config-file importer reading ~/.travis/config.yml, keyed by API endpoint, with the host as the name hint
- Env-var importer and provisioner via TRAVIS_TOKEN
- Verified docs/management URLs and token composition



## Type of change
- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
* Resolves: #
* Relates: #

## How To Test
Generate an access token at https://app.travis-ci.com/account/preferences
Build the plugin locally: make travis/build
Initialize: op plugin init travis
Test authentication: travis whoami



## Changelog
Authenticate the Travis CI CLI using 1Password Shell Plugins.


