### PR TITLE
Add npm and pnpm support

### DIFF
--- a/plugins/npm/access_token.go
+++ b/plugins/npm/access_token.go
@@ -1,0 +1,232 @@
+package npm
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/importer"
+	"github.com/1Password/shell-plugins/sdk/provision"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+const defaultRegistry = "https://registry.npmjs.org/"
+
+func AccessToken() schema.CredentialType {
+	return schema.CredentialType{
+		Name:          credname.AccessToken,
+		DocsURL:       sdk.URL("https://docs.npmjs.com/about-access-tokens"),
+		ManagementURL: sdk.URL("https://www.npmjs.com/settings/~/tokens"),
+		Fields: []schema.CredentialField{
+			{
+				Name:                fieldname.Token,
+				MarkdownDescription: "Access token used to authenticate to an npm-compatible registry.",
+				Secret:              true,
+			},
+			{
+				Name:                fieldname.Organization,
+				MarkdownDescription: "The package scope this registry should be used for, without the leading @.",
+				Optional:            true,
+			},
+			{
+				Name:                fieldname.Host,
+				MarkdownDescription: "The npm-compatible registry host or URL that accepts this access token.",
+				Optional:            true,
+			},
+		},
+		DefaultProvisioner: provision.TempFile(
+			npmConfigFile,
+			provision.Filename(".npmrc"),
+			provision.AddArgs("--userconfig", "{{ .Path }}"),
+		),
+		Importer: importer.TryAll(
+			importer.TryAllEnvVars(fieldname.Token, "NPM_TOKEN", "NODE_AUTH_TOKEN"),
+			tryNPMRCFile("~/.npmrc"),
+			tryPNPMAuthFile(),
+			// pnpm 10 and earlier may have stored npm-compatible settings here.
+			tryNPMRCFile("~/.config/pnpm/rc"),
+		),
+	}
+}
+
+func pnpmProvisioner() sdk.Provisioner {
+	return provision.TempFile(
+		npmConfigFile,
+		provision.Filename(".npmrc"),
+		provision.SetPathAsEnvVar("NPM_CONFIG_USERCONFIG"),
+	)
+}
+
+func npmConfigFile(in sdk.ProvisionInput) ([]byte, error) {
+	registry, err := normalizeRegistry(in.ItemFields[fieldname.Host])
+	if err != nil {
+		return nil, err
+	}
+
+	scope := strings.TrimPrefix(strings.TrimSpace(in.ItemFields[fieldname.Organization]), "@")
+	var contents strings.Builder
+	if scope != "" {
+		fmt.Fprintf(&contents, "@%s:registry=%s\n", scope, registry.String())
+	} else if strings.TrimSpace(in.ItemFields[fieldname.Host]) != "" {
+		fmt.Fprintf(&contents, "registry=%s\n", registry.String())
+	}
+
+	registryPath := registry.EscapedPath()
+	if !strings.HasSuffix(registryPath, "/") {
+		registryPath += "/"
+	}
+	fmt.Fprintf(&contents, "//%s%s:_authToken=%s\n", registry.Host, registryPath, in.ItemFields[fieldname.Token])
+
+	return []byte(contents.String()), nil
+}
+
+func normalizeRegistry(value string) (*url.URL, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		value = defaultRegistry
+	} else if !strings.Contains(value, "://") {
+		value = "https://" + value
+	}
+
+	registry, err := url.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("parsing registry URL: %w", err)
+	}
+	if (registry.Scheme != "https" && registry.Scheme != "http") || registry.Host == "" {
+		return nil, fmt.Errorf("registry URL must use http or https and include a host")
+	}
+	if registry.User != nil || registry.RawQuery != "" || registry.Fragment != "" {
+		return nil, fmt.Errorf("registry URL must not contain credentials, a query, or a fragment")
+	}
+	if registry.Path == "" {
+		registry.Path = "/"
+	} else if !strings.HasSuffix(registry.Path, "/") {
+		registry.Path += "/"
+	}
+
+	return registry, nil
+}
+
+func tryPNPMAuthFile() sdk.Importer {
+	return func(ctx context.Context, in sdk.ImportInput, out *sdk.ImportOutput) {
+		var path string
+		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+			path = filepath.Join(xdgConfigHome, "pnpm", "auth.ini")
+		} else {
+			switch in.OS {
+			case "darwin":
+				path = "~/Library/Preferences/pnpm/auth.ini"
+			case "linux":
+				path = "~/.config/pnpm/auth.ini"
+			default:
+				return
+			}
+		}
+
+		tryNPMRCFile(path)(ctx, in, out)
+	}
+}
+
+func tryNPMRCFile(path string) sdk.Importer {
+	return importer.TryFile(path, func(ctx context.Context, contents importer.FileContents, in sdk.ImportInput, out *sdk.ImportAttempt) {
+		lines := make(map[string]string)
+		scanner := bufio.NewScanner(strings.NewReader(string(contents)))
+		for scanner.Scan() {
+			key, value, found := strings.Cut(scanner.Text(), "=")
+			if !found {
+				continue
+			}
+			lines[strings.TrimSpace(key)] = strings.Trim(strings.TrimSpace(value), `"'`)
+		}
+		if err := scanner.Err(); err != nil {
+			out.AddError(err)
+			return
+		}
+
+		scopesByRegistry := make(map[string][]string)
+		registryURLs := make(map[string]string)
+		for key, value := range lines {
+			lowerKey := strings.ToLower(key)
+			if lowerKey != "registry" && (!strings.HasPrefix(key, "@") || !strings.HasSuffix(lowerKey, ":registry")) {
+				continue
+			}
+			registry, err := normalizeRegistry(value)
+			if err != nil {
+				continue
+			}
+			registryKey := registryAuthKey(registry)
+			registryURLs[registryKey] = registry.String()
+			if lowerKey == "registry" {
+				continue
+			}
+			scope := key[1 : len(key)-len(":registry")]
+			if scope != "" {
+				scopesByRegistry[registryKey] = append(scopesByRegistry[registryKey], scope)
+			}
+		}
+
+		for key, token := range lines {
+			registryKey, explicitScope, ok := parseAuthKey(key)
+			if !ok || token == "" || strings.HasPrefix(token, "${") {
+				continue
+			}
+
+			scopes := []string{explicitScope}
+			if explicitScope == "" {
+				if configuredScopes := scopesByRegistry[registryKey]; len(configuredScopes) > 0 {
+					scopes = configuredScopes
+				}
+			}
+
+			for _, scope := range scopes {
+				host := registryKey
+				if configuredURL := registryURLs[registryKey]; configuredURL != "" {
+					host = configuredURL
+				}
+				fields := map[sdk.FieldName]string{
+					fieldname.Token: token,
+					fieldname.Host:  host,
+				}
+				if scope != "" {
+					fields[fieldname.Organization] = scope
+				}
+				out.AddCandidate(sdk.ImportCandidate{
+					Fields:   fields,
+					NameHint: importer.SanitizeNameHint(registryKey),
+				})
+			}
+		}
+	})
+}
+
+func parseAuthKey(key string) (registry string, scope string, ok bool) {
+	const suffix = ":_authtoken"
+	lowerKey := strings.ToLower(key)
+	if !strings.HasPrefix(key, "//") || !strings.HasSuffix(lowerKey, suffix) {
+		return "", "", false
+	}
+
+	registry = key[2 : len(key)-len(suffix)]
+	if scopeSeparator := strings.LastIndex(registry, ":@"); scopeSeparator >= 0 {
+		scope = strings.TrimPrefix(registry[scopeSeparator+1:], "@")
+		registry = registry[:scopeSeparator]
+	}
+	registry = strings.TrimSuffix(registry, ":")
+	registry = strings.TrimSuffix(registry, "/")
+	if registry == "" {
+		return "", "", false
+	}
+	return registry, scope, true
+}
+
+func registryAuthKey(registry *url.URL) string {
+	path := strings.TrimSuffix(registry.EscapedPath(), "/")
+	return registry.Host + path
+}

