### PR TITLE
Update npm plugin to fix double temp file read issue

### DIFF
--- a/plugins/npm/access_token.go
+++ b/plugins/npm/access_token.go
@@ -3,6 +3,7 @@ package npm
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/1Password/shell-plugins/sdk"
 	"github.com/1Password/shell-plugins/sdk/importer"
-	"github.com/1Password/shell-plugins/sdk/provision"
 	"github.com/1Password/shell-plugins/sdk/schema"
 	"github.com/1Password/shell-plugins/sdk/schema/credname"
 	"github.com/1Password/shell-plugins/sdk/schema/fieldname"
@@ -41,11 +41,7 @@ func AccessToken() schema.CredentialType {
 				Optional:            true,
 			},
 		},
-		DefaultProvisioner: provision.TempFile(
-			npmConfigFile,
-			provision.Filename(".npmrc"),
-			provision.AddArgs("--userconfig", "{{ .Path }}"),
-		),
+		DefaultProvisioner: npmProvisioner(),
 		Importer: importer.TryAll(
 			importer.TryAllEnvVars(fieldname.Token, "NPM_TOKEN", "NODE_AUTH_TOKEN"),
 			tryNPMRCFile("~/.npmrc"),
@@ -56,35 +52,89 @@ func AccessToken() schema.CredentialType {
 	}
 }
 
