### PR TITLE
fix(akamai): use env vars for credential provisioning instead of arg injection

### DIFF
--- a/plugins/akamai/api_client_credentials.go
+++ b/plugins/akamai/api_client_credentials.go
@@ -71,39 +71,22 @@ func APIClientCredentials() schema.CredentialType {
 				},
 			},
 		},
-		DefaultProvisioner: provision.TempFile(configFile,
-			provision.Filename(".edgerc"),
-			provision.AddArgs(
-				"--edgerc", "{{ .Path }}",
-				"--section", "default",
-			),
-			provision.SetPathAsEnvVar("EDGERC"), // for Akamai Terraform provider
-		),
+		DefaultProvisioner: provision.EnvVars(defaultEnvVarMapping),
 		Importer: importer.TryAll(
 			TryAkamaiConfigFile(),
 		)}
 }
 
-func configFile(in sdk.ProvisionInput) ([]byte, error) {
-	contents := "[default]\n"
-
-	if clientsecret, ok := in.ItemFields[fieldname.ClientSecret]; ok {
-		contents += "client_secret = " + clientsecret + "\n"
-	}
-
-	if host, ok := in.ItemFields[fieldname.Host]; ok {
-		contents += "host = " + host + "\n"
-	}
-
-	if accesstoken, ok := in.ItemFields[fieldname.AccessToken]; ok {
-		contents += "access_token = " + accesstoken + "\n"
-	}
-
-	if clienttoken, ok := in.ItemFields[fieldname.ClientToken]; ok {
-		contents += "client_token = " + clienttoken + "\n"
-	}
-
-	return []byte(contents), nil
+// Akamai's edgegrid library (used by the Akamai CLI and its sub-packages) checks these
+// environment variables before falling back to the ~/.edgerc file. Using them avoids
+// relying on command-line flag injection, which several Akamai CLI packages (e.g. cli-gtm)
+// don't parse correctly when the flags are appended after the subcommand.
+// See: https://github.com/akamai/AkamaiOPEN-edgegrid-golang/blob/master/pkg/edgegrid/config.go
+var defaultEnvVarMapping = map[string]sdk.FieldName{
+	"AKAMAI_HOST":          fieldname.Host,
+	"AKAMAI_CLIENT_TOKEN":  fieldname.ClientToken,
+	"AKAMAI_CLIENT_SECRET": fieldname.ClientSecret,
+	"AKAMAI_ACCESS_TOKEN":  fieldname.AccessToken,
 }
 
 // Load credentials from the ~/.edgerc file.

--- a/plugins/akamai/api_client_credentials_test.go
+++ b/plugins/akamai/api_client_credentials_test.go
@@ -18,12 +18,11 @@ func TestAPIClientCredentialsProvisioner(t *testing.T) {
 				fieldname.ClientToken:  "akab-nomoflavjuc4422e-fa2xznerxrm3teg7",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
-				CommandLine: []string{"--edgerc", "/tmp/.edgerc", "--section", "default"},
-				Files: map[string]sdk.OutputFile{
-					"/tmp/.edgerc": {Contents: []byte(plugintest.LoadFixture(t, ".edgerc-single"))},
-				},
 				Environment: map[string]string{
-					"EDGERC": "/tmp/.edgerc",
+					"AKAMAI_HOST":          "akab-lmn789n2k53w7qrs-nfkxaa4lfk3kd6ym.luna.akamaiapis.net",
+					"AKAMAI_CLIENT_TOKEN":  "akab-nomoflavjuc4422e-fa2xznerxrm3teg7",
+					"AKAMAI_CLIENT_SECRET": "abcdE23FNkBxy456z25qx9Yp5CPUxlEfQeTDkfh4QA=I",
+					"AKAMAI_ACCESS_TOKEN":  "akab-zyx987xa6osbli4k-e7jf5ikib5jknes3",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- The Akamai plugin's `DefaultProvisioner` wrote a temp `.edgerc` file and appended `--edgerc`/`--section` flags to the command line, plus set an `EDGERC` env var.
- This doesn't work for Akamai CLI sub-packages such as `cli-gtm`: the SDK appends those flags *after* the subcommand, but `cli-gtm` only reads `--edgerc` via `c.GlobalString("edgerc")`, which requires the flag to appear *before* the subcommand — so it's silently dropped. The `EDGERC` env var is only honored by the Akamai Terraform provider, not the CLI.
- With both paths ineffective, edgegrid falls back to the default `~/.edgerc`, which doesn't exist for plugin users, producing:
  ```
  unable to load config from environment or .edgerc file: loading config file: open ~/.edgerc: no such file or directory
  ```
- `cli-gtm` (and other Go/edgegrid-v2-based packages) call `edgegrid.New(WithEnv(true), ...)`, which tries `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`, `AKAMAI_CLIENT_SECRET`, and `AKAMAI_ACCESS_TOKEN` *before* touching any file. This PR switches `DefaultProvisioner` to `provision.EnvVars` with those four variables, which the child process inherits regardless of argument position — sidestepping the arg-placement bug entirely.

## Testing
- `make akamai/validate` — all schema checks pass.
- `go test ./plugins/akamai/...` — updated provisioner test passes (asserts the four `AKAMAI_*` env vars instead of the temp file/args).
- `go vet` / `gofmt` clean.
- Verified locally with a build override (`make akamai/build`) against a real `cli-gtm` invocation:
  ```
  akamai gtm query-status rubiconproject.net.akadns.net --property=video-server --verbose
  ```
  Before this fix: failed with the `.edgerc` error above.
  After this fix: authenticated via the 1Password-injected environment variables and returned real GTM property status (domain, property, and reporting period) — no `.edgerc` involved.

## Notes for reviewers
- The importer (`TryAkamaiConfigFile`, which imports existing `~/.edgerc` entries into 1Password) is unchanged — this PR only touches how credentials are provisioned *to* the CLI at run time.
- This does not change behavior for the Akamai Terraform provider (a separate executable, out of scope for this plugin's `akamai` CLI target); the `EDGERC` env var this PR removes was explicitly commented as being for that provider.
- Legacy Python-based Akamai CLI sub-packages (edgegrid-python) read only `.edgerc`/`--edgerc`, not env vars, so they aren't fixed by this change — but they were already broken under the previous provisioner for the same arg-placement reason, so this isn't a regression.