--- a/plugins/npm/access_token_test.go
+++ b/plugins/npm/access_token_test.go
@@ -119,7 +119,7 @@ func TestAccessTokenImporter(t *testing.T) {
 			}},
 		},
 		"pnpm scoped auth key": {
-			OS: "linux",
+			OS:          "linux",
 			Environment: map[string]string{"XDG_CONFIG_HOME": ""},
 			Files: map[string]string{
 				"~/.config/pnpm/auth.ini": "//registry.example.com/:@acme:_authToken=custom_from_pnpm\n",
@@ -134,7 +134,7 @@ func TestAccessTokenImporter(t *testing.T) {
 			}},
 		},
 		"pnpm macOS auth file": {
-			OS: "darwin",
+			OS:          "darwin",
 			Environment: map[string]string{"XDG_CONFIG_HOME": ""},
 			Files: map[string]string{
 				"~/Library/Preferences/pnpm/auth.ini": "//registry.npmjs.org/:_authToken=npm_from_pnpm\n",

--- a/plugins/npm/access_token_test.go
+++ b/plugins/npm/access_token_test.go
@@ -1,0 +1,181 @@
+package npm
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
+)
+
+func TestAccessTokenProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, AccessToken().DefaultProvisioner, map[string]plugintest.ProvisionCase{
+		"default registry": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "npm_example123",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					"/tmp/.npmrc": {Contents: []byte("//registry.npmjs.org/:_authToken=npm_example123\n")},
+				},
+				CommandLine: []string{"--userconfig", "/tmp/.npmrc"},
+			},
+		},
+		"custom default registry": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "custom_example123",
+				fieldname.Host:  "registry.example.com/npm",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					"/tmp/.npmrc": {Contents: []byte("registry=https://registry.example.com/npm/\n//registry.example.com/npm/:_authToken=custom_example123\n")},
+				},
+				CommandLine: []string{"--userconfig", "/tmp/.npmrc"},
+			},
+		},
+		"scoped custom registry": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token:        "custom_example123",
+				fieldname.Host:         "https://registry.example.com/npm/",
+				fieldname.Organization: "@acme",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Files: map[string]sdk.OutputFile{
+					"/tmp/.npmrc": {Contents: []byte("@acme:registry=https://registry.example.com/npm/\n//registry.example.com/npm/:_authToken=custom_example123\n")},
+				},
+				CommandLine: []string{"--userconfig", "/tmp/.npmrc"},
+			},
+		},
+	})
+}
+
+func TestPNPMProvisioner(t *testing.T) {
+	plugintest.TestProvisioner(t, PNPMCLI().Uses[0].Provisioner, map[string]plugintest.ProvisionCase{
+		"uses an environment variable instead of an unsupported CLI option": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "npm_example123",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"NPM_CONFIG_USERCONFIG": "/tmp/.npmrc",
+				},
+				Files: map[string]sdk.OutputFile{
+					"/tmp/.npmrc": {Contents: []byte("//registry.npmjs.org/:_authToken=npm_example123\n")},
+				},
+			},
+		},
+	})
+}
+
+func TestAccessTokenImporter(t *testing.T) {
+	plugintest.TestImporter(t, AccessToken().Importer, map[string]plugintest.ImportCase{
+		"NPM_TOKEN environment variable": {
+			Environment: map[string]string{"NPM_TOKEN": "npm_from_env"},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{fieldname.Token: "npm_from_env"},
+			}},
+		},
+		"NODE_AUTH_TOKEN environment variable": {
+			Environment: map[string]string{"NODE_AUTH_TOKEN": "npm_from_node_env"},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{fieldname.Token: "npm_from_node_env"},
+			}},
+		},
+		"npm user config": {
+			Files: map[string]string{
+				"~/.npmrc": "//registry.npmjs.org/:_authToken=npm_from_npmrc\n",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: "npm_from_npmrc",
+					fieldname.Host:  "registry.npmjs.org",
+				},
+				NameHint: "registry.npmjs.org",
+			}},
+		},
+		"scoped custom registry": {
+			Files: map[string]string{
+				"~/.npmrc": "@acme:registry=https://registry.example.com/npm/\n//registry.example.com/npm/:_authToken=custom_from_npmrc\n",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token:        "custom_from_npmrc",
+					fieldname.Host:         "https://registry.example.com/npm/",
+					fieldname.Organization: "acme",
+				},
+				NameHint: "registry.example.com/npm",
+			}},
+		},
+		"custom default registry preserves URL": {
+			Files: map[string]string{
+				"~/.npmrc": "registry=http://localhost:4873/npm/\n//localhost:4873/npm/:_authToken=custom_from_npmrc\n",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: "custom_from_npmrc",
+					fieldname.Host:  "http://localhost:4873/npm/",
+				},
+				NameHint: "localhost:4873/npm",
+			}},
+		},
+		"pnpm scoped auth key": {
+			OS: "linux",
+			Files: map[string]string{
+				"~/.config/pnpm/auth.ini": "//registry.example.com/:@acme:_authToken=custom_from_pnpm\n",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token:        "custom_from_pnpm",
+					fieldname.Host:         "registry.example.com",
+					fieldname.Organization: "acme",
+				},
+				NameHint: "registry.example.com",
+			}},
+		},
+		"pnpm macOS auth file": {
+			OS: "darwin",
+			Files: map[string]string{
+				"~/Library/Preferences/pnpm/auth.ini": "//registry.npmjs.org/:_authToken=npm_from_pnpm\n",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: "npm_from_pnpm",
+					fieldname.Host:  "registry.npmjs.org",
+				},
+				NameHint: "registry.npmjs.org",
+			}},
+		},
+		"pnpm XDG auth file": {
+			OS:          "linux",
+			Environment: map[string]string{"XDG_CONFIG_HOME": "/custom-config"},
+			Files: map[string]string{
+				"/custom-config/pnpm/auth.ini": "//registry.npmjs.org/:_authToken=npm_from_xdg\n",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: "npm_from_xdg",
+					fieldname.Host:  "registry.npmjs.org",
+				},
+				NameHint: "registry.npmjs.org",
+			}},
+		},
+		"legacy pnpm config": {
+			Files: map[string]string{
+				"~/.config/pnpm/rc": "//registry.npmjs.org/:_authToken=npm_from_legacy_pnpm\n",
+			},
+			ExpectedCandidates: []sdk.ImportCandidate{{
+				Fields: map[sdk.FieldName]string{
+					fieldname.Token: "npm_from_legacy_pnpm",
+					fieldname.Host:  "registry.npmjs.org",
+				},
+				NameHint: "registry.npmjs.org",
+			}},
+		},
+		"environment variable reference is not a secret": {
+			Files: map[string]string{
+				"~/.npmrc": "//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n",
+			},
+			ExpectedCandidates: nil,
+		},
+	})
+}