-func pnpmProvisioner() sdk.Provisioner {
-	return provision.TempFile(
-		npmConfigFile,
-		provision.Filename(".npmrc"),
-		provision.SetPathAsEnvVar("NPM_CONFIG_USERCONFIG"),
-	)
+func npmProvisioner() sdk.Provisioner {
+	return npmEnvProvisioner{}
 }
 
-func npmConfigFile(in sdk.ProvisionInput) ([]byte, error) {
+type npmEnvProvisioner struct{}
+
+func (npmEnvProvisioner) Provision(_ context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
 	registry, err := normalizeRegistry(in.ItemFields[fieldname.Host])
 	if err != nil {
-		return nil, err
+		out.AddError(err)
+		return
 	}
 
-	scope := strings.TrimPrefix(strings.TrimSpace(in.ItemFields[fieldname.Organization]), "@")
-	var contents strings.Builder
-	if scope != "" {
-		fmt.Fprintf(&contents, "@%s:registry=%s\n", scope, registry.String())
+	authEnvVar := fmt.Sprintf("npm_config_//%s/:_authToken", registryAuthKey(registry))
+	if strings.ContainsAny(authEnvVar, "=\x00") {
+		out.AddError(fmt.Errorf("registry URL cannot be represented as an npm environment variable"))
+		return
+	}
+	out.AddEnvVar(authEnvVar, in.ItemFields[fieldname.Token])
+
+	organization := strings.TrimPrefix(strings.TrimSpace(in.ItemFields[fieldname.Organization]), "@")
+	if organization != "" {
+		registryEnvVar := "npm_config_@" + organization + ":registry"
+		if strings.ContainsAny(registryEnvVar, "=\x00") {
+			out.AddError(fmt.Errorf("organization cannot be represented as an npm environment variable"))
+			return
+		}
+		out.AddEnvVar(registryEnvVar, registry.String())
 	} else if strings.TrimSpace(in.ItemFields[fieldname.Host]) != "" {
-		fmt.Fprintf(&contents, "registry=%s\n", registry.String())
+		out.AddEnvVar("npm_config_registry", registry.String())
+	}
+}
+
+func (npmEnvProvisioner) Deprovision(_ context.Context, _ sdk.DeprovisionInput, _ *sdk.DeprovisionOutput) {
+	// Nothing to do here: environment variables get wiped automatically when the process exits.
+}
+
+func (npmEnvProvisioner) Description() string {
+	return "Provision npm configuration environment variables"
+}
+
+func pnpmProvisioner() sdk.Provisioner {
+	return pnpmEnvProvisioner{}
+}
+
+type pnpmEnvProvisioner struct{}
+
+type pnpmAuthCredentials struct {
+	AuthToken string `json:"authToken"`
+}
+
+func (pnpmEnvProvisioner) Provision(_ context.Context, in sdk.ProvisionInput, out *sdk.ProvisionOutput) {
+	registry, err := normalizeRegistry(in.ItemFields[fieldname.Host])
+	if err != nil {
+		out.AddError(err)
+		return
 	}
 
-	registryPath := registry.EscapedPath()
-	if !strings.HasSuffix(registryPath, "/") {
-		registryPath += "/"
+	scope := "@"
+	if organization := strings.TrimPrefix(strings.TrimSpace(in.ItemFields[fieldname.Organization]), "@"); organization != "" {
+		scope = "@" + organization
 	}
-	fmt.Fprintf(&contents, "//%s%s:_authToken=%s\n", registry.Host, registryPath, in.ItemFields[fieldname.Token])
 
-	return []byte(contents.String()), nil
+	authConfig := map[string]map[string]pnpmAuthCredentials{
+		registry.String(): {
+			scope: {AuthToken: in.ItemFields[fieldname.Token]},
+		},
+	}
+	contents, err := json.Marshal(authConfig)
+	if err != nil {
+		out.AddError(fmt.Errorf("marshalling pnpm auth configuration: %w", err))
+		return
+	}
+
+	out.AddEnvVar("PNPM_CONFIG__AUTH", string(contents))
+}
+
+func (pnpmEnvProvisioner) Deprovision(_ context.Context, _ sdk.DeprovisionInput, _ *sdk.DeprovisionOutput) {
+	// Nothing to do here: environment variables get wiped automatically when the process exits.
+}
+
+func (pnpmEnvProvisioner) Description() string {
+	return "Provision PNPM_CONFIG__AUTH environment variable"
 }
 
 func normalizeRegistry(value string) (*url.URL, error) {

--- a/plugins/npm/access_token_test.go
+++ b/plugins/npm/access_token_test.go
@@ -15,10 +15,9 @@ func TestAccessTokenProvisioner(t *testing.T) {
 				fieldname.Token: "npm_example123",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
-				Files: map[string]sdk.OutputFile{
-					"/tmp/.npmrc": {Contents: []byte("//registry.npmjs.org/:_authToken=npm_example123\n")},
+				Environment: map[string]string{
+					"npm_config_//registry.npmjs.org/:_authToken": "npm_example123",
 				},
-				CommandLine: []string{"--userconfig", "/tmp/.npmrc"},
 			},
 		},
 		"custom default registry": {
@@ -27,10 +26,10 @@ func TestAccessTokenProvisioner(t *testing.T) {
 				fieldname.Host:  "registry.example.com/npm",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
-				Files: map[string]sdk.OutputFile{
-					"/tmp/.npmrc": {Contents: []byte("registry=https://registry.example.com/npm/\n//registry.example.com/npm/:_authToken=custom_example123\n")},
+				Environment: map[string]string{
+					"npm_config_//registry.example.com/npm/:_authToken": "custom_example123",
+					"npm_config_registry":                               "https://registry.example.com/npm/",
 				},
-				CommandLine: []string{"--userconfig", "/tmp/.npmrc"},
 			},
 		},
 		"scoped custom registry": {
@@ -40,10 +39,10 @@ func TestAccessTokenProvisioner(t *testing.T) {
 				fieldname.Organization: "@acme",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
-				Files: map[string]sdk.OutputFile{
-					"/tmp/.npmrc": {Contents: []byte("@acme:registry=https://registry.example.com/npm/\n//registry.example.com/npm/:_authToken=custom_example123\n")},
+				Environment: map[string]string{
+					"npm_config_//registry.example.com/npm/:_authToken": "custom_example123",
+					"npm_config_@acme:registry":                         "https://registry.example.com/npm/",
 				},
-				CommandLine: []string{"--userconfig", "/tmp/.npmrc"},
 			},
 		},
 	})
@@ -51,16 +50,36 @@ func TestAccessTokenProvisioner(t *testing.T) {
 
 func TestPNPMProvisioner(t *testing.T) {
 	plugintest.TestProvisioner(t, PNPMCLI().Uses[0].Provisioner, map[string]plugintest.ProvisionCase{
-		"uses an environment variable instead of an unsupported CLI option": {
+		"default registry": {
 			ItemFields: map[sdk.FieldName]string{
 				fieldname.Token: "npm_example123",
 			},
 			ExpectedOutput: sdk.ProvisionOutput{
 				Environment: map[string]string{
-					"NPM_CONFIG_USERCONFIG": "/tmp/.npmrc",
+					"PNPM_CONFIG__AUTH": `{"https://registry.npmjs.org/":{"@":{"authToken":"npm_example123"}}}`,
 				},
-				Files: map[string]sdk.OutputFile{
-					"/tmp/.npmrc": {Contents: []byte("//registry.npmjs.org/:_authToken=npm_example123\n")},
+			},
+		},
+		"custom default registry": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token: "custom_example123",
+				fieldname.Host:  "registry.example.com/npm",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"PNPM_CONFIG__AUTH": `{"https://registry.example.com/npm/":{"@":{"authToken":"custom_example123"}}}`,
+				},
+			},
+		},
+		"scoped custom registry": {
+			ItemFields: map[sdk.FieldName]string{
+				fieldname.Token:        "custom_example123",
+				fieldname.Host:         "https://registry.example.com/npm/",
+				fieldname.Organization: "@acme",
+			},
+			ExpectedOutput: sdk.ProvisionOutput{
+				Environment: map[string]string{
+					"PNPM_CONFIG__AUTH": `{"https://registry.example.com/npm/":{"@acme":{"authToken":"custom_example123"}}}`,
 				},
 			},
 		},


### PR DESCRIPTION
## Overview

I originally introduced this plugin in https://github.com/1Password/shell-plugins/pull/658

While recently using the plugin I discovered an issue with the temp file approach related to consuming more than once. 

This arose in version pinning of package managers.

When a version of npm or pnpm is specified inside the package.json

e.g.
```json
{
  "packageManager": "pnpm@11.24.0"
}
```

and this version differs from the global version on the system, the default behaviour is corepack downloads that missing version and spawns a child process using that version.

So the process looks like
```
1Password
  └─ pnpm 11.24 bootstrap process
       └─ pnpm 11.22 actual command process
```

The issue here is the temp file 1Password creates is only readable once as a stream. The parent process consumes it, then the child attempts to read it also and hangs indefinitely.

This also occurs with other double read cases (see testing)

This resolves that issue by instead leveraging env vars which do persist to the child process.

## Type of change

- [ ] Created a new plugin
- [ ] Improved an existing plugin
- [x] Fixed a bug in an existing plugin
- [ ] Improved contributor utilities or experience

## How To Test

With the previous version of the plugin built you can reproduce the issue with the following

### Repro Example 1

1. Create an empty dir
2. Add a package.json file
3. Populate with
    ```json
    {
      "name": "npm-fifo-repro",
      "version": "1.0.0",
      "private": true,
      "scripts": {
        "preinstall": "npm whoami"
      }
    }
    ```
4. Run `npm install`

### Repro Example 2 (pnpm)

assuming your global pnpm version !== 11.22.0 (otherwise just alter packageManager so not equal to global version)

1. Create an empty dir
2. Add a package.json file
3. Populate with
    ```json
    {
      "name": "pnpm-fifo-repro",
      "version": "1.0.0",
      "private": true,
      "packageManager": "pnpm@11.22.0"
    }
    ```
4. Run `pnpm whoami`

Both of these configurations should not hang after rebuilding this version of the plugin

## Changelog
<!--  
A one line sentence describing the change that this PR introduces. 
If this has impact over the user experience, your changelog will be included in the release notes of the next stable version of 1Password CLI.

Here are a few guidelines for writing a good changelog:
- Keep your description to a single sentence if you can, and use proper capitalization and punctuation, including a final period.
- Don't use emoji in your description.
- Avoid starting your sentence with "improved" or "fixed". Instead, describe the improvement or say what you fixed.
- Avoid using terminology like "Users are shown" or "You can now" and instead focus on the thing that was changed.

A few examples:

Authenticate the AWS CLI using Touch ID and other unlock options with 1Password Shell Plugins.
The AWS plugin can now be correctly initialized with a default credential, using `op plugin init`.
The AWS plugin now checks for the `AWS_SHARED_CREDENTIALS_FILE` environment variable and attempts to import credentials using the specified file.

For more examples, have a look over 1Password CLI's past release notes: 
https://app-updates.agilebits.com/product_history/CLI2
-->  
Switch to env based approach for npm plugin, resolving file drain process hang issue.

