### PR TITLE
Makefile - Use resolved config dir in remove-local target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ lint:
 
 %/remove-local: beta-notice
 	$(eval plugin := $(firstword $(subst /, ,$@)))
-	rm -f ~/.op/plugins/local/$(plugin)
+	rm -f $(plugins_dir)/$(plugin)


### PR DESCRIPTION
## Overview

The `%/remove-local` Makefile target hardcoded the legacy `~/.op/plugins/local/` path, while `%/build` installs to the config directory resolved by `cmd/contrib/scripts/config_dir_getter.go` (per the [config directory precedence docs](https://developer.1password.com/docs/cli/config-directories)). On machines using a newer config location such as `~/.config/op`, `make <plugin>/remove-local` silently deleted nothing.

This changes `remove-local` to use the same `$(plugins_dir)` variable as the build target.

## Type of change

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [ ] Fixed a bug in an existing plugin
- [x] Improved contributor utilities or experience

## Related Issue(s)

None.

## How To Test

On a machine whose config dir resolves to `~/.config/op` (i.e. no legacy `~/.op` directory and no `OP_CONFIG_DIR` set):

```
make <plugin>/build
make -n <plugin>/remove-local   # dry run: should print rm -f ~/.config/op/plugins/local/<plugin>
make <plugin>/remove-local      # removes the locally built plugin
```

Before this change, the dry run printed the legacy `~/.op/plugins/local/<plugin>` path, so the plugin was never removed.

## Changelog

The `make <plugin>/remove-local` command now removes locally built plugins from the same config directory that `make <plugin>/build` installs them to.