--- a/plugins/npm/access_token_test.go
+++ b/plugins/npm/access_token_test.go
@@ -120,6 +120,7 @@ func TestAccessTokenImporter(t *testing.T) {
 		},
 		"pnpm scoped auth key": {
 			OS: "linux",
+			Environment: map[string]string{"XDG_CONFIG_HOME": ""},
 			Files: map[string]string{
 				"~/.config/pnpm/auth.ini": "//registry.example.com/:@acme:_authToken=custom_from_pnpm\n",
 			},
@@ -134,6 +135,7 @@ func TestAccessTokenImporter(t *testing.T) {
 		},
 		"pnpm macOS auth file": {
 			OS: "darwin",
+			Environment: map[string]string{"XDG_CONFIG_HOME": ""},
 			Files: map[string]string{
 				"~/Library/Preferences/pnpm/auth.ini": "//registry.npmjs.org/:_authToken=npm_from_pnpm\n",
 			},

--- a/plugins/npm/npm.go
+++ b/plugins/npm/npm.go
@@ -1,0 +1,62 @@
+package npm
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/needsauth"
+	"github.com/1Password/shell-plugins/sdk/schema"
+	"github.com/1Password/shell-plugins/sdk/schema/credname"
+)
+
+func NPMCLI() schema.Executable {
+	return packageManagerCLI("npm CLI", "npm", "https://docs.npmjs.com/cli/")
+}
+
+func PNPMCLI() schema.Executable {
+	executable := packageManagerCLI("pnpm CLI", "pnpm", "https://pnpm.io/cli")
+	executable.Uses[0].Provisioner = pnpmProvisioner()
+	return executable
+}
+
+func packageManagerCLI(name, command, docsURL string) schema.Executable {
+	return schema.Executable{
+		Name:    name,
+		Runs:    []string{command},
+		DocsURL: sdk.URL(docsURL),
+		NeedsAuth: needsauth.IfAll(
+			needsauth.NotForHelpOrVersion(),
+			needsauth.IfAny(
+				needsauth.ForCommand("access"),
+				needsauth.ForCommand("add"),
+				needsauth.ForCommand("audit"),
+				needsauth.ForCommand("ci"),
+				needsauth.ForCommand("cit"),
+				needsauth.ForCommand("deprecate"),
+				needsauth.ForCommand("dist-tag"),
+				needsauth.ForCommand("fetch"),
+				needsauth.ForCommand("i"),
+				needsauth.ForCommand("exec"),
+				needsauth.ForCommand("install"),
+				needsauth.ForCommand("install-ci-test"),
+				needsauth.ForCommand("install-test"),
+				needsauth.ForCommand("it"),
+				needsauth.ForCommand("owner"),
+				needsauth.ForCommand("pack"),
+				needsauth.ForCommand("profile"),
+				needsauth.ForCommand("publish"),
+				needsauth.ForCommand("search"),
+				needsauth.ForCommand("stage"),
+				needsauth.ForCommand("team"),
+				needsauth.ForCommand("token"),
+				needsauth.ForCommand("unpublish"),
+				needsauth.ForCommand("update"),
+				needsauth.ForCommand("view"),
+				needsauth.ForCommand("whoami"),
+			),
+		),
+		Uses: []schema.CredentialUsage{
+			{
+				Name: credname.AccessToken,
+			},
+		},
+	}
+}

--- a/plugins/npm/npm_test.go
+++ b/plugins/npm/npm_test.go
@@ -1,0 +1,36 @@
+package npm
+
+import (
+	"testing"
+
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/plugintest"
+)
+
+func TestNPMCLINeedsAuth(t *testing.T) {
+	testPackageManagerNeedsAuth(t, NPMCLI().NeedsAuth)
+}
+
+func TestPNPMCLINeedsAuth(t *testing.T) {
+	testPackageManagerNeedsAuth(t, PNPMCLI().NeedsAuth)
+}
+
+func testPackageManagerNeedsAuth(t *testing.T, needsAuth sdk.NeedsAuthentication) {
+	t.Helper()
+
+	var needsAuthCases = map[string]plugintest.NeedsAuthCase{
+		"install may access private packages": {Args: []string{"install"}, ExpectedNeedsAuth: true},
+		"install alias may access private packages": {
+			Args:              []string{"i"},
+			ExpectedNeedsAuth: true,
+		},
+		"publish requires authentication":  {Args: []string{"publish"}, ExpectedNeedsAuth: true},
+		"whoami requires authentication":   {Args: []string{"whoami"}, ExpectedNeedsAuth: true},
+		"login establishes authentication": {Args: []string{"login"}, ExpectedNeedsAuth: false},
+		"run is local":                     {Args: []string{"run", "test"}, ExpectedNeedsAuth: false},
+		"help does not require auth":       {Args: []string{"install", "--help"}, ExpectedNeedsAuth: false},
+		"version does not require auth":    {Args: []string{"--version"}, ExpectedNeedsAuth: false},
+	}
+
+	plugintest.TestNeedsAuth(t, needsAuth, needsAuthCases)
+}

--- a/plugins/npm/plugin.go
+++ b/plugins/npm/plugin.go
@@ -1,0 +1,23 @@
+package npm
+
+import (
+	"github.com/1Password/shell-plugins/sdk"
+	"github.com/1Password/shell-plugins/sdk/schema"
+)
+
+func New() schema.Plugin {
+	return schema.Plugin{
+		Name: "npm",
+		Platform: schema.PlatformInfo{
+			Name:     "npm",
+			Homepage: sdk.URL("https://www.npmjs.com"),
+		},
+		Credentials: []schema.CredentialType{
+			AccessToken(),
+		},
+		Executables: []schema.Executable{
+			NPMCLI(),
+			PNPMCLI(),
+		},
+	}
+}


### PR DESCRIPTION
## Overview
<!--  
Provide a high-level description of this change.   
-->

This change introduces a 1Password plugin supporting npm and pnpm. Currently both these systems default is to store credentials on disk in plaintext. 1Password to the rescue!

## Type of change
<!--  
Check the box below that describes your change best:
--> 

- [x] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## Related Issue(s)
<!--  
If applicable - add the issue that your PR relates to or closes:
  - use Resolves: #ISSUE_NUMBER to trigger closing of the issue on merge of this PR  
  - use Relates: #ISSUE_NUMBER to indicate relation to an issue, but issue will not close  
-->  

Didn't see any related issues however similar PR [here](https://github.com/1Password/shell-plugins/pull/422) that looks to be stale from ~2 years ago.

## How To Test
<!--
Provide testing instructions for validating the changes introduced in this PR.
This will serve as a starting point for your reviewers, for functional testing.

If you created a new plugin, you can add a command here which can be used to test authentication.
For example, for the AWS CLI:
  aws s3 ls
-->

Once built run `op plugin init npm` or `op plugin init pnpm`. Follow the steps and then you can verify functionality with `npm whoami` or `pnpm whoami`. 

_Note: You do need an npm account for testing this._

_File import should work if you've run `npm login` or `pnpm login` as these generate the plaintext file the plugin looks for. You can also generate granular access tokens in npm and paste those in the paste flow_


## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  

`Authenticate with npm (or pnpm) using the newly supported plugins`


Some additional notes for the technical writing team in the case this gets accepted and published.
- If a user is importing from a file they should probably be advised to remove the plaintext file once they've configured the plugin, (not strictly necessary functionally but kinda the whole idea of using the plugin is not having plaintext api keys lying about and the plugin ecosystem doesn't seem to provide any way of prompting the removal of these files at the CLI)
- Running `npm login` or `pnpm login` after configuring the plugin will not update your token in 1P but rather it will rewrite the token back into a plaintext file. `npm` will continue to use what's in 1P, and `pnpm` puts higher precedence on `auth.ini` so that will override our 1P token. I could not think of a clean way to manage this nor did I see an existing pattern in any other plugin. For something like `gh`, the CLI itself handles this case
  ```sh
  gh auth login 
  ? Where do you use GitHub? GitHub.com
  The value of the GH_TOKEN environment variable is being used for authentication.
  To have GitHub CLI store credentials instead, first clear the value from the environment.
  ```
  There should probably be guidance around this quirk and encourage users to create granular tokens in the web UI instead of the login commands. It's also worth noting in the past year npm has cranked down their default token expiry on tokens created using `npm login` to I believe 1 hour, so users running this often would continually hit this limitation.